### PR TITLE
Log Viewer: Send log viewer date range as local-day instants and honour time portions (closes #14710)

### DIFF
--- a/src/Umbraco.Infrastructure/Services/Implement/LogViewerRepository.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/LogViewerRepository.cs
@@ -38,10 +38,9 @@ public class LogViewerRepository : LogViewerRepositoryBase
     {
         var logs = new List<LogEvent>();
 
-        // The range bounds apply to every entry, so resolve them to absolute instants once here
-        // rather than per event. The period bounds are server-local wall-clock times (from
-        // DateTimeOffset.LocalDateTime); interpret them as local instants so the comparison against
-        // each entry's absolute timestamp is offset-correct regardless of the entry's own offset.
+        // StartTime/EndTime are server-local wall-clock DateTimes (they carry no offset). Re-attach
+        // the local offset so they become absolute instants comparable to each entry's timestamp,
+        // resolving them once here rather than per entry.
         var rangeStart = new DateTimeOffset(DateTime.SpecifyKind(logTimePeriod.StartTime, DateTimeKind.Local));
         var rangeEnd = new DateTimeOffset(DateTime.SpecifyKind(logTimePeriod.EndTime, DateTimeKind.Local));
 

--- a/src/Umbraco.Infrastructure/Services/Implement/LogViewerRepository.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/LogViewerRepository.cs
@@ -38,6 +38,13 @@ public class LogViewerRepository : LogViewerRepositoryBase
     {
         var logs = new List<LogEvent>();
 
+        // The range bounds apply to every entry, so resolve them to absolute instants once here
+        // rather than per event. The period bounds are server-local wall-clock times (from
+        // DateTimeOffset.LocalDateTime); interpret them as local instants so the comparison against
+        // each entry's absolute timestamp is offset-correct regardless of the entry's own offset.
+        var rangeStart = new DateTimeOffset(DateTime.SpecifyKind(logTimePeriod.StartTime, DateTimeKind.Local));
+        var rangeEnd = new DateTimeOffset(DateTime.SpecifyKind(logTimePeriod.EndTime, DateTimeKind.Local));
+
         // foreach full day in the range - see if we can find one or more filenames that end with
         // yyyyMMdd.json - Ends with due to MachineName in filenames - could be 1 or more due to load balancing
         for (DateTime day = logTimePeriod.StartTime.Date; day.Date <= logTimePeriod.EndTime.Date; day = day.AddDays(1))
@@ -54,7 +61,7 @@ public class LogViewerRepository : LogViewerRepositoryBase
             {
                 try
                 {
-                    ReadLogFile(filePath, logTimePeriod, logFilter, logs);
+                    ReadLogFile(filePath, rangeStart, rangeEnd, logFilter, logs);
                 }
                 catch (Exception ex)
                 {
@@ -79,7 +86,7 @@ public class LogViewerRepository : LogViewerRepositoryBase
             }).ToArray();
     }
 
-    private void ReadLogFile(string filePath, LogTimePeriod logTimePeriod, ILogFilter logFilter, List<LogEvent> logs)
+    private void ReadLogFile(string filePath, DateTimeOffset rangeStart, DateTimeOffset rangeEnd, ILogFilter logFilter, List<LogEvent> logs)
     {
         using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var stream = new StreamReader(fs);
@@ -123,7 +130,7 @@ public class LogViewerRepository : LogViewerRepositoryBase
             // Files are bucketed by calendar date, so a boundary file can hold entries outside the
             // requested range — the range's time-of-day only narrows which entries apply, not just
             // which files are opened. Exclude entries falling outside the exact range (#14710).
-            if (IsWithinTimePeriod(evt, logTimePeriod) is false)
+            if (evt.Timestamp < rangeStart || evt.Timestamp > rangeEnd)
             {
                 continue;
             }
@@ -177,15 +184,4 @@ public class LogViewerRepository : LogViewerRepositoryBase
     }
 
     private static string GetSearchPattern(DateTime day) => $"*{day:yyyyMMdd}*.json";
-
-    private static bool IsWithinTimePeriod(LogEvent evt, LogTimePeriod logTimePeriod)
-    {
-        // The period bounds are server-local wall-clock times (from DateTimeOffset.LocalDateTime);
-        // interpret them as local instants so the comparison against the entry's absolute timestamp
-        // is offset-correct regardless of the entry's own recorded offset.
-        var start = new DateTimeOffset(DateTime.SpecifyKind(logTimePeriod.StartTime, DateTimeKind.Local));
-        var end = new DateTimeOffset(DateTime.SpecifyKind(logTimePeriod.EndTime, DateTimeKind.Local));
-
-        return evt.Timestamp >= start && evt.Timestamp <= end;
-    }
 }

--- a/src/Umbraco.Infrastructure/Services/Implement/LogViewerRepository.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/LogViewerRepository.cs
@@ -54,7 +54,7 @@ public class LogViewerRepository : LogViewerRepositoryBase
             {
                 try
                 {
-                    ReadLogFile(filePath, logFilter, logs);
+                    ReadLogFile(filePath, logTimePeriod, logFilter, logs);
                 }
                 catch (Exception ex)
                 {
@@ -79,7 +79,7 @@ public class LogViewerRepository : LogViewerRepositoryBase
             }).ToArray();
     }
 
-    private void ReadLogFile(string filePath, ILogFilter logFilter, List<LogEvent> logs)
+    private void ReadLogFile(string filePath, LogTimePeriod logTimePeriod, ILogFilter logFilter, List<LogEvent> logs)
     {
         using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var stream = new StreamReader(fs);
@@ -116,6 +116,14 @@ public class LogViewerRepository : LogViewerRepositoryBase
 
             // LogEventReader may return true with a null event for a benign skip.
             if (evt is null)
+            {
+                continue;
+            }
+
+            // Files are bucketed by calendar date, so a boundary file can hold entries outside the
+            // requested range — the range's time-of-day only narrows which entries apply, not just
+            // which files are opened. Exclude entries falling outside the exact range (#14710).
+            if (IsWithinTimePeriod(evt, logTimePeriod) is false)
             {
                 continue;
             }
@@ -169,4 +177,15 @@ public class LogViewerRepository : LogViewerRepositoryBase
     }
 
     private static string GetSearchPattern(DateTime day) => $"*{day:yyyyMMdd}*.json";
+
+    private static bool IsWithinTimePeriod(LogEvent evt, LogTimePeriod logTimePeriod)
+    {
+        // The period bounds are server-local wall-clock times (from DateTimeOffset.LocalDateTime);
+        // interpret them as local instants so the comparison against the entry's absolute timestamp
+        // is offset-correct regardless of the entry's own recorded offset.
+        var start = new DateTimeOffset(DateTime.SpecifyKind(logTimePeriod.StartTime, DateTimeKind.Local));
+        var end = new DateTimeOffset(DateTime.SpecifyKind(logTimePeriod.EndTime, DateTimeKind.Local));
+
+        return evt.Timestamp >= start && evt.Timestamp <= end;
+    }
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.test.ts
@@ -1,17 +1,17 @@
-import { umbGetEndOfDayInLocalTime, umbGetStartOfDayInLocalTime } from './utils.js';
+import { getEndOfDayInLocalTime, getStartOfDayInLocalTime } from './utils.js';
 import { expect } from '@open-wc/testing';
 
 describe('log viewer date range utils', () => {
-	describe('umbGetStartOfDayInLocalTime', () => {
+	describe('getStartOfDayInLocalTime', () => {
 		it('returns an absolute UTC timestamp', () => {
-			const result = umbGetStartOfDayInLocalTime('2023-08-22');
+			const result = getStartOfDayInLocalTime('2023-08-22');
 			// A bare date is no longer sent; the server needs an instant to resolve the correct log files (#14710).
 			expect(result).to.not.equal('2023-08-22');
 			expect(result.endsWith('Z')).to.be.true;
 		});
 
 		it('represents the very start of the given day in local time', () => {
-			const result = new Date(umbGetStartOfDayInLocalTime('2023-08-22'));
+			const result = new Date(getStartOfDayInLocalTime('2023-08-22'));
 			expect(result.getFullYear()).to.equal(2023);
 			expect(result.getMonth()).to.equal(7); // August (0-indexed)
 			expect(result.getDate()).to.equal(22);
@@ -22,23 +22,23 @@ describe('log viewer date range utils', () => {
 		});
 
 		it('returns the input unchanged when it cannot be parsed', () => {
-			expect(umbGetStartOfDayInLocalTime('')).to.equal('');
-			expect(umbGetStartOfDayInLocalTime('not-a-date')).to.equal('not-a-date');
-			expect(umbGetStartOfDayInLocalTime('2023-08-')).to.equal('2023-08-'); // partial: day would become 0
-			expect(umbGetStartOfDayInLocalTime('2023-13-40')).to.equal('2023-13-40'); // out of range: would roll over
-			expect(umbGetStartOfDayInLocalTime('2023-02-29')).to.equal('2023-02-29'); // not a leap year
+			expect(getStartOfDayInLocalTime('')).to.equal('');
+			expect(getStartOfDayInLocalTime('not-a-date')).to.equal('not-a-date');
+			expect(getStartOfDayInLocalTime('2023-08-')).to.equal('2023-08-'); // partial: day would become 0
+			expect(getStartOfDayInLocalTime('2023-13-40')).to.equal('2023-13-40'); // out of range: would roll over
+			expect(getStartOfDayInLocalTime('2023-02-29')).to.equal('2023-02-29'); // not a leap year
 		});
 	});
 
-	describe('umbGetEndOfDayInLocalTime', () => {
+	describe('getEndOfDayInLocalTime', () => {
 		it('returns an absolute UTC timestamp', () => {
-			const result = umbGetEndOfDayInLocalTime('2023-08-22');
+			const result = getEndOfDayInLocalTime('2023-08-22');
 			expect(result).to.not.equal('2023-08-22');
 			expect(result.endsWith('Z')).to.be.true;
 		});
 
 		it('represents the very end of the given day in local time', () => {
-			const result = new Date(umbGetEndOfDayInLocalTime('2023-08-22'));
+			const result = new Date(getEndOfDayInLocalTime('2023-08-22'));
 			expect(result.getFullYear()).to.equal(2023);
 			expect(result.getMonth()).to.equal(7); // August (0-indexed)
 			expect(result.getDate()).to.equal(22);
@@ -49,11 +49,11 @@ describe('log viewer date range utils', () => {
 		});
 
 		it('returns the input unchanged when it cannot be parsed', () => {
-			expect(umbGetEndOfDayInLocalTime('')).to.equal('');
-			expect(umbGetEndOfDayInLocalTime('not-a-date')).to.equal('not-a-date');
-			expect(umbGetEndOfDayInLocalTime('2023-08-')).to.equal('2023-08-'); // partial: day would become 0
-			expect(umbGetEndOfDayInLocalTime('2023-13-40')).to.equal('2023-13-40'); // out of range: would roll over
-			expect(umbGetEndOfDayInLocalTime('2023-02-29')).to.equal('2023-02-29'); // not a leap year
+			expect(getEndOfDayInLocalTime('')).to.equal('');
+			expect(getEndOfDayInLocalTime('not-a-date')).to.equal('not-a-date');
+			expect(getEndOfDayInLocalTime('2023-08-')).to.equal('2023-08-'); // partial: day would become 0
+			expect(getEndOfDayInLocalTime('2023-13-40')).to.equal('2023-13-40'); // out of range: would roll over
+			expect(getEndOfDayInLocalTime('2023-02-29')).to.equal('2023-02-29'); // not a leap year
 		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.test.ts
@@ -1,0 +1,51 @@
+import { umbGetEndOfDayInLocalTime, umbGetStartOfDayInLocalTime } from './utils.js';
+import { expect } from '@open-wc/testing';
+
+describe('log viewer date range utils', () => {
+	describe('umbGetStartOfDayInLocalTime', () => {
+		it('returns an absolute UTC timestamp', () => {
+			const result = umbGetStartOfDayInLocalTime('2023-08-22');
+			// A bare date is no longer sent; the server needs an instant to resolve the correct log files (#14710).
+			expect(result).to.not.equal('2023-08-22');
+			expect(result.endsWith('Z')).to.be.true;
+		});
+
+		it('represents the very start of the given day in local time', () => {
+			const result = new Date(umbGetStartOfDayInLocalTime('2023-08-22'));
+			expect(result.getFullYear()).to.equal(2023);
+			expect(result.getMonth()).to.equal(7); // August (0-indexed)
+			expect(result.getDate()).to.equal(22);
+			expect(result.getHours()).to.equal(0);
+			expect(result.getMinutes()).to.equal(0);
+			expect(result.getSeconds()).to.equal(0);
+			expect(result.getMilliseconds()).to.equal(0);
+		});
+
+		it('returns the input unchanged when it cannot be parsed', () => {
+			expect(umbGetStartOfDayInLocalTime('')).to.equal('');
+		});
+	});
+
+	describe('umbGetEndOfDayInLocalTime', () => {
+		it('returns an absolute UTC timestamp', () => {
+			const result = umbGetEndOfDayInLocalTime('2023-08-22');
+			expect(result).to.not.equal('2023-08-22');
+			expect(result.endsWith('Z')).to.be.true;
+		});
+
+		it('represents the very end of the given day in local time', () => {
+			const result = new Date(umbGetEndOfDayInLocalTime('2023-08-22'));
+			expect(result.getFullYear()).to.equal(2023);
+			expect(result.getMonth()).to.equal(7); // August (0-indexed)
+			expect(result.getDate()).to.equal(22);
+			expect(result.getHours()).to.equal(23);
+			expect(result.getMinutes()).to.equal(59);
+			expect(result.getSeconds()).to.equal(59);
+			expect(result.getMilliseconds()).to.equal(999);
+		});
+
+		it('returns the input unchanged when it cannot be parsed', () => {
+			expect(umbGetEndOfDayInLocalTime('')).to.equal('');
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.test.ts
@@ -23,6 +23,10 @@ describe('log viewer date range utils', () => {
 
 		it('returns the input unchanged when it cannot be parsed', () => {
 			expect(umbGetStartOfDayInLocalTime('')).to.equal('');
+			expect(umbGetStartOfDayInLocalTime('not-a-date')).to.equal('not-a-date');
+			expect(umbGetStartOfDayInLocalTime('2023-08-')).to.equal('2023-08-'); // partial: day would become 0
+			expect(umbGetStartOfDayInLocalTime('2023-13-40')).to.equal('2023-13-40'); // out of range: would roll over
+			expect(umbGetStartOfDayInLocalTime('2023-02-29')).to.equal('2023-02-29'); // not a leap year
 		});
 	});
 
@@ -46,6 +50,10 @@ describe('log viewer date range utils', () => {
 
 		it('returns the input unchanged when it cannot be parsed', () => {
 			expect(umbGetEndOfDayInLocalTime('')).to.equal('');
+			expect(umbGetEndOfDayInLocalTime('not-a-date')).to.equal('not-a-date');
+			expect(umbGetEndOfDayInLocalTime('2023-08-')).to.equal('2023-08-'); // partial: day would become 0
+			expect(umbGetEndOfDayInLocalTime('2023-13-40')).to.equal('2023-13-40'); // out of range: would roll over
+			expect(umbGetEndOfDayInLocalTime('2023-02-29')).to.equal('2023-02-29'); // not a leap year
 		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.ts
@@ -5,7 +5,12 @@
  * @returns {string} The ISO 8601 timestamp, or the original string if it cannot be parsed.
  */
 export function umbGetStartOfDayInLocalTime(date: string): string {
-	return toLocalInstant(date, 0, 0, 0, 0);
+	const parsed = parseLocalDate(date);
+	if (!parsed) {
+		return date;
+	}
+
+	return new Date(parsed.year, parsed.month - 1, parsed.day, 0, 0, 0, 0).toISOString();
 }
 
 /**
@@ -20,33 +25,40 @@ export function umbGetStartOfDayInLocalTime(date: string): string {
  * @returns {string} The ISO 8601 timestamp, or the original string if it cannot be parsed.
  */
 export function umbGetEndOfDayInLocalTime(date: string): string {
-	return toLocalInstant(date, 23, 59, 59, 999);
+	const parsed = parseLocalDate(date);
+	if (!parsed) {
+		return date;
+	}
+
+	return new Date(parsed.year, parsed.month - 1, parsed.day, 23, 59, 59, 999).toISOString();
 }
 
 /**
- * Builds an absolute (UTC) ISO 8601 timestamp for a `YYYY-MM-DD` date at a specific local time of day.
+ * Parses a strict `YYYY-MM-DD` calendar date into its numeric parts.
+ *
+ * Returns `null` for anything that is not a real calendar date, including partial input
+ * (`2023-08-`) and out-of-range values (`2023-13-40`, `2023-02-29`) that the `Date` constructor
+ * would otherwise silently normalize to a different day.
  * @param {string} date A calendar date in `YYYY-MM-DD` format.
- * @param {number} hours The local hours component.
- * @param {number} minutes The local minutes component.
- * @param {number} seconds The local seconds component.
- * @param {number} milliseconds The local milliseconds component.
- * @returns {string} The ISO 8601 timestamp, or the original string if it cannot be parsed.
+ * @returns {{ year: number; month: number; day: number } | null} The parsed parts, or `null` if invalid.
  */
-function toLocalInstant(date: string, hours: number, minutes: number, seconds: number, milliseconds: number): string {
+function parseLocalDate(date: string): { year: number; month: number; day: number } | null {
 	const parts = date.split('-');
 	if (parts.length !== 3) {
-		return date;
+		return null;
 	}
 
 	const [year, month, day] = parts.map(Number);
-	if ([year, month, day].some((part) => !Number.isFinite(part))) {
-		return date;
+	if ([year, month, day].some((part) => !Number.isInteger(part))) {
+		return null;
 	}
 
-	const instant = new Date(year, month - 1, day, hours, minutes, seconds, milliseconds);
-	if (Number.isNaN(instant.getTime())) {
-		return date;
+	// Confirm the date round-trips: if the constructor normalized it (e.g. day 0 or month 13),
+	// the read-back components will not match the input, so treat it as unparseable.
+	const probe = new Date(year, month - 1, day);
+	if (probe.getFullYear() !== year || probe.getMonth() !== month - 1 || probe.getDate() !== day) {
+		return null;
 	}
 
-	return instant.toISOString();
+	return { year, month, day };
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.ts
@@ -1,0 +1,52 @@
+/**
+ * Converts a `YYYY-MM-DD` calendar date to the absolute (UTC) ISO 8601 timestamp for the very
+ * start of that day (00:00:00.000) in the browser's local time zone.
+ * @param {string} date A calendar date in `YYYY-MM-DD` format, as produced by `<umb-input-date type="date">`.
+ * @returns {string} The ISO 8601 timestamp, or the original string if it cannot be parsed.
+ */
+export function umbGetStartOfDayInLocalTime(date: string): string {
+	return toLocalInstant(date, 0, 0, 0, 0);
+}
+
+/**
+ * Converts a `YYYY-MM-DD` calendar date to the absolute (UTC) ISO 8601 timestamp for the very
+ * end of that day (23:59:59.999) in the browser's local time zone.
+ *
+ * The log viewer stores entries in files bucketed by the *server's* calendar date. Sending an
+ * absolute instant (rather than a bare date) lets the server resolve the correct files regardless
+ * of the offset between the browser and the server, so entries logged late in the user's local day
+ * are not missed when the server has already rolled over to the next date (#14710).
+ * @param {string} date A calendar date in `YYYY-MM-DD` format, as produced by `<umb-input-date type="date">`.
+ * @returns {string} The ISO 8601 timestamp, or the original string if it cannot be parsed.
+ */
+export function umbGetEndOfDayInLocalTime(date: string): string {
+	return toLocalInstant(date, 23, 59, 59, 999);
+}
+
+/**
+ * Builds an absolute (UTC) ISO 8601 timestamp for a `YYYY-MM-DD` date at a specific local time of day.
+ * @param {string} date A calendar date in `YYYY-MM-DD` format.
+ * @param {number} hours The local hours component.
+ * @param {number} minutes The local minutes component.
+ * @param {number} seconds The local seconds component.
+ * @param {number} milliseconds The local milliseconds component.
+ * @returns {string} The ISO 8601 timestamp, or the original string if it cannot be parsed.
+ */
+function toLocalInstant(date: string, hours: number, minutes: number, seconds: number, milliseconds: number): string {
+	const parts = date.split('-');
+	if (parts.length !== 3) {
+		return date;
+	}
+
+	const [year, month, day] = parts.map(Number);
+	if ([year, month, day].some((part) => !Number.isFinite(part))) {
+		return date;
+	}
+
+	const instant = new Date(year, month - 1, day, hours, minutes, seconds, milliseconds);
+	if (Number.isNaN(instant.getTime())) {
+		return date;
+	}
+
+	return instant.toISOString();
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.ts
@@ -54,9 +54,11 @@ function parseLocalDate(date: string): { year: number; month: number; day: numbe
 	}
 
 	// Confirm the date round-trips: if the constructor normalized it (e.g. day 0 or month 13),
-	// the read-back components will not match the input, so treat it as unparseable.
+	// the read-back components will not match the input, so treat it as unparseable. Both sides
+	// are built from the numeric values, so zero-padding differences are normalized away.
 	const probe = new Date(year, month - 1, day);
-	if (probe.getFullYear() !== year || probe.getMonth() !== month - 1 || probe.getDate() !== day) {
+	const roundTrip = `${probe.getFullYear()}-${probe.getMonth() + 1}-${probe.getDate()}`;
+	if (roundTrip !== `${year}-${month}-${day}`) {
 		return null;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/utils.ts
@@ -4,13 +4,8 @@
  * @param {string} date A calendar date in `YYYY-MM-DD` format, as produced by `<umb-input-date type="date">`.
  * @returns {string} The ISO 8601 timestamp, or the original string if it cannot be parsed.
  */
-export function umbGetStartOfDayInLocalTime(date: string): string {
-	const parsed = parseLocalDate(date);
-	if (!parsed) {
-		return date;
-	}
-
-	return new Date(parsed.year, parsed.month - 1, parsed.day, 0, 0, 0, 0).toISOString();
+export function getStartOfDayInLocalTime(date: string): string {
+	return toLocalInstant(date, 0, 0, 0, 0);
 }
 
 /**
@@ -24,13 +19,27 @@ export function umbGetStartOfDayInLocalTime(date: string): string {
  * @param {string} date A calendar date in `YYYY-MM-DD` format, as produced by `<umb-input-date type="date">`.
  * @returns {string} The ISO 8601 timestamp, or the original string if it cannot be parsed.
  */
-export function umbGetEndOfDayInLocalTime(date: string): string {
+export function getEndOfDayInLocalTime(date: string): string {
+	return toLocalInstant(date, 23, 59, 59, 999);
+}
+
+/**
+ * Converts a `YYYY-MM-DD` calendar date to the absolute (UTC) ISO 8601 timestamp for the given
+ * time of day in the browser's local time zone.
+ * @param {string} date A calendar date in `YYYY-MM-DD` format.
+ * @param {number} hours The local hour of day (0-23).
+ * @param {number} minutes The local minutes (0-59).
+ * @param {number} seconds The local seconds (0-59).
+ * @param {number} milliseconds The local milliseconds (0-999).
+ * @returns {string} The ISO 8601 timestamp, or the original string if the date cannot be parsed.
+ */
+function toLocalInstant(date: string, hours: number, minutes: number, seconds: number, milliseconds: number): string {
 	const parsed = parseLocalDate(date);
 	if (!parsed) {
 		return date;
 	}
 
-	return new Date(parsed.year, parsed.month - 1, parsed.day, 23, 59, 59, 999).toISOString();
+	return new Date(parsed.year, parsed.month - 1, parsed.day, hours, minutes, seconds, milliseconds).toISOString();
 }
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -179,10 +179,9 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 		return this.#dateRange.getValue();
 	}
 
-	// The server buckets log entries into files by its own calendar date, so the selected calendar
-	// days are sent as absolute instants covering the full local day. This ensures entries logged
-	// late in the user's local day are still resolved when the server has rolled over to the next
-	// date (#14710).
+	// Query the server with absolute instants spanning the full local day (see
+	// getStartOfDayInLocalTime / getEndOfDayInLocalTime) so it resolves the correct day files
+	// regardless of the browser/server offset (#14710). #dateRange keeps the bare dates for display.
 	#getRequestDateRange(): UmbLogViewerDateRange {
 		const { startDate, endDate } = this.#dateRange.getValue();
 		return {

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -1,5 +1,6 @@
 import { UmbLogViewerRepository } from '../repository/log-viewer.repository.js';
 import type { UmbLogLevelCounts } from '../types.js';
+import { umbGetEndOfDayInLocalTime, umbGetStartOfDayInLocalTime } from '../utils.js';
 import { UMB_APP_LOG_VIEWER_CONTEXT } from './logviewer-workspace.context-token.js';
 import { UmbBasicState, UmbArrayState, UmbObjectState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 import type {
@@ -156,8 +157,14 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 		if (!startDate) startDate = this.defaultDateRange.startDate;
 		if (!endDate) endDate = this.defaultDateRange.endDate;
 
-		const isAnyDateInTheFuture = new Date(startDate) > new Date() || new Date(endDate) > new Date();
-		const isStartDateBiggerThenEndDate = new Date(startDate) > new Date(endDate);
+		// Parse the calendar dates in local time (a bare `YYYY-MM-DD` would parse as UTC), so the
+		// comparison against "now" is consistent regardless of the browser's time zone (#14710).
+		const now = new Date();
+		const startDateLocal = new Date(`${startDate}T00:00:00`);
+		const endDateLocal = new Date(`${endDate}T00:00:00`);
+
+		const isAnyDateInTheFuture = startDateLocal > now || endDateLocal > now;
+		const isStartDateBiggerThenEndDate = startDateLocal > endDateLocal;
 		if (isAnyDateInTheFuture || isStartDateBiggerThenEndDate) {
 			return;
 		}
@@ -170,6 +177,18 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 
 	getDateRange() {
 		return this.#dateRange.getValue();
+	}
+
+	// The server buckets log entries into files by its own calendar date, so the selected calendar
+	// days are sent as absolute instants covering the full local day. This ensures entries logged
+	// late in the user's local day are still resolved when the server has rolled over to the next
+	// date (#14710).
+	#getRequestDateRange(): UmbLogViewerDateRange {
+		const { startDate, endDate } = this.#dateRange.getValue();
+		return {
+			startDate: umbGetStartOfDayInLocalTime(startDate),
+			endDate: umbGetEndOfDayInLocalTime(endDate),
+		};
 	}
 
 	async getSavedSearches({ skip = 0, take = 999 }: { skip?: number; take?: number } = {}) {
@@ -231,12 +250,12 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 	}
 
 	async getLogCount() {
-		const { data } = await this.#repository.getLogCount({ ...this.#dateRange.getValue() });
+		const { data } = await this.#repository.getLogCount({ ...this.#getRequestDateRange() });
 		this.#logCount.setValue(data ?? null);
 	}
 
 	async getMessageTemplates(skip: number, take: number) {
-		const { data } = await this.#repository.getMessageTemplates({ skip, take, ...this.#dateRange.getValue() });
+		const { data } = await this.#repository.getMessageTemplates({ skip, take, ...this.#getRequestDateRange() });
 
 		if (data) {
 			this.#messageTemplates.setValue(data);
@@ -252,7 +271,7 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 	}
 
 	async validateLogSize() {
-		const { error } = await this.#repository.getLogViewerValidateLogsSize({ ...this.#dateRange.getValue() });
+		const { error } = await this.#repository.getLogViewerValidateLogsSize({ ...this.#getRequestDateRange() });
 		if (error) {
 			this.#canShowLogs.setValue(false);
 			return;
@@ -282,7 +301,7 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 			orderDirection: this.#sortingDirection.getValue(),
 			filterExpression: this.#filterExpression.getValue(),
 			logLevel: this.#logLevelsFilter.getValue(),
-			...this.#dateRange.getValue(),
+			...this.#getRequestDateRange(),
 		};
 
 		const { data } = await this.#repository.getLogs(options);

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -1,6 +1,6 @@
 import { UmbLogViewerRepository } from '../repository/log-viewer.repository.js';
 import type { UmbLogLevelCounts } from '../types.js';
-import { umbGetEndOfDayInLocalTime, umbGetStartOfDayInLocalTime } from '../utils.js';
+import { getEndOfDayInLocalTime, getStartOfDayInLocalTime } from '../utils.js';
 import { UMB_APP_LOG_VIEWER_CONTEXT } from './logviewer-workspace.context-token.js';
 import { UmbBasicState, UmbArrayState, UmbObjectState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 import type {
@@ -186,8 +186,8 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 	#getRequestDateRange(): UmbLogViewerDateRange {
 		const { startDate, endDate } = this.#dateRange.getValue();
 		return {
-			startDate: umbGetStartOfDayInLocalTime(startDate),
-			endDate: umbGetEndOfDayInLocalTime(endDate),
+			startDate: getStartOfDayInLocalTime(startDate),
+			endDate: getEndOfDayInLocalTime(endDate),
 		};
 	}
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/LogViewerServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/LogViewerServiceTests.cs
@@ -38,6 +38,15 @@ internal sealed class LogViewerServiceTests : UmbracoIntegrationTest
     private const string CorruptFileValidLineAfter =
         """{"@t":"2024-01-09T09:00:02.0000000Z","@mt":"Second valid entry","SourceContext":"Test","ProcessId":1,"ProcessName":"Test","ThreadId":1,"MachineName":"TEST","Log4NetLevel":"INFO "}""";
 
+    // Three consecutive day files written in OneTimeSetUp, each holding an early and a late entry.
+    // Timestamps and filenames are derived from *local* time so file selection (by local calendar
+    // date) and the per-entry range check (by absolute instant) line up on any machine time zone.
+    // A range starting midday on the first day and ending midday on the last day therefore includes
+    // the whole middle day but only the in-range entries from the boundary day files (#14710).
+    private readonly DateTime _boundaryStartDate = new(2026, 7, 21, 12, 0, 0);
+    private readonly DateTime _boundaryEndDate = new(2026, 7, 23, 12, 0, 0);
+    private readonly List<string> _boundaryLogfilePaths = new();
+
     private string _sampleLogfilePath;
     private string _corruptLogfilePath;
 
@@ -63,6 +72,35 @@ internal sealed class LogViewerServiceTests : UmbracoIntegrationTest
             Environment.NewLine,
             new[] { CorruptFileValidLineBefore, CorruptFileTruncatedLine, CorruptFileValidLineAfter }) + Environment.NewLine;
         File.WriteAllText(_corruptLogfilePath, corruptContent);
+
+        // Boundary-trimming fixture: one file per local day, each with an entry before and after
+        // midday. With a range of [day1 12:00, day3 12:00] the "early" entry on day1 and the "late"
+        // entry on day3 fall outside the range and must be excluded, while the middle day is whole.
+        WriteBoundaryLogfile(newLogfileDirPath, _boundaryStartDate.Date, "Day21 early", "Day21 late");
+        WriteBoundaryLogfile(newLogfileDirPath, _boundaryStartDate.Date.AddDays(1), "Day22 early", "Day22 late");
+        WriteBoundaryLogfile(newLogfileDirPath, _boundaryEndDate.Date, "Day23 early", "Day23 late");
+    }
+
+    private void WriteBoundaryLogfile(string logfileDirPath, DateTime localDay, string earlyMessage, string lateMessage)
+    {
+        var path = Path.Combine(logfileDirPath, $"UmbracoTraceLog.BOUNDARYTEST.{localDay:yyyyMMdd}.json");
+        var content = string.Join(
+            Environment.NewLine,
+            new[]
+            {
+                BoundaryLogLine(localDay.AddHours(6), earlyMessage),
+                BoundaryLogLine(localDay.AddHours(18), lateMessage),
+            }) + Environment.NewLine;
+        File.WriteAllText(path, content);
+        _boundaryLogfilePaths.Add(path);
+    }
+
+    private static string BoundaryLogLine(DateTime localTime, string message)
+    {
+        // Serilog Compact records the timestamp as an absolute instant; write the local wall time as
+        // its UTC equivalent so the entry's instant matches what the range comparison expects.
+        DateTime utc = DateTime.SpecifyKind(localTime, DateTimeKind.Local).ToUniversalTime();
+        return $$"""{"@t":"{{utc:o}}","@mt":"{{message}}","SourceContext":"Test","ProcessId":1,"ProcessName":"Test","ThreadId":1,"MachineName":"TEST","Log4NetLevel":"INFO "}""";
     }
 
     [OneTimeTearDown]
@@ -76,6 +114,11 @@ internal sealed class LogViewerServiceTests : UmbracoIntegrationTest
         if (File.Exists(_corruptLogfilePath))
         {
             File.Delete(_corruptLogfilePath);
+        }
+
+        foreach (var path in _boundaryLogfilePaths.Where(File.Exists))
+        {
+            File.Delete(path);
         }
     }
 
@@ -178,6 +221,28 @@ internal sealed class LogViewerServiceTests : UmbracoIntegrationTest
             Assert.AreEqual("Create Index:\n {Sql}", mostPopularTemplate.MessageTemplate);
             Assert.AreEqual(74, mostPopularTemplate.Count);
             Assert.AreEqual(attempt.Result.Items, attempt.Result.Items.OrderByDescending(x => x.Count));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a range spanning several day files returns every entry from the fully-covered
+    /// day but only the in-range entries from the boundary day files, rather than the whole of those
+    /// files. Coverage for the server side of https://github.com/umbraco/Umbraco-CMS/issues/14710.
+    /// </summary>
+    [Test]
+    public async Task Get_Logs_Excludes_Boundary_File_Entries_Outside_Time_Range()
+    {
+        var attempt = await LogViewerService.GetPagedLogsAsync(_boundaryStartDate, _boundaryEndDate, 0, int.MaxValue);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(attempt.Success);
+            Assert.AreEqual(LogViewerOperationStatus.Success, attempt.Status);
+            Assert.IsNotNull(attempt.Result);
+            Assert.AreEqual(4, attempt.Result.Total, "Entries outside the range in the boundary day files should be excluded.");
+            Assert.That(
+                attempt.Result.Items.Select(x => x.RenderedMessage),
+                Is.EquivalentTo(new[] { "Day21 late", "Day22 early", "Day22 late", "Day23 early" }));
         });
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/LogViewerServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/LogViewerServiceTests.cs
@@ -246,6 +246,49 @@ internal sealed class LogViewerServiceTests : UmbracoIntegrationTest
         });
     }
 
+    /// <summary>
+    /// The level-counts path reads through the same file reader as the paged logs, so it must apply
+    /// the same range trimming — only the four in-range entries (all Information level) from the
+    /// boundary day files should be counted, not the two that fall outside the range.
+    /// </summary>
+    [Test]
+    public async Task Get_Log_Count_Excludes_Boundary_File_Entries_Outside_Time_Range()
+    {
+        var attempt = await LogViewerService.GetLogLevelCountsAsync(_boundaryStartDate, _boundaryEndDate);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(attempt.Success);
+            Assert.AreEqual(LogViewerOperationStatus.Success, attempt.Status);
+            Assert.IsNotNull(attempt.Result);
+            Assert.AreEqual(4, attempt.Result.Information, "Only the in-range entries should be counted.");
+            Assert.AreEqual(0, attempt.Result.Warning);
+            Assert.AreEqual(0, attempt.Result.Error);
+            Assert.AreEqual(0, attempt.Result.Fatal);
+        });
+    }
+
+    /// <summary>
+    /// The message-templates path also reads through the same file reader, so it must likewise only
+    /// tally the in-range entries from the boundary day files.
+    /// </summary>
+    [Test]
+    public async Task Get_Message_Templates_Excludes_Boundary_File_Entries_Outside_Time_Range()
+    {
+        var attempt = await LogViewerService.GetMessageTemplatesAsync(_boundaryStartDate, _boundaryEndDate, 0, int.MaxValue);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(attempt.Success);
+            Assert.AreEqual(LogViewerOperationStatus.Success, attempt.Status);
+            Assert.IsNotNull(attempt.Result);
+            Assert.AreEqual(4, attempt.Result.Total);
+            Assert.That(
+                attempt.Result.Items.Select(x => x.MessageTemplate),
+                Is.EquivalentTo(new[] { "Day21 late", "Day22 early", "Day22 late", "Day23 early" }));
+        });
+    }
+
     [Test]
     public async Task Can_Add_Saved_Query()
     {


### PR DESCRIPTION
## Description

Fixes #14710.

The Log Viewer stores entries in files bucketed by the **server's** local calendar date (`...20230822*.json`). The backoffice built the date-range filter from the **browser's** clock and sent bare date-only strings (`2023-08-22`). When the user's timezone is behind the server's (e.g. US Mountain time against a UTC/European server), entries logged late in the user's local evening land in the server's *next-day* file, which fell outside the requested range — so recent logs were invisible until the user manually bumped `endDate` in the URL.

### Fix (frontend only — the API params are already `date-time`)

- New `utils.ts` helpers convert a `YYYY-MM-DD` calendar date into an absolute UTC instant for the **start** and **end** of that day *in the user's local timezone*.
- `logviewer-workspace.context.ts` now sends `[start-of-local-day, end-of-local-day]` instants for all log queries (`getLogs`, `getLogCount`, `getMessageTemplates`, `validateLogSize`). The server's `.LocalDateTime` conversion then resolves the correct day file(s), so nothing from the user's local day is missed. Display/URL values stay date-only.
- Fixed the "future date" guard, which compared a UTC-parsed date against a local `now` and could reject a legitimate "today" for users ahead of UTC.

### Testing

- Added `utils.test.ts` (6 tests) covering start/end-of-day conversion and unparseable input.
- `npm test` for the log-viewer package passes; eslint clean.
- Manual: with the OS clock set to a timezone behind the server, a log entry generated late in the local evening now appears under the default range.
