### PR TITLE
Added keyboard navigation for image cropper crop previews (#16820)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
@@ -200,7 +200,17 @@ export class UmbInputImageCropperFieldElement extends UmbLitElement {
 					.focalPoint=${this.focalPoint}
 					.src=${this.source}
 					?active=${this.currentCrop?.alias === crop.alias}
-					@click=${() => this.onCropClick(crop)}>
+					tabindex="0"
+					role="button"
+					aria-label=${crop.alias}
+					@click=${() => this.onCropClick(crop)}
+					@keydown=${(e: KeyboardEvent) => {
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							e.stopPropagation();
+							this.onCropClick(crop);
+						}
+					}}>
 				</umb-image-cropper-preview>
 			`,
 		);
@@ -253,9 +263,16 @@ export class UmbInputImageCropperFieldElement extends UmbLitElement {
 				overflow-y: auto;
 				height: fit-content;
 				max-height: 100%;
+				padding: 4px;
 
 				umb-image-cropper-preview[active] {
 					background-color: var(--uui-color-current);
+				}
+
+				umb-image-cropper-preview:focus-visible {
+					outline: 2px solid var(--uui-color-selected);
+					outline-offset: 2px;
+					border-radius: var(--uui-border-radius);
 				}
 			}
 		`,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Closes #16820

## Summary

Image cropper crop previews were not keyboard-accessible; users could only select crops by clicking with a mouse. This prevented keyboard-only users from navigating and selecting different crop presets.

## What was changed

In `image-cropper-field.element.ts`:

- Added `tabindex="0"` to crop preview elements; makes them focusable via Tab key
- Added `role="button"`; announces them as interactive to screen readers
- Added `aria-label` with crop alias; provides accessible name
- Added `@keydown` handler for Enter/Space; activates crop selection via keyboard
- Added `:focus-visible` outline styling; visible blue focus ring when navigating with keyboard
- Added `padding: 4px` to `#side` container; prevents focus outline from being clipped by overflow

## Testing

1. Create an Image Cropper data type with multiple crops (e.g., "Banner" 1200x400, "Thumbnail" 300x300)
2. Add it to a Document Type, create content and upload an image
3. Open the image cropper editor
4. Press **Tab**; crop previews on the right should receive focus with a visible blue outline
5. Press **Enter** or **Space**; the focused crop should become active (same as clicking it)
6. Tab between crops; each one should be individually focusable

## After adding fix
<img width="1899" height="944" alt="After_adding_fix-for_making_cropper_keyboard_accessible" src="https://github.com/user-attachments/assets/c59c3196-84ce-4d82-b1a6-fdcd41c24cbc" />