### PR TITLE
Migrations: Ensure the umbracoContent.contentTypeId index is created when upgrading from 18.0 to 18.1

### DIFF
--- a/src/Umbraco.Infrastructure/CLAUDE.md
+++ b/src/Umbraco.Infrastructure/CLAUDE.md
@@ -549,6 +549,22 @@ using (var outer = ScopeProvider.CreateCoreScope())
 - Keep the Guids in **one place** (a shared `Constants` value referenced by both `DatabaseDataCreator`
   and the migration) so they cannot drift.
 
+**Migrations merged UP into an already-released version line must be re-applied at the plan's end**:
+- The upgrader only ever walks the migration chain **forward** from the state stored in the database.
+  A migration merged up from a lower version (e.g. a 17.6 migration merged into v18) lands in the
+  `UmbracoPlan` in namespace order — i.e. **before** the higher line's own migrations.
+- Sites already released on the higher line have a stored state **past** that insertion point, so they
+  will **never** run it (e.g. sites on 18.0.x skip a 17.6-positioned migration when upgrading to 18.1).
+- **Fix**: re-apply the migration at the **end** of the plan under a new version section with a new GUID.
+  Migrations are already required to be idempotent (guard with `IndexExists`, existence checks, etc.),
+  so upgrade paths that hit it twice are unaffected.
+- Implement the re-run as an **empty subclass of the original migration** placed in the **new version's**
+  namespace (e.g. `V_18_1_0.AddContentTypeIdIndexForContent : V_17_6_0.AddContentTypeIdIndexForContent`).
+  Do **not** re-list the original type directly: `UmbracoPlan.GetVersionForState` (used by
+  `RuntimeState.CurrentMigrationVersion`) derives the database version from the **final** migration
+  type's `V_{major}_{minor}_{patch}` namespace, so the last step must live in the new version's namespace
+  to report the correct version. See PR #23328 (original) and #23466 (re-application).
+
 ### Repository Edge Cases
 
 **Cache Invalidation**:

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -106,6 +106,11 @@ public partial class UmbracoPlan : MigrationPlan
         To<V_18_0_0.AddElementContainerPermissions>("{D00BB11A-DDF8-47C4-B58E-150C123BB3BB}");
         To<V_18_0_0.MigrateSingleBlockList>("{74332C49-B279-4945-8943-F8F00B1F5949}");
         To<V_18_0_0.AddElementSectionForAdmins>("{6FE4656E-8B8D-452F-AE2A-438A615B61BC}");
+
+        // To 18.1.0
+        // Re-run of the 17.6 index migration: it sits earlier in the chain than the final 18.0 state,
+        // so sites already on 18.0.x skipped it. Idempotent, so other upgrade paths are unaffected.
+        To<V_18_1_0.AddContentTypeIdIndexForContent>("{AE533AF6-4611-4E25-AA4D-89AEFA468E79}");
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -62,6 +62,11 @@ public partial class UmbracoPlan : MigrationPlan
         //   .With()
         //     .To<ChangeB>("state-b")
         //   .As("state-2");
+        //
+        // Merging a migration UP into an already-released version line: it lands here in namespace order,
+        // BEFORE that line's own migrations, so sites already on that line skip it (they only walk forward).
+        // Re-apply it at the END of the plan as an empty subclass of the original, in the new version's
+        // namespace. See V_18_1_0.AddContentTypeIdIndexForContent and the Migration Edge Cases in CLAUDE.md.
 
         From(InitialState);
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_1_0/AddContentTypeIdIndexForContent.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_1_0/AddContentTypeIdIndexForContent.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_18_1_0;
+
+/// <summary>
+/// Re-applies the <see cref="V_17_6_0.AddContentTypeIdIndexForContent"/> migration for sites upgrading
+/// from an 18.0.x release.
+/// </summary>
+/// <remarks>
+/// The original migration was added for 17.6 and merged up, so it sits earlier in the plan than the
+/// final 18.0 migration state. Sites already on 18.0.x have moved past that point in the chain and would
+/// therefore never run it. Running it again here ensures they also gain the index. The operation is
+/// idempotent (guarded by <c>IndexExists</c>), so sites that reached it via the 17.6 path are unaffected.
+/// </remarks>
+public class AddContentTypeIdIndexForContent : V_17_6_0.AddContentTypeIdIndexForContent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddContentTypeIdIndexForContent"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public AddContentTypeIdIndexForContent(IMigrationContext context)
+        : base(context)
+    {
+    }
+}


### PR DESCRIPTION
## Description

PR #23328 added a migration (`V_17_6_0.AddContentTypeIdIndexForContent`) that creates the `IX_umbracoContent_contentTypeId` index on upgrade. It was merged up into the v18 line, but inserted into the migration chain **before** the 18.0 migrations.

As a result, sites already on an **18.0.x** release never receive the index when upgrading to 18.1: their stored migration state (`{6FE4656E-8B8D-452F-AE2A-438A615B61BC}`, the final 18.0 state) sits *after* the 17.6 migration in the linear chain, so the upgrader — which only walks forward — never reaches it.

Fresh 18.1 installs are unaffected (the index is declared on `ContentDto`), as are upgrades from 17.x (they pass through the 17.6 step).

To fix I have added:

- A new migration `V_18_1_0.AddContentTypeIdIndexForContent` is appended to the end of the plan with a new GUID (`{AE533AF6-4611-4E25-AA4D-89AEFA468E79}`), giving 18.0.x installs a forward path to it.
- It **inherits** `V_17_6_0.AddContentTypeIdIndexForContent`, so both paths build the exact same DTO-derived index. The operation is idempotent (guarded by `IndexExists`), so sites that already gained the index via the 17.6 path are unaffected.
- The migration lives in the `V_18_1_0` namespace (rather than re-referencing the 17.6 type) so that `RuntimeState.CurrentMigrationVersion` — derived from the final migration type's namespace via `GetVersionForState` — correctly reports 18.1.0.

## Testing

Verified by running the app against an 18.0 database: the migration runs, the stored migration state in the database is updated, and the `IX_umbracoContent_contentTypeId` index is created.