### PR TITLE
Property Editors: Use range property editor for min/max configuration (closes #16444, #17509)

### DIFF
--- a/src/Umbraco.Core/Extensions/JsonNodeExtensions.cs
+++ b/src/Umbraco.Core/Extensions/JsonNodeExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
+using System.Text.Json.Nodes;
+
+namespace Umbraco.Extensions;
+
+/// <summary>
+///     Extension methods for <see cref="JsonNode" />.
+/// </summary>
+public static class JsonNodeExtensions
+{
+    /// <summary>
+    ///     Reads the node as a <see cref="decimal" />, falling back to invariant-culture string parsing, and returning
+    ///     <c>null</c> when the node is <c>null</c> or cannot be interpreted as a number.
+    /// </summary>
+    /// <param name="node">The node to read.</param>
+    /// <returns>The decimal value, or <c>null</c> when the node is absent or not numeric.</returns>
+    public static decimal? ToDecimal(this JsonNode? node)
+    {
+        if (node is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return node.GetValue<decimal>();
+        }
+        catch
+        {
+            return decimal.TryParse(node.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/BlockGridConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/BlockGridConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
@@ -17,8 +19,8 @@ public class BlockGridConfiguration
     /// <summary>
     /// Gets or sets the validation limits for the number of blocks allowed.
     /// </summary>
-    [ConfigurationField("validationLimit")]
-    public NumberRange ValidationLimit { get; set; } = new NumberRange();
+    [ConfigurationField("validationLimit", Type = typeof(RangeConfigurationField))]
+    public PropertyEditors.NumberRange ValidationLimit { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the number of grid columns available in the Block Grid.
@@ -65,17 +67,9 @@ public class BlockGridConfiguration
     /// <summary>
     /// Represents a numeric range with optional minimum and maximum values.
     /// </summary>
-    public class NumberRange
+    [Obsolete("No longer used by Umbraco; use Umbraco.Cms.Core.PropertyEditors.NumberRange instead. Scheduled for removal in Umbraco 21.")]
+    public class NumberRange : PropertyEditors.NumberRange
     {
-        /// <summary>
-        /// Gets or sets the minimum value of the range.
-        /// </summary>
-        public int? Min { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum value of the range.
-        /// </summary>
-        public int? Max { get; set; }
     }
 
     /// <summary>
@@ -104,13 +98,46 @@ public class BlockGridConfiguration
         public int? RowSpan { get; set; }
 
         /// <summary>
+        /// Gets or sets the validation limits for the number of blocks allowed in this area.
+        /// </summary>
+        public PropertyEditors.NumberRange? ValidationLimit { get; set; }
+
+        /// <summary>
         /// Gets or sets the minimum number of blocks allowed in this area.
         /// </summary>
-        public int? MinAllowed { get; set; }
+        [Obsolete("Use ValidationLimit instead. Scheduled for removal in Umbraco 21.")]
+        [JsonIgnore]
+        public int? MinAllowed
+        {
+            get => ValidationLimit?.Min;
+            set
+            {
+                if (value is null && ValidationLimit is null)
+                {
+                    return;
+                }
+
+                (ValidationLimit ??= new()).Min = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the maximum number of blocks allowed in this area.
         /// </summary>
-        public int? MaxAllowed { get; set; }
+        [Obsolete("Use ValidationLimit instead. Scheduled for removal in Umbraco 21.")]
+        [JsonIgnore]
+        public int? MaxAllowed
+        {
+            get => ValidationLimit?.Max;
+            set
+            {
+                if (value is null && ValidationLimit is null)
+                {
+                    return;
+                }
+
+                (ValidationLimit ??= new()).Max = value;
+            }
+        }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/BlockListConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/BlockListConfiguration.cs
@@ -17,8 +17,8 @@ public class BlockListConfiguration
     /// <summary>
     ///     Gets or sets the validation limit for the number of blocks.
     /// </summary>
-    [ConfigurationField("validationLimit")]
-    public NumberRange ValidationLimit { get; set; } = new();
+    [ConfigurationField("validationLimit", Type = typeof(RangeConfigurationField))]
+    public PropertyEditors.NumberRange ValidationLimit { get; set; } = new();
 
     /// <summary>
     ///     Gets or sets a value indicating whether single block mode is enabled.
@@ -42,16 +42,8 @@ public class BlockListConfiguration
     /// <summary>
     ///     Represents a number range with optional minimum and maximum values.
     /// </summary>
-    public class NumberRange
+    [Obsolete("No longer used by Umbraco; use Umbraco.Cms.Core.PropertyEditors.NumberRange instead. Scheduled for removal in Umbraco 21.")]
+    public class NumberRange : PropertyEditors.NumberRange
     {
-        /// <summary>
-        ///     Gets or sets the minimum number of blocks allowed.
-        /// </summary>
-        public int? Min { get; set; }
-
-        /// <summary>
-        ///     Gets or sets the maximum number of blocks allowed.
-        /// </summary>
-        public int? Max { get; set; }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/DecimalConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalConfiguration.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents the configuration for the decimal property editor.
+/// </summary>
+public class DecimalConfiguration
+{
+    /// <summary>
+    ///     Gets or sets the allowed range of the entered value.
+    /// </summary>
+    [ConfigurationField("validationRange", Type = typeof(RangeConfigurationField))]
+    public DecimalRange ValidationRange { get; set; } = new();
+
+    /// <summary>
+    ///     Gets or sets the step size between allowed values.
+    /// </summary>
+    [ConfigurationField("step")]
+    public decimal? Step { get; set; }
+}

--- a/src/Umbraco.Core/PropertyEditors/DecimalConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalConfigurationEditor.cs
@@ -1,30 +1,28 @@
-using Umbraco.Cms.Core.PropertyEditors.Validators;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
-///     A custom pre-value editor class to deal with the legacy way that the pre-value data is stored.
+///     The configuration editor for the decimal property editor.
 /// </summary>
-public class DecimalConfigurationEditor : ConfigurationEditor
+public class DecimalConfigurationEditor : ConfigurationEditor<DecimalConfiguration>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DecimalConfigurationEditor"/> class.
     /// </summary>
-    public DecimalConfigurationEditor()
+    public DecimalConfigurationEditor(IIOHelper ioHelper)
+        : base(ioHelper)
     {
-        Fields.Add(new ConfigurationField(new DecimalValidator())
-        {
-            Key = "min"
-        });
+    }
 
-        Fields.Add(new ConfigurationField(new DecimalValidator())
-        {
-            Key = "step",
-        });
-
-        Fields.Add(new ConfigurationField(new DecimalValidator())
-        {
-            Key = "max",
-        });
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DecimalConfigurationEditor"/> class.
+    /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 21.")]
+    public DecimalConfigurationEditor()
+        : this(StaticServiceProvider.Instance.GetRequiredService<IIOHelper>())
+    {
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/DecimalConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalConfigurationEditor.cs
@@ -12,6 +12,7 @@ public class DecimalConfigurationEditor : ConfigurationEditor<DecimalConfigurati
     /// <summary>
     /// Initializes a new instance of the <see cref="DecimalConfigurationEditor"/> class.
     /// </summary>
+    /// <param name="ioHelper">The IO helper.</param>
     public DecimalConfigurationEditor(IIOHelper ioHelper)
         : base(ioHelper)
     {

--- a/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -23,13 +25,29 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueEditorIsReusable = true)]
 public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
 {
+    private readonly IIOHelper _ioHelper;
+
     /// <summary>
     ///     Initializes a new instance of the <see cref="DecimalPropertyEditor" /> class.
     /// </summary>
     public DecimalPropertyEditor(
-        IDataValueEditorFactory dataValueEditorFactory)
-        : base(dataValueEditorFactory) =>
+        IDataValueEditorFactory dataValueEditorFactory,
+        IIOHelper ioHelper)
+        : base(dataValueEditorFactory)
+    {
+        _ioHelper = ioHelper;
         SupportsReadOnly = true;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DecimalPropertyEditor" /> class.
+    /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 21.")]
+    public DecimalPropertyEditor(
+        IDataValueEditorFactory dataValueEditorFactory)
+        : this(dataValueEditorFactory, StaticServiceProvider.Instance.GetRequiredService<IIOHelper>())
+    {
+    }
 
     /// <inheritdoc />
     public Type? GetValueType(object? configuration) => typeof(decimal?);
@@ -43,28 +61,39 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
             ["type"] = new JsonArray("number", "null"),
         };
 
-        // Add min/max/step constraints from configuration if available
-        if (configuration is IDictionary<string, object> configDict)
+        // Add min/max/step constraints from configuration if available. The configuration arrives either as the
+        // typed configuration object (from the data type's ConfigurationObject) or as the raw dictionary.
+        if (configuration is DecimalConfiguration or IDictionary<string, object>)
         {
-            if (configDict.TryGetValue("min", out var minValue) && minValue is double min)
+            object? rangeValue = configuration switch
             {
-                schema["minimum"] = min;
+                DecimalConfiguration decimalConfiguration => decimalConfiguration.ValidationRange,
+                IDictionary<string, object> configDict when configDict.TryGetValue("validationRange", out var range) => range,
+                _ => null,
+            };
+
+            if (RangeConfigurationHelper.TryGetBounds(rangeValue, out decimal? min, out decimal? max))
+            {
+                if (min.HasValue)
+                {
+                    schema["minimum"] = (double)min.Value;
+                }
+
+                if (max.HasValue)
+                {
+                    schema["maximum"] = (double)max.Value;
+                }
             }
 
-            if (configDict.TryGetValue("max", out var maxValue) && maxValue is double max)
+            var step = configuration switch
             {
-                schema["maximum"] = max;
-            }
+                DecimalConfiguration decimalConfiguration when decimalConfiguration.Step.HasValue => (double)decimalConfiguration.Step.Value,
+                IDictionary<string, object> configDict when configDict.TryGetValue("step", out var stepValue) && stepValue is double stepDouble => stepDouble,
+                _ => (double?)null,
+            };
 
-            if (configDict.TryGetValue("step", out var stepValue) && stepValue is double step && step > 0)
-            {
-                schema["multipleOf"] = step;
-            }
-            else
-            {
-                // Default: allow up to 6 decimal places, matching DB DECIMAL(38,6)
-                schema["multipleOf"] = 0.000001;
-            }
+            // Default: allow up to 6 decimal places, matching DB DECIMAL(38,6).
+            schema["multipleOf"] = step is double configuredStep && configuredStep > 0 ? configuredStep : 0.000001;
         }
 
         return schema;
@@ -75,7 +104,7 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
         => DataValueEditorFactory.Create<DecimalPropertyValueEditor>(Attribute!);
 
     /// <inheritdoc />
-    protected override IConfigurationEditor CreateConfigurationEditor() => new DecimalConfigurationEditor();
+    protected override IConfigurationEditor CreateConfigurationEditor() => new DecimalConfigurationEditor(_ioHelper);
 
     /// <summary>
     /// Defines the value editor for the decimal property editor.
@@ -122,14 +151,9 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
         internal abstract class DecimalPropertyConfigurationValidatorBase : SimplePropertyConfigurationValidatorBase<double>
         {
             /// <summary>
-            /// The configuration key for the minimum value.
+            /// The configuration key for the validation range.
             /// </summary>
-            protected const string ConfigurationKeyMinValue = "min";
-
-            /// <summary>
-            /// The configuration key for the maximum value.
-            /// </summary>
-            protected const string ConfigurationKeyMaxValue = "max";
+            protected const string ConfigurationKeyValidationRange = "validationRange";
 
             /// <summary>
             /// The configuration key for the step value.
@@ -203,17 +227,22 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
                     yield break;
                 }
 
-                if (TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyMinValue, out double min) && parsedDecimalValue < min)
+                if (TryGetConfiguredRange(dataTypeConfiguration, ConfigurationKeyValidationRange, out decimal? min, out decimal? max) is false)
+                {
+                    yield break;
+                }
+
+                if (min.HasValue && parsedDecimalValue < (double)min.Value)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "outOfRangeMinimum", [parsedDecimalValue.ToString(), min.ToString()]),
+                        LocalizedTextService.Localize("validation", "outOfRangeMinimum", [parsedDecimalValue.ToString(), min.Value.ToString(CultureInfo.InvariantCulture)]),
                         ["value"]);
                 }
 
-                if (TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyMaxValue, out double max) && parsedDecimalValue > max)
+                if (max.HasValue && parsedDecimalValue > (double)max.Value)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "outOfRangeMaximum", [parsedDecimalValue.ToString(), max.ToString()]),
+                        LocalizedTextService.Localize("validation", "outOfRangeMaximum", [parsedDecimalValue.ToString(), max.Value.ToString(CultureInfo.InvariantCulture)]),
                         ["value"]);
                 }
             }
@@ -241,10 +270,8 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
                 }
 
                 // Default min to 0 if not configured (step validation is relative to min).
-                if (TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyMinValue, out double min) is false)
-                {
-                    min = 0;
-                }
+                TryGetConfiguredRange(dataTypeConfiguration, ConfigurationKeyValidationRange, out decimal? configuredMin, out _);
+                var min = configuredMin.HasValue ? (double)configuredMin.Value : 0d;
 
                 // Default step to 0.000001 (6 decimal places) if not configured,
                 // matching the database DECIMAL(38,6) column precision.

--- a/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
@@ -30,6 +30,8 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
     /// <summary>
     ///     Initializes a new instance of the <see cref="DecimalPropertyEditor" /> class.
     /// </summary>
+    /// <param name="dataValueEditorFactory">The data value editor factory.</param>
+    /// <param name="ioHelper">The IO helper.</param>
     public DecimalPropertyEditor(
         IDataValueEditorFactory dataValueEditorFactory,
         IIOHelper ioHelper)
@@ -42,6 +44,7 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
     /// <summary>
     ///     Initializes a new instance of the <see cref="DecimalPropertyEditor" /> class.
     /// </summary>
+    /// <param name="dataValueEditorFactory">The data value editor factory.</param>
     [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 21.")]
     public DecimalPropertyEditor(
         IDataValueEditorFactory dataValueEditorFactory)
@@ -65,14 +68,7 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
         // typed configuration object (from the data type's ConfigurationObject) or as the raw dictionary.
         if (configuration is DecimalConfiguration or IDictionary<string, object>)
         {
-            object? rangeValue = configuration switch
-            {
-                DecimalConfiguration decimalConfiguration => decimalConfiguration.ValidationRange,
-                IDictionary<string, object> configDict when configDict.TryGetValue("validationRange", out var range) => range,
-                _ => null,
-            };
-
-            if (RangeConfigurationHelper.TryGetBounds(rangeValue, out decimal? min, out decimal? max))
+            if (RangeConfigurationHelper.TryGetBounds(GetRangeValue(configuration), out decimal? min, out decimal? max))
             {
                 if (min.HasValue)
                 {
@@ -85,19 +81,28 @@ public class DecimalPropertyEditor : DataEditor, IValueSchemaProvider
                 }
             }
 
-            var step = configuration switch
-            {
-                DecimalConfiguration decimalConfiguration when decimalConfiguration.Step.HasValue => (double)decimalConfiguration.Step.Value,
-                IDictionary<string, object> configDict when configDict.TryGetValue("step", out var stepValue) && stepValue is double stepDouble => stepDouble,
-                _ => (double?)null,
-            };
-
             // Default: allow up to 6 decimal places, matching DB DECIMAL(38,6).
-            schema["multipleOf"] = step is double configuredStep && configuredStep > 0 ? configuredStep : 0.000001;
+            schema["multipleOf"] = GetStep(configuration) is double configuredStep && configuredStep > 0 ? configuredStep : 0.000001;
         }
 
         return schema;
     }
+
+    private static object? GetRangeValue(object? configuration)
+        => configuration switch
+        {
+            DecimalConfiguration decimalConfiguration => decimalConfiguration.ValidationRange,
+            IDictionary<string, object> configDict when configDict.TryGetValue("validationRange", out var range) => range,
+            _ => null,
+        };
+
+    private static double? GetStep(object? configuration)
+        => configuration switch
+        {
+            DecimalConfiguration decimalConfiguration when decimalConfiguration.Step.HasValue => (double)decimalConfiguration.Step.Value,
+            IDictionary<string, object> configDict when configDict.TryGetValue("step", out var stepValue) && stepValue is double stepDouble => stepDouble,
+            _ => (double?)null,
+        };
 
     /// <inheritdoc />
     protected override IDataValueEditor CreateValueEditor()

--- a/src/Umbraco.Core/PropertyEditors/DecimalRange.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalRange.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+/// Represents a decimal range with an optional minimum and maximum value, where <c>null</c> means "no bound".
+/// </summary>
+public class DecimalRange
+{
+    /// <summary>
+    /// Gets or sets the minimum value of the range, or <c>null</c> for no minimum.
+    /// </summary>
+    public decimal? Min { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum value of the range, or <c>null</c> for no maximum.
+    /// </summary>
+    public decimal? Max { get; set; }
+}

--- a/src/Umbraco.Core/PropertyEditors/ElementPickerConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/ElementPickerConfiguration.cs
@@ -12,8 +12,8 @@ public class ElementPickerConfiguration : IIgnoreUserStartNodesConfig
     /// <summary>
     /// Gets or sets the validation limits for the number of elements allowed.
     /// </summary>
-    [ConfigurationField("validationLimit")]
-    public NumberRange? ValidationLimit { get; set; }
+    [ConfigurationField("validationLimit", Type = typeof(RangeConfigurationField))]
+    public PropertyEditors.NumberRange? ValidationLimit { get; set; }
 
     /// <summary>
     /// Gets or sets the content type filter for allowed selections.
@@ -24,16 +24,8 @@ public class ElementPickerConfiguration : IIgnoreUserStartNodesConfig
     /// <summary>
     /// Represents a numeric range with optional minimum and maximum values.
     /// </summary>
-    public class NumberRange
+    [Obsolete("No longer used by Umbraco; use Umbraco.Cms.Core.PropertyEditors.NumberRange instead. Scheduled for removal in Umbraco 21.")]
+    public class NumberRange : PropertyEditors.NumberRange
     {
-        /// <summary>
-        /// Gets or sets the minimum value of the range.
-        /// </summary>
-        public int? Min { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum value of the range.
-        /// </summary>
-        public int? Max { get; set; }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/EntityDataPickerConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/EntityDataPickerConfiguration.cs
@@ -8,8 +8,8 @@ public sealed class EntityDataPickerConfiguration
     /// <summary>
     ///     Gets or sets the validation limit for the number of selected entities.
     /// </summary>
-    [ConfigurationField("validationLimit")]
-    public NumberRange ValidationLimit { get; set; } = new();
+    [ConfigurationField("validationLimit", Type = typeof(RangeConfigurationField))]
+    public PropertyEditors.NumberRange ValidationLimit { get; set; } = new();
 
     /// <summary>
     ///     Gets or sets the data source identifier for the entity picker.
@@ -20,16 +20,8 @@ public sealed class EntityDataPickerConfiguration
     /// <summary>
     ///     Represents a number range with optional minimum and maximum values.
     /// </summary>
-    public class NumberRange
+    [Obsolete("No longer used by Umbraco; use Umbraco.Cms.Core.PropertyEditors.NumberRange instead. Scheduled for removal in Umbraco 21.")]
+    public class NumberRange : PropertyEditors.NumberRange
     {
-        /// <summary>
-        ///     Gets or sets the minimum number of items allowed.
-        /// </summary>
-        public int? Min { get; set; }
-
-        /// <summary>
-        ///     Gets or sets the maximum number of items allowed.
-        /// </summary>
-        public int? Max { get; set; }
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/IntegerConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/IntegerConfiguration.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Represents the configuration for the integer (numeric) property editor.
+/// </summary>
+public class IntegerConfiguration
+{
+    /// <summary>
+    ///     Gets or sets the allowed range of the entered value.
+    /// </summary>
+    [ConfigurationField("validationRange", Type = typeof(RangeConfigurationField))]
+    public NumberRange ValidationRange { get; set; } = new();
+
+    /// <summary>
+    ///     Gets or sets the step size between allowed values.
+    /// </summary>
+    [ConfigurationField("step")]
+    public int? Step { get; set; }
+}

--- a/src/Umbraco.Core/PropertyEditors/IntegerConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IntegerConfigurationEditor.cs
@@ -1,30 +1,28 @@
-using Umbraco.Cms.Core.PropertyEditors.Validators;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
-///     A custom pre-value editor class to deal with the legacy way that the pre-value data is stored.
+///     The configuration editor for the integer (numeric) property editor.
 /// </summary>
-public class IntegerConfigurationEditor : ConfigurationEditor
+public class IntegerConfigurationEditor : ConfigurationEditor<IntegerConfiguration>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="IntegerConfigurationEditor"/> class.
     /// </summary>
-    public IntegerConfigurationEditor()
+    public IntegerConfigurationEditor(IIOHelper ioHelper)
+        : base(ioHelper)
     {
-        Fields.Add(new ConfigurationField(new IntegerValidator())
-        {
-            Key = "min",
-        });
+    }
 
-        Fields.Add(new ConfigurationField(new IntegerValidator())
-        {
-            Key = "step",
-        });
-
-        Fields.Add(new ConfigurationField(new IntegerValidator())
-        {
-            Key = "max",
-        });
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntegerConfigurationEditor"/> class.
+    /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 21.")]
+    public IntegerConfigurationEditor()
+        : this(StaticServiceProvider.Instance.GetRequiredService<IIOHelper>())
+    {
     }
 }

--- a/src/Umbraco.Core/PropertyEditors/IntegerConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IntegerConfigurationEditor.cs
@@ -12,6 +12,7 @@ public class IntegerConfigurationEditor : ConfigurationEditor<IntegerConfigurati
     /// <summary>
     /// Initializes a new instance of the <see cref="IntegerConfigurationEditor"/> class.
     /// </summary>
+    /// <param name="ioHelper">The IO helper.</param>
     public IntegerConfigurationEditor(IIOHelper ioHelper)
         : base(ioHelper)
     {

--- a/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
@@ -30,6 +30,7 @@ public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
     /// <summary>
     /// Initializes a new instance of the <see cref="IntegerPropertyEditor"/> class.
     /// </summary>
+    /// <param name="dataValueEditorFactory">The data value editor factory.</param>
     [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 21.")]
     public IntegerPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
         : this(dataValueEditorFactory, StaticServiceProvider.Instance.GetRequiredService<IIOHelper>())
@@ -39,6 +40,8 @@ public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
     /// <summary>
     /// Initializes a new instance of the <see cref="IntegerPropertyEditor"/> class.
     /// </summary>
+    /// <param name="dataValueEditorFactory">The data value editor factory.</param>
+    /// <param name="ioHelper">The IO helper.</param>
     public IntegerPropertyEditor(IDataValueEditorFactory dataValueEditorFactory, IIOHelper ioHelper)
         : base(dataValueEditorFactory)
     {
@@ -227,14 +230,15 @@ public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
                     yield break;
                 }
 
-                TryGetConfiguredRange(dataTypeConfiguration, ConfigurationKeyValidationRange, out decimal? min, out _);
+                // Default min to 0 if not configured (step validation is relative to min).
+                TryGetConfiguredRange(dataTypeConfiguration, ConfigurationKeyValidationRange, out decimal? configuredMin, out _);
+                var min = configuredMin.HasValue ? (int)configuredMin.Value : 0;
 
-                if (min.HasValue &&
-                    TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyStepValue, out int step) &&
-                    ValidationHelper.IsValueValidForStep(parsedIntegerValue, (int)min.Value, step) is false)
+                if (TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyStepValue, out int step) &&
+                    ValidationHelper.IsValueValidForStep(parsedIntegerValue, min, step) is false)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "invalidStep", [parsedIntegerValue.ToString(), step.ToString(), ((int)min.Value).ToString()]),
+                        LocalizedTextService.Localize("validation", "invalidStep", [parsedIntegerValue.ToString(), step.ToString(), min.ToString()]),
                         ["value"]);
                 }
             }

--- a/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -23,12 +25,26 @@ namespace Umbraco.Cms.Core.PropertyEditors;
     ValueEditorIsReusable = true)]
 public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
 {
+    private readonly IIOHelper _ioHelper;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="IntegerPropertyEditor"/> class.
     /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 21.")]
     public IntegerPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
+        : this(dataValueEditorFactory, StaticServiceProvider.Instance.GetRequiredService<IIOHelper>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntegerPropertyEditor"/> class.
+    /// </summary>
+    public IntegerPropertyEditor(IDataValueEditorFactory dataValueEditorFactory, IIOHelper ioHelper)
         : base(dataValueEditorFactory)
-        => SupportsReadOnly = true;
+    {
+        _ioHelper = ioHelper;
+        SupportsReadOnly = true;
+    }
 
     /// <inheritdoc />
     public Type? GetValueType(object? configuration) => typeof(int?);
@@ -42,23 +58,38 @@ public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
             ["type"] = new JsonArray("integer", "null"),
         };
 
-        // Add min/max constraints from configuration if available
-        if (configuration is IDictionary<string, object> configDict)
+        // Add min/max constraints from configuration if available. The configuration arrives either as the typed
+        // configuration object (from the data type's ConfigurationObject) or as the raw dictionary.
+        object? rangeValue = configuration switch
         {
-            if (configDict.TryGetValue("min", out var minValue) && minValue is int min)
+            IntegerConfiguration integerConfiguration => integerConfiguration.ValidationRange,
+            IDictionary<string, object> configDict when configDict.TryGetValue("validationRange", out var range) => range,
+            _ => null,
+        };
+
+        if (RangeConfigurationHelper.TryGetBounds(rangeValue, out decimal? min, out decimal? max))
+        {
+            if (min.HasValue)
             {
-                schema["minimum"] = min;
+                schema["minimum"] = (int)min.Value;
             }
 
-            if (configDict.TryGetValue("max", out var maxValue) && maxValue is int max)
+            if (max.HasValue)
             {
-                schema["maximum"] = max;
+                schema["maximum"] = (int)max.Value;
             }
+        }
 
-            if (configDict.TryGetValue("step", out var stepValue) && stepValue is int step && step > 1)
-            {
-                schema["multipleOf"] = step;
-            }
+        var step = configuration switch
+        {
+            IntegerConfiguration integerConfiguration => integerConfiguration.Step,
+            IDictionary<string, object> configDict when configDict.TryGetValue("step", out var stepValue) && stepValue is int stepInt => stepInt,
+            _ => null,
+        };
+
+        if (step is int configuredStep && configuredStep > 1)
+        {
+            schema["multipleOf"] = configuredStep;
         }
 
         return schema;
@@ -69,7 +100,7 @@ public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
         => DataValueEditorFactory.Create<IntegerPropertyValueEditor>(Attribute!);
 
     /// <inheritdoc />
-    protected override IConfigurationEditor CreateConfigurationEditor() => new IntegerConfigurationEditor();
+    protected override IConfigurationEditor CreateConfigurationEditor() => new IntegerConfigurationEditor(_ioHelper);
 
     /// <summary>
     /// Defines the value editor for the integer property editor.
@@ -109,14 +140,9 @@ public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
         internal abstract class IntegerPropertyConfigurationValidatorBase : SimplePropertyConfigurationValidatorBase<int>
         {
             /// <summary>
-            /// The configuration key for the minimum value.
+            /// The configuration key for the validation range.
             /// </summary>
-            protected const string ConfigurationKeyMinValue = "min";
-
-            /// <summary>
-            /// The configuration key for the maximum value.
-            /// </summary>
-            protected const string ConfigurationKeyMaxValue = "max";
+            protected const string ConfigurationKeyValidationRange = "validationRange";
 
             /// <summary>
             /// The configuration key for the step value.
@@ -159,17 +185,22 @@ public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
                     yield break;
                 }
 
-                if (TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyMinValue, out int min) && parsedIntegerValue < min)
+                if (TryGetConfiguredRange(dataTypeConfiguration, ConfigurationKeyValidationRange, out decimal? min, out decimal? max) is false)
+                {
+                    yield break;
+                }
+
+                if (min.HasValue && parsedIntegerValue < min.Value)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "outOfRangeMinimum", [parsedIntegerValue.ToString(), min.ToString()]),
+                        LocalizedTextService.Localize("validation", "outOfRangeMinimum", [parsedIntegerValue.ToString(), ((int)min.Value).ToString()]),
                         ["value"]);
                 }
 
-                if (TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyMaxValue, out int max) && parsedIntegerValue > max)
+                if (max.HasValue && parsedIntegerValue > max.Value)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "outOfRangeMaximum", [parsedIntegerValue.ToString(), max.ToString()]),
+                        LocalizedTextService.Localize("validation", "outOfRangeMaximum", [parsedIntegerValue.ToString(), ((int)max.Value).ToString()]),
                         ["value"]);
                 }
             }
@@ -196,12 +227,14 @@ public class IntegerPropertyEditor : DataEditor, IValueSchemaProvider
                     yield break;
                 }
 
-                if (TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyMinValue, out int min) &&
+                TryGetConfiguredRange(dataTypeConfiguration, ConfigurationKeyValidationRange, out decimal? min, out _);
+
+                if (min.HasValue &&
                     TryGetConfiguredValue(dataTypeConfiguration, ConfigurationKeyStepValue, out int step) &&
-                    ValidationHelper.IsValueValidForStep(parsedIntegerValue, min, step) is false)
+                    ValidationHelper.IsValueValidForStep(parsedIntegerValue, (int)min.Value, step) is false)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "invalidStep", [parsedIntegerValue.ToString(), step.ToString(), min.ToString()]),
+                        LocalizedTextService.Localize("validation", "invalidStep", [parsedIntegerValue.ToString(), step.ToString(), ((int)min.Value).ToString()]),
                         ["value"]);
                 }
             }

--- a/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
+++ b/src/Umbraco.Core/PropertyEditors/MediaPicker3Configuration.cs
@@ -20,8 +20,8 @@ public class MediaPicker3Configuration : IIgnoreUserStartNodesConfig
     /// <summary>
     /// Gets or sets the validation limits for the number of selected items.
     /// </summary>
-    [ConfigurationField("validationLimit")]
-    public NumberRange ValidationLimit { get; set; } = new();
+    [ConfigurationField("validationLimit", Type = typeof(RangeConfigurationField))]
+    public PropertyEditors.NumberRange ValidationLimit { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the start node ID for the media picker.
@@ -48,17 +48,9 @@ public class MediaPicker3Configuration : IIgnoreUserStartNodesConfig
     /// <summary>
     /// Represents a numeric range with optional minimum and maximum values.
     /// </summary>
-    public class NumberRange
+    [Obsolete("No longer used by Umbraco; use Umbraco.Cms.Core.PropertyEditors.NumberRange instead. Scheduled for removal in Umbraco 21.")]
+    public class NumberRange : PropertyEditors.NumberRange
     {
-        /// <summary>
-        /// Gets or sets the minimum value of the range.
-        /// </summary>
-        public int? Min { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum value of the range.
-        /// </summary>
-        public int? Max { get; set; }
     }
 
     /// <summary>

--- a/src/Umbraco.Core/PropertyEditors/MultiNodePickerConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/MultiNodePickerConfiguration.cs
@@ -15,16 +15,32 @@ public class MultiNodePickerConfiguration : IIgnoreUserStartNodesConfig
     public MultiNodePickerConfigurationTreeSource? TreeSource { get; set; }
 
     /// <summary>
+    /// Gets or sets the validation limits for the number of items that can be selected.
+    /// </summary>
+    [ConfigurationField("validationLimit", Type = typeof(RangeConfigurationField))]
+    public NumberRange ValidationLimit { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the minimum number of items that must be selected.
     /// </summary>
-    [ConfigurationField("minNumber")]
-    public int MinNumber { get; set; }
+    [Obsolete("Use ValidationLimit instead. Scheduled for removal in Umbraco 21.")]
+    [JsonIgnore]
+    public int MinNumber
+    {
+        get => ValidationLimit.Min ?? 0;
+        set => ValidationLimit.Min = value == 0 ? null : value;
+    }
 
     /// <summary>
     /// Gets or sets the maximum number of items that can be selected.
     /// </summary>
-    [ConfigurationField("maxNumber")]
-    public int MaxNumber { get; set; }
+    [Obsolete("Use ValidationLimit instead. Scheduled for removal in Umbraco 21.")]
+    [JsonIgnore]
+    public int MaxNumber
+    {
+        get => ValidationLimit.Max ?? 0;
+        set => ValidationLimit.Max = value == 0 ? null : value;
+    }
 
     /// <summary>
     /// Gets or sets the content type filter for allowed selections.

--- a/src/Umbraco.Core/PropertyEditors/MultiUrlPickerConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/MultiUrlPickerConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
@@ -6,16 +8,32 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class MultiUrlPickerConfiguration : IIgnoreUserStartNodesConfig
 {
     /// <summary>
+    /// Gets or sets the validation limits for the number of URLs that can be selected.
+    /// </summary>
+    [ConfigurationField("validationLimit", Type = typeof(RangeConfigurationField))]
+    public NumberRange ValidationLimit { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the minimum number of URLs that must be selected.
     /// </summary>
-    [ConfigurationField("minNumber")]
-    public int MinNumber { get; set; }
+    [Obsolete("Use ValidationLimit instead. Scheduled for removal in Umbraco 21.")]
+    [JsonIgnore]
+    public int MinNumber
+    {
+        get => ValidationLimit.Min ?? 0;
+        set => ValidationLimit.Min = value == 0 ? null : value;
+    }
 
     /// <summary>
     /// Gets or sets the maximum number of URLs that can be selected.
     /// </summary>
-    [ConfigurationField("maxNumber")]
-    public int MaxNumber { get; set; }
+    [Obsolete("Use ValidationLimit instead. Scheduled for removal in Umbraco 21.")]
+    [JsonIgnore]
+    public int MaxNumber
+    {
+        get => ValidationLimit.Max ?? 0;
+        set => ValidationLimit.Max = value == 0 ? null : value;
+    }
 
     /// <inheritdoc />
     [ConfigurationField(Constants.DataTypes.ReservedPreValueKeys.IgnoreUserStartNodes)]

--- a/src/Umbraco.Core/PropertyEditors/MultipleTextStringConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/MultipleTextStringConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
@@ -6,12 +8,30 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class MultipleTextStringConfiguration
 {
     /// <summary>
+    /// Gets or sets the validation limits for the number of text strings allowed.
+    /// </summary>
+    [ConfigurationField("validationLimit", Type = typeof(RangeConfigurationField))]
+    public NumberRange ValidationLimit { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the minimum number of text strings required.
     /// </summary>
-    public int Min { get; set; }
+    [Obsolete("Use ValidationLimit instead. Scheduled for removal in Umbraco 21.")]
+    [JsonIgnore]
+    public int Min
+    {
+        get => ValidationLimit.Min ?? 0;
+        set => ValidationLimit.Min = value == 0 ? null : value;
+    }
 
     /// <summary>
     /// Gets or sets the maximum number of text strings allowed.
     /// </summary>
-    public int Max { get; set; }
+    [Obsolete("Use ValidationLimit instead. Scheduled for removal in Umbraco 21.")]
+    [JsonIgnore]
+    public int Max
+    {
+        get => ValidationLimit.Max ?? 0;
+        set => ValidationLimit.Max = value == 0 ? null : value;
+    }
 }

--- a/src/Umbraco.Core/PropertyEditors/NumberRange.cs
+++ b/src/Umbraco.Core/PropertyEditors/NumberRange.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+/// Represents a numeric range with an optional minimum and maximum value, where <c>null</c> means "no bound".
+/// </summary>
+public class NumberRange
+{
+    /// <summary>
+    /// Gets or sets the minimum value of the range, or <c>null</c> for no minimum.
+    /// </summary>
+    public int? Min { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum value of the range, or <c>null</c> for no maximum.
+    /// </summary>
+    public int? Max { get; set; }
+}

--- a/src/Umbraco.Core/PropertyEditors/RangeConfigurationField.cs
+++ b/src/Umbraco.Core/PropertyEditors/RangeConfigurationField.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.PropertyEditors.Validators;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     A <see cref="ConfigurationField" /> for a range value (a <see cref="NumberRange" /> or <see cref="DecimalRange" />)
+///     that validates the maximum is not lower than the minimum.
+/// </summary>
+public sealed class RangeConfigurationField : ConfigurationField
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="RangeConfigurationField" /> class.
+    /// </summary>
+    public RangeConfigurationField() => Validators.Add(new RangeConfigurationValidator());
+}

--- a/src/Umbraco.Core/PropertyEditors/RangeConfigurationHelper.cs
+++ b/src/Umbraco.Core/PropertyEditors/RangeConfigurationHelper.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
@@ -39,8 +40,8 @@ public static class RangeConfigurationHelper
                 max = decimalRange.Max;
                 return true;
             case JsonObject jsonObject:
-                min = ToDecimal(jsonObject["min"]);
-                max = ToDecimal(jsonObject["max"]);
+                min = jsonObject["min"].ToDecimal();
+                max = jsonObject["max"].ToDecimal();
                 return true;
             case JsonElement jsonElement when jsonElement.ValueKind == JsonValueKind.Object:
                 min = GetDecimal(jsonElement, "min");
@@ -60,23 +61,6 @@ public static class RangeConfigurationHelper
             ? value
             : null;
 
-    private static decimal? ToDecimal(JsonNode? node)
-    {
-        if (node is null)
-        {
-            return null;
-        }
-
-        try
-        {
-            return node.GetValue<decimal>();
-        }
-        catch
-        {
-            return decimal.TryParse(node.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
-        }
-    }
-
     private static decimal? ToDecimal(object? value)
         => value switch
         {
@@ -86,7 +70,7 @@ public static class RangeConfigurationHelper
             long l => l,
             double db => (decimal)db,
             float f => (decimal)f,
-            JsonNode node => ToDecimal(node),
+            JsonNode node => node.ToDecimal(),
             string s when decimal.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) => parsed,
             _ => null,
         };

--- a/src/Umbraco.Core/PropertyEditors/RangeConfigurationHelper.cs
+++ b/src/Umbraco.Core/PropertyEditors/RangeConfigurationHelper.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+///     Helper for reading the minimum and maximum bounds out of a range configuration value, regardless of the shape
+///     it arrives in (a typed <see cref="NumberRange" />/<see cref="DecimalRange" />, a <see cref="JsonObject" />, a
+///     <see cref="JsonElement" /> or a dictionary).
+/// </summary>
+public static class RangeConfigurationHelper
+{
+    /// <summary>
+    ///     Attempts to read the minimum and maximum bounds from a range configuration value.
+    /// </summary>
+    /// <param name="value">The range configuration value.</param>
+    /// <param name="min">The minimum bound, or <c>null</c> when unbounded or not present.</param>
+    /// <param name="max">The maximum bound, or <c>null</c> when unbounded or not present.</param>
+    /// <returns><c>true</c> when the value could be interpreted as a range; otherwise <c>false</c>.</returns>
+    public static bool TryGetBounds(object? value, out decimal? min, out decimal? max)
+    {
+        min = null;
+        max = null;
+
+        switch (value)
+        {
+            case null:
+                return false;
+            case NumberRange numberRange:
+                min = numberRange.Min;
+                max = numberRange.Max;
+                return true;
+            case DecimalRange decimalRange:
+                min = decimalRange.Min;
+                max = decimalRange.Max;
+                return true;
+            case JsonObject jsonObject:
+                min = ToDecimal(jsonObject["min"]);
+                max = ToDecimal(jsonObject["max"]);
+                return true;
+            case JsonElement jsonElement when jsonElement.ValueKind == JsonValueKind.Object:
+                min = GetDecimal(jsonElement, "min");
+                max = GetDecimal(jsonElement, "max");
+                return true;
+            case IDictionary<string, object> dictionary:
+                min = dictionary.TryGetValue("min", out var minObject) ? ToDecimal(minObject) : null;
+                max = dictionary.TryGetValue("max", out var maxObject) ? ToDecimal(maxObject) : null;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static decimal? GetDecimal(JsonElement jsonElement, string key)
+        => jsonElement.TryGetProperty(key, out JsonElement property) && property.ValueKind == JsonValueKind.Number && property.TryGetDecimal(out var value)
+            ? value
+            : null;
+
+    private static decimal? ToDecimal(JsonNode? node)
+    {
+        if (node is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return node.GetValue<decimal>();
+        }
+        catch
+        {
+            return decimal.TryParse(node.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+        }
+    }
+
+    private static decimal? ToDecimal(object? value)
+        => value switch
+        {
+            null => null,
+            decimal d => d,
+            int i => i,
+            long l => l,
+            double db => (decimal)db,
+            float f => (decimal)f,
+            JsonNode node => ToDecimal(node),
+            string s when decimal.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null,
+        };
+}

--- a/src/Umbraco.Core/PropertyEditors/SliderConfiguration.cs
+++ b/src/Umbraco.Core/PropertyEditors/SliderConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
@@ -12,16 +14,32 @@ public class SliderConfiguration
     public bool EnableRange { get; set; }
 
     /// <summary>
+    /// Gets or sets the allowed range (minimum and maximum values) of the slider.
+    /// </summary>
+    [ConfigurationField("validationRange", Type = typeof(RangeConfigurationField))]
+    public DecimalRange ValidationRange { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the minimum value of the slider.
     /// </summary>
-    [ConfigurationField("minVal")]
-    public decimal MinimumValue { get; set; }
+    [Obsolete("Use ValidationRange instead. Scheduled for removal in Umbraco 21.")]
+    [JsonIgnore]
+    public decimal MinimumValue
+    {
+        get => ValidationRange.Min ?? 0;
+        set => ValidationRange.Min = value;
+    }
 
     /// <summary>
     /// Gets or sets the maximum value of the slider.
     /// </summary>
-    [ConfigurationField("maxVal")]
-    public decimal MaximumValue { get; set; }
+    [Obsolete("Use ValidationRange instead. Scheduled for removal in Umbraco 21.")]
+    [JsonIgnore]
+    public decimal MaximumValue
+    {
+        get => ValidationRange.Max ?? 0;
+        set => ValidationRange.Max = value == 0 ? null : value;
+    }
 
     /// <summary>
     /// Gets or sets the step increment value for the slider.

--- a/src/Umbraco.Core/PropertyEditors/Validators/DictionaryConfigurationValidatorBase.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validators/DictionaryConfigurationValidatorBase.cs
@@ -31,6 +31,24 @@ public abstract class DictionaryConfigurationValidatorBase
         return false;
     }
 
+    /// <summary>
+    /// Retrieves the minimum and maximum bounds of a range value from data type dictionary configuration.
+    /// </summary>
+    /// <param name="dataTypeConfiguration">The data type configuration.</param>
+    /// <param name="key">The configuration key holding the range value.</param>
+    /// <param name="min">The minimum bound, or <c>null</c> when unbounded or not present.</param>
+    /// <param name="max">The maximum bound, or <c>null</c> when unbounded or not present.</param>
+    /// <returns>True if the range configuration value was found.</returns>
+    protected static bool TryGetConfiguredRange(object? dataTypeConfiguration, string key, out decimal? min, out decimal? max)
+    {
+        min = null;
+        max = null;
+
+        return dataTypeConfiguration is IDictionary<string, object> configuration
+            && configuration.TryGetValue(key, out object? rangeValue)
+            && RangeConfigurationHelper.TryGetBounds(rangeValue, out min, out max);
+    }
+
     private static bool TryCastValue<TValue>(object? value, [NotNullWhen(true)] out TValue? castValue)
     {
         if (value is TValue valueAsType)

--- a/src/Umbraco.Core/PropertyEditors/Validators/RangeConfigurationValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validators/RangeConfigurationValidator.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Umbraco.Cms.Core.Models.Validation;
+
+namespace Umbraco.Cms.Core.PropertyEditors.Validators;
+
+/// <summary>
+///     Validates that a range configuration value does not have a maximum that is lower than its minimum.
+/// </summary>
+/// <remarks>
+///     Works against the raw configuration value for a range field (a <see cref="NumberRange" /> or
+///     <see cref="DecimalRange" />), whatever shape it arrives in.
+/// </remarks>
+public sealed class RangeConfigurationValidator : IValueValidator
+{
+    /// <inheritdoc />
+    public IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext)
+    {
+        if (RangeConfigurationHelper.TryGetBounds(value, out decimal? min, out decimal? max)
+            && min.HasValue
+            && max.HasValue
+            && max.Value < min.Value)
+        {
+            yield return new ValidationResult(
+                $"The maximum value ({max.Value.ToString(CultureInfo.InvariantCulture)}) cannot be less than the minimum value ({min.Value.ToString(CultureInfo.InvariantCulture)}).",
+                ["value"]);
+        }
+    }
+}

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -242,7 +242,7 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase, IDe
     }
 
     private static bool IsSingleNodePicker(IPublishedPropertyType propertyType) =>
-        propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.MaxNumber == 1;
+        propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.ValidationLimit.Max == 1;
 
     private static string GetEntityType(IPublishedPropertyType propertyType) =>
         propertyType.DataType.ConfigurationAs<MultiNodePickerConfiguration>()?.TreeSource?.ObjectType ?? Constants.UdiEntityType.Document;

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -109,6 +109,13 @@ public partial class UmbracoPlan : MigrationPlan
 
         // To 19.0.0
         To<V_19_0_0.AddExternalBlockElementRelationType>("{2D8F1B6E-4C3A-4E7D-9A1B-5F0C7E2D8A93}");
+        To<V_19_0_0.MigrateMultiUrlPickerMinMaxToRange>("{B1E4A7C2-3F5D-4A98-9C1E-0D2F6B7A81C4}");
+        To<V_19_0_0.MigrateMultiNodeTreePickerMinMaxToRange>("{C2F5B8D3-4A6E-4BA9-8D2F-1E3A7C8B92D5}");
+        To<V_19_0_0.MigrateMultipleTextStringMinMaxToRange>("{D3A6C9E4-5B7F-4CBA-9E30-2F4B8D9CA3E6}");
+        To<V_19_0_0.MigrateIntegerMinMaxToRange>("{E4B7DAF5-6C80-4DCB-8F41-3A5C9EADB4F7}");
+        To<V_19_0_0.MigrateDecimalMinMaxToRange>("{F5C8EB06-7D91-4EDC-9052-4B6DAFBEC508}");
+        To<V_19_0_0.MigrateSliderMinMaxToRange>("{06D9FC17-8EA2-4FED-A163-5C7EB0CFD619}");
+        To<V_19_0_0.MigrateBlockGridAreaMinMaxToRange>("{17EA0D28-9FB3-40FE-B274-6D8FC1D0E72A}");
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateBlockGridAreaMinMaxToRange.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateBlockGridAreaMinMaxToRange.cs
@@ -32,6 +32,8 @@ internal sealed class MigrateBlockGridAreaMinMaxToRange : MigrateMinMaxToRangeMi
     ///     Walks the <c>blocks[].areas[]</c> structure, converting each area's <c>minAllowed</c>/<c>maxAllowed</c>
     ///     into a single <c>validationLimit</c> range.
     /// </summary>
+    /// <param name="configuration">The Block Grid configuration to migrate in place.</param>
+    /// <returns><c>true</c> when at least one area was changed.</returns>
     internal static bool MigrateAreas(JsonObject configuration)
     {
         var blocksKey = FindKey(configuration, "blocks");
@@ -43,49 +45,58 @@ internal sealed class MigrateBlockGridAreaMinMaxToRange : MigrateMinMaxToRangeMi
         var changed = false;
         foreach (JsonNode? blockNode in blocks)
         {
-            if (blockNode is not JsonObject block)
+            if (blockNode is JsonObject block)
             {
-                continue;
-            }
-
-            var areasKey = FindKey(block, "areas");
-            if (areasKey is null || block[areasKey] is not JsonArray areas)
-            {
-                continue;
-            }
-
-            foreach (JsonNode? areaNode in areas)
-            {
-                if (areaNode is not JsonObject area)
-                {
-                    continue;
-                }
-
-                var minName = FindKey(area, "minAllowed");
-                var maxName = FindKey(area, "maxAllowed");
-                if (minName is null && maxName is null)
-                {
-                    continue;
-                }
-
-                decimal? min = minName is not null ? ToBound(area[minName], zeroIsUnbounded: false) : null;
-                decimal? max = maxName is not null ? ToBound(area[maxName], zeroIsUnbounded: false) : null;
-
-                if (minName is not null)
-                {
-                    area.Remove(minName);
-                }
-
-                if (maxName is not null)
-                {
-                    area.Remove(maxName);
-                }
-
-                SetRange(area, "validationLimit", min, max);
-                changed = true;
+                changed |= MigrateBlockAreas(block);
             }
         }
 
         return changed;
+    }
+
+    private static bool MigrateBlockAreas(JsonObject block)
+    {
+        var areasKey = FindKey(block, "areas");
+        if (areasKey is null || block[areasKey] is not JsonArray areas)
+        {
+            return false;
+        }
+
+        var changed = false;
+        foreach (JsonNode? areaNode in areas)
+        {
+            if (areaNode is JsonObject area)
+            {
+                changed |= MigrateArea(area);
+            }
+        }
+
+        return changed;
+    }
+
+    private static bool MigrateArea(JsonObject area)
+    {
+        var minName = FindKey(area, "minAllowed");
+        var maxName = FindKey(area, "maxAllowed");
+        if (minName is null && maxName is null)
+        {
+            return false;
+        }
+
+        decimal? min = minName is not null ? ToBound(area[minName], zeroIsUnbounded: false) : null;
+        decimal? max = maxName is not null ? ToBound(area[maxName], zeroIsUnbounded: false) : null;
+
+        if (minName is not null)
+        {
+            area.Remove(minName);
+        }
+
+        if (maxName is not null)
+        {
+            area.Remove(maxName);
+        }
+
+        SetRange(area, "validationLimit", min, max);
+        return true;
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateBlockGridAreaMinMaxToRange.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateBlockGridAreaMinMaxToRange.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+/// <summary>
+///     Converts the Block Grid's per-area <c>minAllowed</c>/<c>maxAllowed</c> configuration into a single
+///     <c>validationLimit</c> range. The bounds are preserved as-is (they are already optional, so no zero handling).
+/// </summary>
+internal sealed class MigrateBlockGridAreaMinMaxToRange : MigrateMinMaxToRangeMigrationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateBlockGridAreaMinMaxToRange"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public MigrateBlockGridAreaMinMaxToRange(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string EditorAlias => Constants.PropertyEditors.Aliases.BlockGrid;
+
+    /// <inheritdoc />
+    protected override bool TryMigrateConfiguration(JsonObject configuration)
+        => MigrateAreas(configuration);
+
+    /// <summary>
+    ///     Walks the <c>blocks[].areas[]</c> structure, converting each area's <c>minAllowed</c>/<c>maxAllowed</c>
+    ///     into a single <c>validationLimit</c> range.
+    /// </summary>
+    internal static bool MigrateAreas(JsonObject configuration)
+    {
+        var blocksKey = FindKey(configuration, "blocks");
+        if (blocksKey is null || configuration[blocksKey] is not JsonArray blocks)
+        {
+            return false;
+        }
+
+        var changed = false;
+        foreach (JsonNode? blockNode in blocks)
+        {
+            if (blockNode is not JsonObject block)
+            {
+                continue;
+            }
+
+            var areasKey = FindKey(block, "areas");
+            if (areasKey is null || block[areasKey] is not JsonArray areas)
+            {
+                continue;
+            }
+
+            foreach (JsonNode? areaNode in areas)
+            {
+                if (areaNode is not JsonObject area)
+                {
+                    continue;
+                }
+
+                var minName = FindKey(area, "minAllowed");
+                var maxName = FindKey(area, "maxAllowed");
+                if (minName is null && maxName is null)
+                {
+                    continue;
+                }
+
+                decimal? min = minName is not null ? ToBound(area[minName], zeroIsUnbounded: false) : null;
+                decimal? max = maxName is not null ? ToBound(area[maxName], zeroIsUnbounded: false) : null;
+
+                if (minName is not null)
+                {
+                    area.Remove(minName);
+                }
+
+                if (maxName is not null)
+                {
+                    area.Remove(maxName);
+                }
+
+                SetRange(area, "validationLimit", min, max);
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateDecimalMinMaxToRange.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateDecimalMinMaxToRange.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+/// <summary>
+///     Converts the Decimal editor's <c>min</c>/<c>max</c> configuration into a single <c>validationRange</c> range.
+/// </summary>
+internal sealed class MigrateDecimalMinMaxToRange : MigrateMinMaxToRangeMigrationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateDecimalMinMaxToRange"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public MigrateDecimalMinMaxToRange(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string EditorAlias => Constants.PropertyEditors.Aliases.Decimal;
+
+    /// <inheritdoc />
+    protected override bool TryMigrateConfiguration(JsonObject configuration)
+        => MigrateTopLevelRange(configuration, "min", "max", "validationRange", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateIntegerMinMaxToRange.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateIntegerMinMaxToRange.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+/// <summary>
+///     Converts the Numeric (integer) editor's <c>min</c>/<c>max</c> configuration into a single <c>validationRange</c> range.
+/// </summary>
+internal sealed class MigrateIntegerMinMaxToRange : MigrateMinMaxToRangeMigrationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateIntegerMinMaxToRange"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public MigrateIntegerMinMaxToRange(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string EditorAlias => Constants.PropertyEditors.Aliases.Integer;
+
+    /// <inheritdoc />
+    protected override bool TryMigrateConfiguration(JsonObject configuration)
+        => MigrateTopLevelRange(configuration, "min", "max", "validationRange", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeMigrationBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeMigrationBase.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+/// <summary>
+///     Base migration that converts a property editor's separate minimum/maximum configuration fields into a single
+///     range object. Rewrites the stored data type configuration JSON directly (bypassing the data type service,
+///     whose new range validation would otherwise reject legacy configurations where the minimum exceeds the maximum).
+/// </summary>
+internal abstract class MigrateMinMaxToRangeMigrationBase : AsyncMigrationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateMinMaxToRangeMigrationBase"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    protected MigrateMinMaxToRangeMigrationBase(IMigrationContext context)
+        : base(context)
+
+        // The rewrite bypasses the data type service, so make sure all caches are rebuilt afterwards.
+        => RebuildCache = true;
+
+    /// <summary>
+    ///     Gets the property editor alias of the data types to migrate.
+    /// </summary>
+    protected abstract string EditorAlias { get; }
+
+    /// <summary>
+    ///     Migrates a single data type's configuration in place.
+    /// </summary>
+    /// <returns><c>true</c> when the configuration was changed and should be persisted.</returns>
+    protected abstract bool TryMigrateConfiguration(JsonObject configuration);
+
+    /// <inheritdoc />
+    protected override Task MigrateAsync()
+    {
+        List<DataTypeDto> dataTypeDtos = Database.Fetch<DataTypeDto>(
+            Database.SqlContext.Sql()
+                .Select<DataTypeDto>()
+                .From<DataTypeDto>()
+                .Where<DataTypeDto>(x => x.EditorAlias == EditorAlias));
+
+        var migrated = 0;
+        var unchanged = 0;
+        var unparseable = 0;
+
+        foreach (DataTypeDto dataTypeDto in dataTypeDtos)
+        {
+            if (string.IsNullOrWhiteSpace(dataTypeDto.Configuration))
+            {
+                unchanged++;
+                continue;
+            }
+
+            JsonObject? configuration;
+            try
+            {
+                configuration = JsonNode.Parse(dataTypeDto.Configuration) as JsonObject;
+            }
+            catch (JsonException exception)
+            {
+                unparseable++;
+                Logger.LogWarning(
+                    exception,
+                    "Could not parse the configuration of data type {DataTypeId} for editor {EditorAlias}; skipping its range migration.",
+                    dataTypeDto.NodeId,
+                    EditorAlias);
+                continue;
+            }
+
+            if (configuration is null)
+            {
+                unparseable++;
+                Logger.LogWarning(
+                    "The configuration of data type {DataTypeId} for editor {EditorAlias} is not a JSON object; skipping its range migration.",
+                    dataTypeDto.NodeId,
+                    EditorAlias);
+                continue;
+            }
+
+            if (TryMigrateConfiguration(configuration) is false)
+            {
+                unchanged++;
+                Logger.LogDebug(
+                    "No range configuration to migrate for data type {DataTypeId} of editor {EditorAlias}.",
+                    dataTypeDto.NodeId,
+                    EditorAlias);
+                continue;
+            }
+
+            Database.Execute(
+                $"UPDATE {DataTypeDto.TableName} SET config = @0 WHERE {DataTypeDto.PrimaryKeyColumnName} = @1",
+                configuration.ToJsonString(),
+                dataTypeDto.NodeId);
+            migrated++;
+        }
+
+        Logger.LogInformation(
+            "Range configuration migration for editor {EditorAlias} complete: migrated {Migrated} of {Total} data type(s) ({Unchanged} unchanged, {Unparseable} could not be parsed).",
+            EditorAlias,
+            migrated,
+            dataTypeDtos.Count,
+            unchanged,
+            unparseable);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    ///     Converts two separate top-level min/max keys into a single range object under <paramref name="rangeKey" />.
+    /// </summary>
+    /// <param name="configuration">The configuration object to mutate.</param>
+    /// <param name="minKey">The existing minimum key.</param>
+    /// <param name="maxKey">The existing maximum key.</param>
+    /// <param name="rangeKey">The new range key.</param>
+    /// <param name="minZeroIsUnbounded">Whether a stored minimum of zero represents "no minimum".</param>
+    /// <param name="maxZeroIsUnbounded">Whether a stored maximum of zero represents "no maximum".</param>
+    /// <returns><c>true</c> when a change was made.</returns>
+    internal static bool MigrateTopLevelRange(
+        JsonObject configuration,
+        string minKey,
+        string maxKey,
+        string rangeKey,
+        bool minZeroIsUnbounded,
+        bool maxZeroIsUnbounded)
+    {
+        var minName = FindKey(configuration, minKey);
+        var maxName = FindKey(configuration, maxKey);
+
+        if (minName is null && maxName is null)
+        {
+            // Nothing to migrate (e.g. already migrated).
+            return false;
+        }
+
+        decimal? min = minName is not null ? ToBound(configuration[minName], minZeroIsUnbounded) : null;
+        decimal? max = maxName is not null ? ToBound(configuration[maxName], maxZeroIsUnbounded) : null;
+
+        if (minName is not null)
+        {
+            configuration.Remove(minName);
+        }
+
+        if (maxName is not null)
+        {
+            configuration.Remove(maxName);
+        }
+
+        SetRange(configuration, rangeKey, min, max);
+        return true;
+    }
+
+    /// <summary>
+    ///     Sets a range object with the supplied bounds, omitting it entirely when both bounds are absent.
+    /// </summary>
+    internal static void SetRange(JsonObject configuration, string rangeKey, decimal? min, decimal? max)
+    {
+        var existingKey = FindKey(configuration, rangeKey);
+        if (existingKey is not null)
+        {
+            configuration.Remove(existingKey);
+        }
+
+        if (min is null && max is null)
+        {
+            return;
+        }
+
+        var range = new JsonObject();
+        if (min is not null)
+        {
+            range["min"] = JsonValue.Create(min.Value);
+        }
+
+        if (max is not null)
+        {
+            range["max"] = JsonValue.Create(max.Value);
+        }
+
+        configuration[rangeKey] = range;
+    }
+
+    /// <summary>
+    ///     Parses a JSON node into a numeric bound, treating zero as unbounded when requested.
+    /// </summary>
+    internal static decimal? ToBound(JsonNode? node, bool zeroIsUnbounded)
+    {
+        decimal? value = ToDecimal(node);
+        if (value is null)
+        {
+            return null;
+        }
+
+        return zeroIsUnbounded && value.Value == 0m ? null : value;
+    }
+
+    private static decimal? ToDecimal(JsonNode? node)
+    {
+        if (node is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return node.GetValue<decimal>();
+        }
+        catch
+        {
+            return decimal.TryParse(node.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+        }
+    }
+
+    /// <summary>
+    ///     Finds the actual property name in the configuration that matches <paramref name="key" /> case-insensitively.
+    /// </summary>
+    /// <param name="configuration">The configuration object to search.</param>
+    /// <param name="key">The key to look for.</param>
+    /// <returns>The matching property name as stored, or <c>null</c> when not present.</returns>
+    internal static string? FindKey(JsonObject configuration, string key)
+        => configuration.Select(pair => pair.Key)
+            .FirstOrDefault(existing => existing.InvariantEquals(key));
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeMigrationBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeMigrationBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
@@ -35,6 +34,7 @@ internal abstract class MigrateMinMaxToRangeMigrationBase : AsyncMigrationBase
     /// <summary>
     ///     Migrates a single data type's configuration in place.
     /// </summary>
+    /// <param name="configuration">The data type configuration to migrate in place.</param>
     /// <returns><c>true</c> when the configuration was changed and should be persisted.</returns>
     protected abstract bool TryMigrateConfiguration(JsonObject configuration);
 
@@ -88,10 +88,14 @@ internal abstract class MigrateMinMaxToRangeMigrationBase : AsyncMigrationBase
             if (TryMigrateConfiguration(configuration) is false)
             {
                 unchanged++;
-                Logger.LogDebug(
-                    "No range configuration to migrate for data type {DataTypeId} of editor {EditorAlias}.",
-                    dataTypeDto.NodeId,
-                    EditorAlias);
+                if (Logger.IsEnabled(LogLevel.Debug))
+                {
+                    Logger.LogDebug(
+                        "No range configuration to migrate for data type {DataTypeId} of editor {EditorAlias}.",
+                        dataTypeDto.NodeId,
+                        EditorAlias);
+                }
+
                 continue;
             }
 
@@ -160,6 +164,10 @@ internal abstract class MigrateMinMaxToRangeMigrationBase : AsyncMigrationBase
     /// <summary>
     ///     Sets a range object with the supplied bounds, omitting it entirely when both bounds are absent.
     /// </summary>
+    /// <param name="configuration">The configuration object to mutate.</param>
+    /// <param name="rangeKey">The range key to set.</param>
+    /// <param name="min">The minimum bound, or <c>null</c> when unbounded.</param>
+    /// <param name="max">The maximum bound, or <c>null</c> when unbounded.</param>
     internal static void SetRange(JsonObject configuration, string rangeKey, decimal? min, decimal? max)
     {
         var existingKey = FindKey(configuration, rangeKey);
@@ -190,32 +198,18 @@ internal abstract class MigrateMinMaxToRangeMigrationBase : AsyncMigrationBase
     /// <summary>
     ///     Parses a JSON node into a numeric bound, treating zero as unbounded when requested.
     /// </summary>
+    /// <param name="node">The JSON node to read the bound from.</param>
+    /// <param name="zeroIsUnbounded">Whether a stored value of zero represents "no bound".</param>
+    /// <returns>The numeric bound, or <c>null</c> when absent or (optionally) zero.</returns>
     internal static decimal? ToBound(JsonNode? node, bool zeroIsUnbounded)
     {
-        decimal? value = ToDecimal(node);
+        decimal? value = node.ToDecimal();
         if (value is null)
         {
             return null;
         }
 
         return zeroIsUnbounded && value.Value == 0m ? null : value;
-    }
-
-    private static decimal? ToDecimal(JsonNode? node)
-    {
-        if (node is null)
-        {
-            return null;
-        }
-
-        try
-        {
-            return node.GetValue<decimal>();
-        }
-        catch
-        {
-            return decimal.TryParse(node.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
-        }
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultiNodeTreePickerMinMaxToRange.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultiNodeTreePickerMinMaxToRange.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+/// <summary>
+///     Converts the Multi Node Tree Picker's <c>minNumber</c>/<c>maxNumber</c> configuration into a single
+///     <c>validationLimit</c> range.
+/// </summary>
+internal sealed class MigrateMultiNodeTreePickerMinMaxToRange : MigrateMinMaxToRangeMigrationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateMultiNodeTreePickerMinMaxToRange"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public MigrateMultiNodeTreePickerMinMaxToRange(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string EditorAlias => Constants.PropertyEditors.Aliases.MultiNodeTreePicker;
+
+    /// <inheritdoc />
+    protected override bool TryMigrateConfiguration(JsonObject configuration)
+        => MigrateTopLevelRange(configuration, "minNumber", "maxNumber", "validationLimit", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultiUrlPickerMinMaxToRange.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultiUrlPickerMinMaxToRange.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+/// <summary>
+///     Converts the Multi URL Picker's <c>minNumber</c>/<c>maxNumber</c> configuration into a single
+///     <c>validationLimit</c> range.
+/// </summary>
+internal sealed class MigrateMultiUrlPickerMinMaxToRange : MigrateMinMaxToRangeMigrationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateMultiUrlPickerMinMaxToRange"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public MigrateMultiUrlPickerMinMaxToRange(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string EditorAlias => Constants.PropertyEditors.Aliases.MultiUrlPicker;
+
+    /// <inheritdoc />
+    protected override bool TryMigrateConfiguration(JsonObject configuration)
+        => MigrateTopLevelRange(configuration, "minNumber", "maxNumber", "validationLimit", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultipleTextStringMinMaxToRange.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultipleTextStringMinMaxToRange.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+/// <summary>
+///     Converts the Multiple Text String's <c>min</c>/<c>max</c> configuration into a single <c>validationLimit</c> range.
+/// </summary>
+internal sealed class MigrateMultipleTextStringMinMaxToRange : MigrateMinMaxToRangeMigrationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateMultipleTextStringMinMaxToRange"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public MigrateMultipleTextStringMinMaxToRange(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string EditorAlias => Constants.PropertyEditors.Aliases.MultipleTextstring;
+
+    /// <inheritdoc />
+    protected override bool TryMigrateConfiguration(JsonObject configuration)
+        => MigrateTopLevelRange(configuration, "min", "max", "validationLimit", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateSliderMinMaxToRange.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateSliderMinMaxToRange.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+/// <summary>
+///     Converts the Slider editor's <c>minVal</c>/<c>maxVal</c> configuration into a single <c>validationRange</c> range.
+///     The minimum is preserved as-is (a value of zero is a real lower bound); a maximum of zero means "no maximum".
+/// </summary>
+internal sealed class MigrateSliderMinMaxToRange : MigrateMinMaxToRangeMigrationBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateSliderMinMaxToRange"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public MigrateSliderMinMaxToRange(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string EditorAlias => Constants.PropertyEditors.Aliases.Slider;
+
+    /// <inheritdoc />
+    protected override bool TryMigrateConfiguration(JsonObject configuration)
+        => MigrateTopLevelRange(configuration, "minVal", "maxVal", "validationRange", minZeroIsUnbounded: false, maxZeroIsUnbounded: true);
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
@@ -226,7 +226,7 @@ public abstract class BlockGridPropertyEditorBase : DataEditor, IValueSchemaProv
                         continue;
                     }
 
-                    if ((areaConfig.MinAllowed.HasValue && area.Items.Length < areaConfig.MinAllowed) || (areaConfig.MaxAllowed.HasValue && area.Items.Length > areaConfig.MaxAllowed))
+                    if ((areaConfig.ValidationLimit?.Min is int minAllowed && area.Items.Length < minAllowed) || (areaConfig.ValidationLimit?.Max is int maxAllowed && area.Items.Length > maxAllowed))
                     {
                         validationResults.Add(new ValidationResult(TextService.Localize("validation", "entriesAreasMismatch")));
                     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
@@ -185,7 +185,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor, IValueSchemaProv
             {
                 var blockConfig = (BlockListConfiguration?)dataTypeConfiguration;
 
-                BlockListConfiguration.NumberRange? validationLimit = blockConfig?.ValidationLimit;
+                NumberRange? validationLimit = blockConfig?.ValidationLimit;
                 if (validationLimit == null)
                 {
                     return Array.Empty<ValidationResult>();

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -77,14 +77,14 @@ public class MultiNodeTreePickerPropertyEditor : DataEditor, IValueSchemaProvide
         // Add minItems/maxItems from configuration if available
         if (configuration is MultiNodePickerConfiguration pickerConfig)
         {
-            if (pickerConfig.MinNumber > 0)
+            if (pickerConfig.ValidationLimit.Min is int min && min > 0)
             {
-                schema["minItems"] = pickerConfig.MinNumber;
+                schema["minItems"] = min;
             }
 
-            if (pickerConfig.MaxNumber > 0)
+            if (pickerConfig.ValidationLimit.Max is int max && max > 0)
             {
-                schema["maxItems"] = pickerConfig.MaxNumber;
+                schema["maxItems"] = max;
             }
         }
 
@@ -240,13 +240,16 @@ public class MultiNodeTreePickerPropertyEditor : DataEditor, IValueSchemaProvide
                     return validationResults;
                 }
 
-                if (configuration.MinNumber > 0 && (entityReferences is null || entityReferences.Length < configuration.MinNumber))
+                var minNumber = configuration.ValidationLimit.Min ?? 0;
+                var maxNumber = configuration.ValidationLimit.Max ?? 0;
+
+                if (minNumber > 0 && (entityReferences is null || entityReferences.Length < minNumber))
                 {
                     validationResults.Add(new ValidationResult(
                         _localizedTextService.Localize(
                             "validation",
                             "entriesShort",
-                            [configuration.MinNumber.ToString(), (configuration.MinNumber - (entityReferences?.Length ?? 0)).ToString()
+                            [minNumber.ToString(), (minNumber - (entityReferences?.Length ?? 0)).ToString()
                             ]),
                         ["value"]));
                 }
@@ -256,13 +259,13 @@ public class MultiNodeTreePickerPropertyEditor : DataEditor, IValueSchemaProvide
                     return validationResults;
                 }
 
-                if (configuration.MaxNumber > 0 && entityReferences.Length > configuration.MaxNumber)
+                if (maxNumber > 0 && entityReferences.Length > maxNumber)
                 {
                     validationResults.Add(new ValidationResult(
                         _localizedTextService.Localize(
                             "validation",
                             "entriesExceed",
-                            [configuration.MaxNumber.ToString(), (entityReferences.Length - configuration.MaxNumber).ToString()
+                            [maxNumber.ToString(), (entityReferences.Length - maxNumber).ToString()
                             ]),
                         ["value"]));
                 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerPropertyEditor.cs
@@ -93,14 +93,14 @@ public class MultiUrlPickerPropertyEditor : DataEditor, IValueSchemaProvider
         // Add minItems/maxItems from configuration if available
         if (configuration is MultiUrlPickerConfiguration pickerConfig)
         {
-            if (pickerConfig.MinNumber > 0)
+            if (pickerConfig.ValidationLimit.Min is int min && min > 0)
             {
-                schema["minItems"] = pickerConfig.MinNumber;
+                schema["minItems"] = min;
             }
 
-            if (pickerConfig.MaxNumber > 0)
+            if (pickerConfig.ValidationLimit.Max is int max && max > 0)
             {
-                schema["maxItems"] = pickerConfig.MaxNumber;
+                schema["maxItems"] = max;
             }
         }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -424,22 +424,30 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference, I
             string? valueType,
             PropertyValidationContext validationContext)
         {
-           if (multiUrlPickerConfiguration is null || (linksDtos is null && multiUrlPickerConfiguration.MinNumber == 0))
+           if (multiUrlPickerConfiguration is null)
            {
                return [];
            }
 
-           if (linksDtos is null || linksDtos.Length < multiUrlPickerConfiguration.MinNumber)
+           var minNumber = multiUrlPickerConfiguration.ValidationLimit.Min ?? 0;
+           var maxNumber = multiUrlPickerConfiguration.ValidationLimit.Max ?? 0;
+
+           if (linksDtos is null && minNumber == 0)
+           {
+               return [];
+           }
+
+           if (linksDtos is null || linksDtos.Length < minNumber)
            {
                return [new ValidationResult(
                    _localizedTextService.Localize(
                        "validation",
                        "entriesShort",
-                       [multiUrlPickerConfiguration.MinNumber.ToString(), (multiUrlPickerConfiguration.MinNumber - (linksDtos?.Length ?? 0)).ToString()]),
+                       [minNumber.ToString(), (minNumber - (linksDtos?.Length ?? 0)).ToString()]),
                    ["value"])];
            }
 
-           if (linksDtos.Length > multiUrlPickerConfiguration.MaxNumber && multiUrlPickerConfiguration.MaxNumber > 0)
+           if (linksDtos.Length > maxNumber && maxNumber > 0)
            {
                return
                [
@@ -448,8 +456,8 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference, I
                            "validation",
                            "entriesExceed",
                            [
-                               multiUrlPickerConfiguration.MaxNumber.ToString(),
-                               (linksDtos.Length - multiUrlPickerConfiguration.MaxNumber).ToString()
+                               maxNumber.ToString(),
+                               (linksDtos.Length - maxNumber).ToString()
                            ]),
                        ["value"])
                ];

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringConfigurationEditor.cs
@@ -2,7 +2,6 @@
 // See LICENSE for more details.
 
 using Umbraco.Cms.Core.IO;
-using Umbraco.Cms.Core.PropertyEditors.Validators;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
@@ -18,16 +17,5 @@ internal sealed class MultipleTextStringConfigurationEditor : ConfigurationEdito
     public MultipleTextStringConfigurationEditor(IIOHelper ioHelper)
         : base(ioHelper)
     {
-        Fields.Add(new ConfigurationField(new IntegerValidator())
-        {
-            Key = "min",
-            PropertyName = nameof(MultipleTextStringConfiguration.Min),
-        });
-
-        Fields.Add(new ConfigurationField(new IntegerValidator())
-        {
-            Key = "max",
-            PropertyName = nameof(MultipleTextStringConfiguration.Max),
-        });
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -57,14 +57,14 @@ public class MultipleTextStringPropertyEditor : DataEditor, IValueSchemaProvider
         // Add min/max items from configuration if available
         if (configuration is MultipleTextStringConfiguration textStringConfig)
         {
-            if (textStringConfig.Min > 0)
+            if (textStringConfig.ValidationLimit.Min is int min && min > 0)
             {
-                schema["minItems"] = textStringConfig.Min;
+                schema["minItems"] = min;
             }
 
-            if (textStringConfig.Max > 0)
+            if (textStringConfig.ValidationLimit.Max is int max && max > 0)
             {
-                schema["maxItems"] = textStringConfig.Max;
+                schema["maxItems"] = max;
             }
         }
 
@@ -238,26 +238,29 @@ public class MultipleTextStringPropertyEditor : DataEditor, IValueSchemaProvider
                     ? strings.Count(s => string.IsNullOrWhiteSpace(s) is false)
                     : 0;
 
-            if (stringCount < multipleTextStringConfiguration.Min)
+            var minCount = multipleTextStringConfiguration.ValidationLimit.Min ?? 0;
+            var maxCount = multipleTextStringConfiguration.ValidationLimit.Max ?? 0;
+
+            if (stringCount < minCount)
             {
                 if (stringCount == 1)
                 {
                     yield return new ValidationResult(
-                        _localizedTextService.Localize("validation", "outOfRangeSingleItemMinimum", [multipleTextStringConfiguration.Min.ToString()]),
+                        _localizedTextService.Localize("validation", "outOfRangeSingleItemMinimum", [minCount.ToString()]),
                         ["value"]);
                 }
                 else
                 {
                     yield return new ValidationResult(
-                        _localizedTextService.Localize("validation", "outOfRangeMultipleItemsMinimum", [stringCount.ToString(), multipleTextStringConfiguration.Min.ToString()]),
+                        _localizedTextService.Localize("validation", "outOfRangeMultipleItemsMinimum", [stringCount.ToString(), minCount.ToString()]),
                         ["value"]);
                 }
             }
 
-            if (multipleTextStringConfiguration.Max > 0 && stringCount > multipleTextStringConfiguration.Max)
+            if (maxCount > 0 && stringCount > maxCount)
             {
                 yield return new ValidationResult(
-                    _localizedTextService.Localize("validation", "outOfRangeMultipleItemsMaximum", [stringCount.ToString(), multipleTextStringConfiguration.Max.ToString()]),
+                    _localizedTextService.Localize("validation", "outOfRangeMultipleItemsMaximum", [stringCount.ToString(), maxCount.ToString()]),
                     ["value"]);
             }
         }

--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -72,16 +72,16 @@ public class SliderPropertyEditor : DataEditor, IValueSchemaProvider
             var fromSchema = (JsonObject)schema["properties"]!["from"]!;
             var toSchema = (JsonObject)schema["properties"]!["to"]!;
 
-            if (sliderConfig.MinimumValue != 0)
+            if (sliderConfig.ValidationRange.Min is decimal minimum && minimum != 0)
             {
-                fromSchema["minimum"] = sliderConfig.MinimumValue;
-                toSchema["minimum"] = sliderConfig.MinimumValue;
+                fromSchema["minimum"] = minimum;
+                toSchema["minimum"] = minimum;
             }
 
-            if (sliderConfig.MaximumValue != 0)
+            if (sliderConfig.ValidationRange.Max is decimal maximum && maximum != 0)
             {
-                fromSchema["maximum"] = sliderConfig.MaximumValue;
-                toSchema["maximum"] = sliderConfig.MaximumValue;
+                fromSchema["maximum"] = maximum;
+                toSchema["maximum"] = maximum;
             }
         }
 
@@ -330,17 +330,18 @@ public class SliderPropertyEditor : DataEditor, IValueSchemaProvider
                     yield break;
                 }
 
-                if (sliderRange.From < sliderConfiguration.MinimumValue)
+                decimal minimum = sliderConfiguration.ValidationRange.Min ?? 0;
+                if (sliderRange.From < minimum)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "outOfRangeMinimum", [sliderRange.From.ToString(CultureInfo.InvariantCulture), sliderConfiguration.MinimumValue.ToString(CultureInfo.InvariantCulture)]),
+                        LocalizedTextService.Localize("validation", "outOfRangeMinimum", [sliderRange.From.ToString(CultureInfo.InvariantCulture), minimum.ToString(CultureInfo.InvariantCulture)]),
                         ["value"]);
                 }
 
-                if (sliderConfiguration.MaximumValue != 0 && sliderRange.To > sliderConfiguration.MaximumValue)
+                if (sliderConfiguration.ValidationRange.Max is decimal maximum && sliderRange.To > maximum)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "outOfRangeMaximum", [sliderRange.To.ToString(CultureInfo.InvariantCulture), sliderConfiguration.MaximumValue.ToString(CultureInfo.InvariantCulture)]),
+                        LocalizedTextService.Localize("validation", "outOfRangeMaximum", [sliderRange.To.ToString(CultureInfo.InvariantCulture), maximum.ToString(CultureInfo.InvariantCulture)]),
                         ["value"]);
                 }
             }
@@ -372,11 +373,12 @@ public class SliderPropertyEditor : DataEditor, IValueSchemaProvider
                     yield break;
                 }
 
-                if (ValidationHelper.IsValueValidForStep(sliderRange.From, sliderConfiguration.MinimumValue, sliderConfiguration.Step) is false ||
-                    ValidationHelper.IsValueValidForStep(sliderRange.To, sliderConfiguration.MinimumValue, sliderConfiguration.Step) is false)
+                decimal minimum = sliderConfiguration.ValidationRange.Min ?? 0;
+                if (ValidationHelper.IsValueValidForStep(sliderRange.From, minimum, sliderConfiguration.Step) is false ||
+                    ValidationHelper.IsValueValidForStep(sliderRange.To, minimum, sliderConfiguration.Step) is false)
                 {
                     yield return new ValidationResult(
-                        LocalizedTextService.Localize("validation", "invalidStep", [sliderRange.ToString(), sliderConfiguration.Step.ToString(CultureInfo.InvariantCulture), sliderConfiguration.MinimumValue.ToString(CultureInfo.InvariantCulture)]),
+                        LocalizedTextService.Localize("validation", "invalidStep", [sliderRange.ToString(), sliderConfiguration.Step.ToString(CultureInfo.InvariantCulture), minimum.ToString(CultureInfo.InvariantCulture)]),
                         ["value"]);
                 }
             }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -129,7 +129,7 @@ public class MultiUrlPickerValueConverter : PropertyValueConverterBase, IDeliver
         using (!_proflog.IsEnabled(Core.Logging.LogLevel.Debug) ? null : _proflog.DebugDuration<MultiUrlPickerValueConverter>(
                    $"ConvertPropertyToLinks ({propertyType.DataType.Id})"))
         {
-            var maxNumber = propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>()!.MaxNumber;
+            var maxNumber = propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>()!.ValidationLimit.Max ?? 0;
 
             if (string.IsNullOrWhiteSpace(inter?.ToString()))
             {
@@ -276,7 +276,7 @@ public class MultiUrlPickerValueConverter : PropertyValueConverterBase, IDeliver
     }
 
     private static bool IsSingleUrlPicker(IPublishedPropertyType propertyType)
-        => propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>()!.MaxNumber == 1;
+        => propertyType.DataType.ConfigurationAs<MultiUrlPickerConfiguration>()!.ValidationLimit.Max == 1;
 
     private IEnumerable<MultiUrlPickerValueEditor.LinkDto>? ParseLinkDtos(string inter)
         => inter.DetectIsJson() ? _jsonSerializer.Deserialize<IEnumerable<MultiUrlPickerValueEditor.LinkDto>>(inter) : null;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/block-grid-area-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/block-grid-area-type-workspace.context.ts
@@ -106,8 +106,7 @@ export class UmbBlockGridAreaTypeWorkspaceContext
 			alias: '',
 			columnSpan: 12,
 			rowSpan: 1,
-			minAllowed: 0,
-			maxAllowed: undefined,
+			validationLimit: { min: 0, max: undefined },
 			specifiedAllowance: [],
 		};
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/block-grid-area-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/block-grid-area-type-workspace.context.ts
@@ -106,7 +106,7 @@ export class UmbBlockGridAreaTypeWorkspaceContext
 			alias: '',
 			columnSpan: 12,
 			rowSpan: 1,
-			validationLimit: { min: 0, max: undefined },
+			validationLimit: undefined,
 			specifiedAllowance: [],
 		};
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/views/settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/views/settings.element.ts
@@ -5,6 +5,7 @@ import type { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/workspace'
 import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import type { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import type { UmbInputNumberRangeElement } from '@umbraco-cms/backoffice/components';
+import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
 
 @customElement('umb-block-grid-area-type-workspace-view')
 export class UmbBlockGridAreaTypeWorkspaceViewSettingsElement extends UmbLitElement implements UmbWorkspaceViewElement {
@@ -24,24 +25,18 @@ export class UmbBlockGridAreaTypeWorkspaceViewSettingsElement extends UmbLitElem
 		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, async (context) => {
 			this.#dataset = context;
 			this.observe(
-				await this.#dataset?.propertyValueByAlias<number>('minAllowed'),
-				(min) => {
-					this._minValue = min ?? 0;
+				await this.#dataset?.propertyValueByAlias<UmbNumberRangeValueType>('validationLimit'),
+				(range) => {
+					this._minValue = range?.min ?? 0;
+					this._maxValue = range?.max ?? Infinity;
 				},
-				'observeMinAllowed',
-			);
-			this.observe(
-				await this.#dataset?.propertyValueByAlias<number>('maxAllowed'),
-				(max) => {
-					this._maxValue = max ?? Infinity;
-				},
-				'observeMaxAllowed',
+				'observeValidationLimit',
 			);
 		});
 	}
 	#onAllowedRangeChange = (e: UmbChangeEvent) => {
-		this.#dataset?.setPropertyValue('minAllowed', (e!.target! as UmbInputNumberRangeElement).minValue);
-		this.#dataset?.setPropertyValue('maxAllowed', (e!.target! as UmbInputNumberRangeElement).maxValue);
+		const target = e!.target! as UmbInputNumberRangeElement;
+		this.#dataset?.setPropertyValue('validationLimit', { min: target.minValue, max: target.maxValue });
 	};
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.context.ts
@@ -134,14 +134,14 @@ export class UmbBlockGridEntriesContext
 
 	getMinAllowed() {
 		if (this.#areaKey) {
-			return this.#areaType.getValue()?.minAllowed ?? 0;
+			return this.#areaType.getValue()?.validationLimit?.min ?? 0;
 		}
 		return this._manager?.getMinAllowed() ?? 0;
 	}
 
 	getMaxAllowed() {
 		if (this.#areaKey) {
-			return this.#areaType.getValue()?.maxAllowed ?? Infinity;
+			return this.#areaType.getValue()?.validationLimit?.max ?? Infinity;
 		}
 		return this._manager?.getMaxAllowed() ?? Infinity;
 	}
@@ -431,8 +431,8 @@ export class UmbBlockGridEntriesContext
 			if (!areaType) return undefined;
 			// No need to observe as this method is called every time the area is changed.
 			this.#rangeLimits.setValue({
-				min: areaType.minAllowed ?? 0,
-				max: areaType.maxAllowed ?? Infinity,
+				min: areaType.validationLimit?.min ?? 0,
+				max: areaType.validationLimit?.max ?? Infinity,
 			});
 		} else if (this.#areaKey === null) {
 			if (!this._manager) return undefined;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/types.ts
@@ -1,5 +1,6 @@
 import type { UmbBlockLayoutBaseModel, UmbBlockValueType } from '@umbraco-cms/backoffice/block';
 import type { UmbBlockTypeWithGroupKey } from '@umbraco-cms/backoffice/block-type';
+import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
 
 export type * from './clipboard/types.js';
 
@@ -25,8 +26,7 @@ export interface UmbBlockGridTypeAreaType {
 	alias: string;
 	columnSpan?: number;
 	rowSpan?: number;
-	minAllowed?: number;
-	maxAllowed?: number;
+	validationLimit?: UmbNumberRangeValueType;
 	specifiedAllowance?: Array<UmbBlockGridTypeAreaTypePermission>;
 	createLabel?: string;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.element.ts
@@ -10,7 +10,8 @@ import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
  * @param value
  */
 function getNumberOrUndefined(value: string) {
-	const num = parseInt(value, 10);
+	if (value.trim() === '') return undefined;
+	const num = Number(value);
 	return isNaN(num) ? undefined : num;
 }
 
@@ -38,6 +39,13 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 	required = false;
 	@property({ type: String })
 	requiredMessage = UMB_VALIDATION_EMPTY_LOCALIZATION_KEY;
+
+	/**
+	 * The step size accepted by the inputs. Defaults to 1 (integers only); set a fractional value
+	 * (e.g. 0.000001) to allow decimals.
+	 */
+	@property({ type: Number })
+	step?: number;
 
 	@state()
 	private _maxValue?: number;
@@ -70,7 +78,9 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 
 	#updateValue() {
 		const newValue =
-			this._minValue || this._maxValue ? (this._minValue ?? '') + ',' + (this._maxValue ?? '') : undefined;
+			this._minValue != null || this._maxValue != null
+				? (this._minValue ?? '') + ',' + (this._maxValue ?? '')
+				: undefined;
 		if (super.value !== newValue) {
 			super.value = newValue;
 		}
@@ -89,7 +99,9 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 		}
 	}
 	public override get value(): string | undefined {
-		return this.minValue || this.maxValue ? (this.minValue || '') + ',' + (this.maxValue || '') : undefined;
+		return this.minValue != null || this.maxValue != null
+			? (this.minValue ?? '') + ',' + (this.maxValue ?? '')
+			: undefined;
 	}
 
 	constructor() {
@@ -139,6 +151,7 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 				label=${this.minLabel}
 				min=${ifDefined(this.validationRange?.min)}
 				max=${ifDefined(this.validationRange?.max)}
+				step=${ifDefined(this.step)}
 				placeholder=${this._minPlaceholder}
 				?required=${this.required}
 				.value=${this._minValue?.toString() ?? ''}
@@ -149,6 +162,7 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 				label=${this.maxLabel}
 				min=${ifDefined(this.validationRange?.min)}
 				max=${ifDefined(this.validationRange?.max)}
+				step=${ifDefined(this.step)}
 				placeholder=${this._maxPlaceholder}
 				?required=${this.required}
 				.value=${this._maxValue?.toString() ?? ''}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.test.ts
@@ -17,4 +17,28 @@ describe('UmbPropertyEditorUINumberRangeElement', () => {
 			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);
 		});
 	}
+
+	it('treats a zero bound as a set value', () => {
+		element.minValue = 0;
+		element.maxValue = 5;
+		expect(element.value).to.equal('0,5');
+	});
+
+	it('supports negative bounds', () => {
+		element.minValue = -5;
+		element.maxValue = 5;
+		expect(element.value).to.equal('-5,5');
+	});
+
+	it('parses decimal values from the string value', () => {
+		element.value = '1.5,3.5';
+		expect(element.minValue).to.equal(1.5);
+		expect(element.maxValue).to.equal(3.5);
+	});
+
+	it('is undefined when both bounds are unset', () => {
+		element.minValue = undefined;
+		element.maxValue = undefined;
+		expect(element.value).to.equal(undefined);
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.test.ts
@@ -39,6 +39,6 @@ describe('UmbPropertyEditorUINumberRangeElement', () => {
 	it('is undefined when both bounds are unset', () => {
 		element.minValue = undefined;
 		element.maxValue = undefined;
-		expect(element.value).to.equal(undefined);
+		expect(element.value).to.be.undefined;
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/property-editor/Umbraco.MultiUrlPicker.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/property-editor/Umbraco.MultiUrlPicker.ts
@@ -9,18 +9,11 @@ export const manifest: ManifestPropertyEditorSchema = {
 		settings: {
 			properties: [
 				{
-					alias: 'minNumber',
-					label: 'Minimum number of items',
-					description: '',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-					config: [{ alias: 'min', value: 0 }],
-				},
-				{
-					alias: 'maxNumber',
-					label: 'Maximum number of items',
-					description: '',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-					config: [{ alias: 'min', value: 0 }],
+					alias: 'validationLimit',
+					label: 'Amount',
+					description: 'Set the minimum and maximum number of items allowed.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.NumberRange',
+					config: [{ alias: 'validationRange', value: { min: 0, max: Infinity } }],
 				},
 				{
 					alias: 'ignoreUserStartNodes',
@@ -28,10 +21,6 @@ export const manifest: ManifestPropertyEditorSchema = {
 					description: 'Selecting this option allows a user to choose nodes that they normally dont have access to.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
 				},
-			],
-			defaultData: [
-				{ alias: 'minNumber', value: 0 },
-				{ alias: 'maxNumber', value: 0 },
 			],
 		},
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/Umbraco.MultiNodeTreePicker.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/Umbraco.MultiNodeTreePicker.ts
@@ -9,18 +9,11 @@ export const manifest: ManifestPropertyEditorSchema = {
 		settings: {
 			properties: [
 				{
-					alias: 'minNumber',
-					label: 'Minimum number of items',
-					description: '',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-					config: [{ alias: 'min', value: 0 }],
-				},
-				{
-					alias: 'maxNumber',
-					label: 'Maximum number of items',
-					description: '',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-					config: [{ alias: 'min', value: 0 }],
+					alias: 'validationLimit',
+					label: 'Amount',
+					description: 'Set the minimum and maximum number of items allowed.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.NumberRange',
+					config: [{ alias: 'validationRange', value: { min: 0, max: Infinity } }],
 				},
 				{
 					alias: 'ignoreUserStartNodes',
@@ -34,10 +27,6 @@ export const manifest: ManifestPropertyEditorSchema = {
 					description: '',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.ContentPicker.Source',
 				},
-			],
-			defaultData: [
-				{ alias: 'minNumber', value: 0 },
-				{ alias: 'maxNumber', value: 0 },
 			],
 		},
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/multiple-text-string/Umbraco.MultipleTextString.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/multiple-text-string/Umbraco.MultipleTextString.ts
@@ -8,23 +8,12 @@ export const manifests: Array<UmbExtensionManifest> = [
 			settings: {
 				properties: [
 					{
-						alias: 'min',
-						label: 'Minimum',
-						description: 'Enter the minimum amount of text boxes to be displayed',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-						config: [{ alias: 'min', value: 0 }],
+						alias: 'validationLimit',
+						label: 'Amount',
+						description: 'Set the minimum and maximum number of text boxes to be displayed.',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUi.NumberRange',
+						config: [{ alias: 'validationRange', value: { min: 0, max: Infinity } }],
 					},
-					{
-						alias: 'max',
-						label: 'Maximum',
-						description: 'Enter the maximum amount of text boxes to be displayed, enter 0 for unlimited',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-						config: [{ alias: 'min', value: 0 }],
-					},
-				],
-				defaultData: [
-					{ alias: 'min', value: 0 },
-					{ alias: 'max', value: 0 },
 				],
 			},
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number-range/property-editor-ui-number-range.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number-range/property-editor-ui-number-range.element.ts
@@ -26,6 +26,9 @@ export class UmbPropertyEditorUINumberRangeElement
 	@state()
 	private _validationRange?: UmbNumberRangeValueType;
 
+	@state()
+	private _step?: number;
+
 	@property({ type: Boolean })
 	mandatory = false;
 	@property({ type: String })
@@ -44,6 +47,7 @@ export class UmbPropertyEditorUINumberRangeElement
 	public set config(config: UmbPropertyEditorConfigCollection) {
 		if (!config) return;
 		this._validationRange = config.getValueByAlias<UmbNumberRangeValueType>('validationRange');
+		this._step = config.getValueByAlias<number>('step');
 	}
 
 	#onChange(event: CustomEvent & { target: UmbInputNumberRangeElement }) {
@@ -69,6 +73,7 @@ export class UmbPropertyEditorUINumberRangeElement
 				?required=${this.mandatory}
 				.requiredMessage=${this.mandatoryMessage}
 				.validationRange=${this._validationRange}
+				.step=${this._step}
 				@change=${this.#onChange}>
 			</umb-input-number-range>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
@@ -8,21 +8,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			settings: {
 				properties: [
 					{
-						alias: 'min',
-						label: 'Minimum',
-						description: 'Enter the minimum amount of number to be entered',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-						config: [{ alias: 'step', value: '0.000001' }],
-					},
-					{
-						alias: 'max',
-						label: 'Maximum',
-						description: 'Enter the maximum amount of number to be entered',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-						config: [
-							{ alias: 'placeholder', value: '∞' },
-							{ alias: 'step', value: '0.000001' },
-						],
+						alias: 'validationRange',
+						label: 'Value range',
+						description: 'Set the minimum and maximum value that can be entered',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUi.NumberRange',
+						config: [{ alias: 'step', value: 0.000001 }],
 					},
 					{
 						alias: 'step',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Integer.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Integer.ts
@@ -8,17 +8,10 @@ export const manifests: Array<UmbExtensionManifest> = [
 			settings: {
 				properties: [
 					{
-						alias: 'min',
-						label: 'Minimum',
-						description: 'Enter the minimum amount of number to be entered',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-					},
-					{
-						alias: 'max',
-						label: 'Maximum',
-						description: 'Enter the maximum amount of number to be entered',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-						config: [{ alias: 'placeholder', value: '∞' }],
+						alias: 'validationRange',
+						label: 'Value range',
+						description: 'Set the minimum and maximum value that can be entered',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUi.NumberRange',
 					},
 					{
 						alias: 'step',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/property-editor-ui-number.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/property-editor-ui-number.element.ts
@@ -7,6 +7,7 @@ import type {
 	UmbPropertyEditorConfigCollection,
 	UmbPropertyEditorUiElement,
 } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
 
 @customElement('umb-property-editor-ui-number')
 export class UmbPropertyEditorUINumberElement
@@ -54,8 +55,9 @@ export class UmbPropertyEditorUINumberElement
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
-		this._min = this.#parseNumber(config.getValueByAlias('min'));
-		this._max = this.#parseNumber(config.getValueByAlias('max'));
+		const range = config.getValueByAlias<UmbNumberRangeValueType>('validationRange');
+		this._min = range?.min;
+		this._max = range?.max;
 		this._step = this.#parseNumber(config.getValueByAlias('step'));
 		this._placeholder = this.localize.string(config.getValueByAlias<string>('placeholder') ?? '');
 	}
@@ -70,24 +72,24 @@ export class UmbPropertyEditorUINumberElement
 		this.addValidator(
 			'rangeUnderflow',
 			() => this.localize.term('validation_numberMinimum', this._min),
-			() => !!this._min && this.value! < this._min,
+			() => this._min != null && this.value! < this._min,
 		);
 
 		this.addValidator(
 			'rangeOverflow',
 			() => this.localize.term('validation_numberMaximum', this._max),
-			() => !!this._max && this.value! > this._max,
+			() => this._max != null && this.value! > this._max,
 		);
 
 		this.addValidator(
 			'customError',
 			() => this.localize.term('validation_numberMisconfigured', this._min, this._max),
-			() => !!this._min && !!this._max && this._min > this._max,
+			() => this._min != null && this._max != null && this._min > this._max,
 		);
 	}
 
 	protected override firstUpdated() {
-		if (this._min && this._max && this._min > this._max) {
+		if (this._min != null && this._max != null && this._min > this._max) {
 			console.warn(
 				`Property '${this._label}' (Numeric) has been misconfigured, 'min' is greater than 'max'. Please correct your data type configuration.`,
 				this,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/Umbraco.Slider.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/Umbraco.Slider.ts
@@ -9,18 +9,11 @@ export const manifest: ManifestPropertyEditorSchema = {
 		settings: {
 			properties: [
 				{
-					alias: 'minVal',
-					label: 'Minimum value',
-					description: '',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-					config: [{ alias: 'step', value: '0.00001' }],
-				},
-				{
-					alias: 'maxVal',
-					label: 'Maximum value',
-					description: '',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-					config: [{ alias: 'step', value: '0.00001' }],
+					alias: 'validationRange',
+					label: 'Value range',
+					description: 'Set the minimum and maximum value of the slider.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.NumberRange',
+					config: [{ alias: 'step', value: 0.00001 }],
 				},
 				{
 					alias: 'minimumRange',
@@ -32,8 +25,7 @@ export const manifest: ManifestPropertyEditorSchema = {
 				},
 			],
 			defaultData: [
-				{ alias: 'minVal', value: 0.0 },
-				{ alias: 'maxVal', value: 100.0 },
+				{ alias: 'validationRange', value: { min: 0.0, max: 100.0 } },
 				{ alias: 'minimumRange', value: 0.0 },
 			],
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/property-editor-ui-slider.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/property-editor-ui-slider.element.ts
@@ -8,6 +8,7 @@ import type {
 	UmbPropertyEditorConfigCollection,
 	UmbPropertyEditorUiElement,
 } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
 import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 /**
@@ -111,8 +112,9 @@ export class UmbPropertyEditorUISliderElement
 		const initVal2 = Number(config.getValueByAlias('initVal2'));
 		this._initVal2 = isNaN(initVal2) ? this._initVal1 + this._step : initVal2;
 
-		this._min = this.#parseNumber(config.getValueByAlias('minVal')) || 0;
-		this._max = this.#parseNumber(config.getValueByAlias('maxVal')) || 100;
+		const range = config.getValueByAlias<UmbNumberRangeValueType>('validationRange');
+		this._min = range?.min ?? 0;
+		this._max = range?.max || 100;
 		this._minimumRange = Math.max(this.#parseNumber(config.getValueByAlias('minimumRange')) || 0, 0);
 
 		if (this._min === this._max) {

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/builders/dataTypes/blockGridBuilder/blockGridAreaBuilder.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/builders/dataTypes/blockGridBuilder/blockGridAreaBuilder.ts
@@ -81,12 +81,12 @@ export class BlockGridAreaBuilder {
       values.rowSpan = this.rowSpan;
     }
 
-    if (this.minAllowed !== undefined) {
-      values.minAllowed = this.minAllowed;
-    }
-
-    if (this.maxAllowed !== undefined) {
-      values.maxAllowed = this.maxAllowed;
+    // The per-area minimum/maximum is stored as a single range object (Umbraco 19+).
+    if (this.minAllowed !== undefined || this.maxAllowed !== undefined) {
+      values.validationLimit = {
+        min: this.minAllowed,
+        max: this.maxAllowed,
+      };
     }
 
     if (this.createLabel !== undefined) {

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DataTypeApiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DataTypeApiHelper.ts
@@ -1029,12 +1029,12 @@ export class DataTypeApiHelper {
 
   async doesBlockEditorBlockContainAreaWithMinAllowed(blockGridName: string, elementTypeKey: string, areaAlias: string = 'area', minAllowed: number) {
     const block = await this.getBlockWithContentElementTypeId(blockGridName, elementTypeKey);
-    return block.areas.find(area => area.minAllowed === minAllowed && area.alias === areaAlias);
+    return block.areas.find(area => area.validationLimit?.min === minAllowed && area.alias === areaAlias);
   }
 
   async doesBlockEditorBlockContainAreaWithMaxAllowed(blockGridName: string, elementTypeKey: string, areaAlias: string = 'area', maxAllowed: number) {
     const block = await this.getBlockWithContentElementTypeId(blockGridName, elementTypeKey);
-    return block.areas.find(area => area.maxAllowed === maxAllowed && area.alias === areaAlias);
+    return block.areas.find(area => area.validationLimit?.max === maxAllowed && area.alias === areaAlias);
   }
 
   async doesBlockEditorBlockContainAreaWithSpecifiedAllowance(blockGridName: string, elementTypeKey: string, areaAlias: string = 'area') {
@@ -1889,6 +1889,19 @@ export class DataTypeApiHelper {
     const dataTypeData = await this.getByName(dataTypeName);
     const valueData = dataTypeData.values.find(item => item.alias === 'validationLimit');
     return valueData?.value.max === max && valueData?.value.min === min;
+  }
+
+  // Checks a single range configuration value (e.g. 'validationRange' or 'validationLimit') that stores its
+  // bounds as a {min, max} object. Only the bounds passed in are asserted, so a min-only or max-only check works.
+  async doesDataTypeHaveRangeValue(dataTypeName: string, alias: string, min?: number, max?: number, dataTypeData?) {
+    const dataType = dataTypeData || await this.getByName(dataTypeName);
+    const valueData = dataType.values.find(item => item.alias === alias);
+    if (!valueData) {
+      return false;
+    }
+    const minMatches = min === undefined || valueData.value?.min === min;
+    const maxMatches = max === undefined || valueData.value?.max === max;
+    return minMatches && maxMatches;
   }
 
   async doesDataTypeHaveCrops(dataTypeName: string, cropLabel: string, cropAlias: string, cropWidth: number, cropHeight: number) {

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DataTypeUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DataTypeUiHelper.ts
@@ -25,11 +25,9 @@ export class DataTypeUiHelper extends UiBaseLocators {
   private readonly aliasTxt: Locator;
   private readonly widthTxt: Locator;
   private readonly heightTxt: Locator;
-  private readonly minimumTxt: Locator;
-  private readonly maximumTxt: Locator;
+  private readonly rangeLowValueTxt: Locator;
+  private readonly rangeHighValueTxt: Locator;
   private readonly stepSizeTxt: Locator;
-  private readonly sliderMinimumTxt: Locator;
-  private readonly sliderMaximumTxt: Locator;
   private readonly optionTxt: Locator;
   private readonly addOptionBtn: Locator;
   private readonly maximumAllowedCharsTxt: Locator;
@@ -38,8 +36,6 @@ export class DataTypeUiHelper extends UiBaseLocators {
   private readonly maxHeightTxt: Locator;
   private readonly acceptedFileExtensionsTxt: Locator;
   private readonly addAcceptedFileExtensionsBtn: Locator;
-  private readonly minimumNumberOfItemsTxt: Locator;
-  private readonly maximumNumberOfItemsTxt: Locator;
   private readonly ignoreUserStartNodesToggle: Locator;
   private readonly overlaySizeDropDownBox: Locator;
   private readonly hideAnchorQueryStringInputToggle: Locator;
@@ -197,15 +193,14 @@ export class DataTypeUiHelper extends UiBaseLocators {
     this.createCropBtn = this.propertyCrops.getByRole('button', {name: 'Create'});
     this.editCropBtn = this.propertyCrops.getByRole('button', {name: 'Edit'});
 
+    // Range control - the single min/max control shared by Numeric, Decimal, Slider,
+    // Multiple Text String and Multi URL Picker. Defined once so the label lookup lives in one place.
+    this.rangeLowValueTxt = page.getByLabel('Low value');
+    this.rangeHighValueTxt = page.getByLabel('High value');
+
     // Numeric
-    this.minimumTxt = page.getByTestId('property:min').locator('#input');
-    this.maximumTxt = page.getByTestId('property:max').locator('#input');
     this.stepSizeTxt = page.getByTestId('property:step').locator('#input');
     this.allowDecimalsToggle = page.locator('umb-property[label="Allow decimals"] #toggle');
-
-    // Slider (uses minVal/maxVal aliases rather than the Numeric min/max)
-    this.sliderMinimumTxt = page.getByTestId('property:minVal').locator('#input');
-    this.sliderMaximumTxt = page.getByTestId('property:maxVal').locator('#input');
 
     // Radiobox
     this.optionTxt = page.getByTestId('property:items').locator('#input');
@@ -222,8 +217,6 @@ export class DataTypeUiHelper extends UiBaseLocators {
     this.addAcceptedFileExtensionsBtn = page.getByTestId('property:fileExtensions').getByLabel('Add', {exact: true});
 
     // Multi URL Picker
-    this.minimumNumberOfItemsTxt = page.getByTestId('property:minNumber').locator('#input');
-    this.maximumNumberOfItemsTxt = page.getByTestId('property:maxNumber').locator('#input');
     this.overlaySizeDropDownBox = page.getByTestId('property:overlaySize').locator('select');
     this.hideAnchorQueryStringInputToggle = page.getByTestId('property:hideAnchor').locator('#toggle');
 
@@ -596,11 +589,11 @@ export class DataTypeUiHelper extends UiBaseLocators {
 
   // Numeric
   async enterMinimumValue(value: string) {
-    await this.enterText(this.minimumTxt, value);
+    await this.enterText(this.rangeLowValueTxt, value);
   }
 
   async enterMaximumValue(value: string) {
-    await this.enterText(this.maximumTxt, value);
+    await this.enterText(this.rangeHighValueTxt, value);
   }
 
   async enterStepSizeValue(value: string) {
@@ -608,11 +601,11 @@ export class DataTypeUiHelper extends UiBaseLocators {
   }
 
   async enterSliderMinimumValue(value: string) {
-    await this.enterText(this.sliderMinimumTxt, value);
+    await this.enterText(this.rangeLowValueTxt, value);
   }
 
   async enterSliderMaximumValue(value: string) {
-    await this.enterText(this.sliderMaximumTxt, value);
+    await this.enterText(this.rangeHighValueTxt, value);
   }
 
   async clickAllowDecimalsToggle() {
@@ -666,11 +659,11 @@ export class DataTypeUiHelper extends UiBaseLocators {
 
   // Multi URL Picker
   async enterMinimumNumberOfItemsValue(value: string) {
-    await this.enterText(this.minimumNumberOfItemsTxt, value);
+    await this.enterText(this.rangeLowValueTxt, value);
   }
 
   async enterMaximumNumberOfItemsValue(value: string) {
-    await this.enterText(this.maximumNumberOfItemsTxt, value);
+    await this.enterText(this.rangeHighValueTxt, value);
   }
 
   async clickIgnoreUserStartNodesToggle() {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/BlockGrid/Block/BlockGridBlockAreas.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/BlockGrid/Block/BlockGridBlockAreas.spec.ts
@@ -172,7 +172,7 @@ test('can remove create button label for an area in a block', async ({umbracoApi
 test('can add min allowed for an area in a block', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const areaAlias = 'TestArea';
-  const minAllowed = 3;
+  const minAllowed = 1;
   await umbracoApi.dataType.createBlockGridWithAnAreaInABlock(blockGridEditorName, contentElementTypeId, areaAlias);
 
   // Act
@@ -251,8 +251,7 @@ test('can remove max allowed for an area in a block', async ({umbracoApi, umbrac
   expect(await umbracoApi.dataType.doesBlockEditorBlockContainAreaWithMaxAllowed(blockGridEditorName, contentElementTypeId, areaAlias, maxAllowed)).toBeFalsy();
 });
 
-// TODO: Remove skip when the front-end is ready. Currently there is no frontend validation for min and max values
-test.skip('min can not be more than max an area in a block', async ({umbracoApi, umbracoUi}) => {
+test('min can not be more than max an area in a block', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const areaAlias = 'TestArea';
   const minAllowed = 6;

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/Decimal.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/Decimal.spec.ts
@@ -45,7 +45,7 @@ test('can update minimum value', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'min', minimumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationRange', minimumValue)).toBeTruthy();
 });
 
 test('can update maximum value', async ({umbracoApi, umbracoUi}) => {
@@ -59,7 +59,7 @@ test('can update maximum value', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'max', maximumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationRange', undefined, maximumValue)).toBeTruthy();
 });
 
 test('can update step size value', async ({umbracoApi, umbracoUi}) => {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/MultiUrlPicker.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/MultiUrlPicker.spec.ts
@@ -27,7 +27,7 @@ test('can update minimum number of items value', async ({umbracoApi, umbracoUi})
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'minNumber', minimumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationLimit', minimumValue)).toBeTruthy();
 });
 
 test('can update maximum number of items value', async ({umbracoApi, umbracoUi}) => {
@@ -41,7 +41,7 @@ test('can update maximum number of items value', async ({umbracoApi, umbracoUi})
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'maxNumber', maximumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationLimit', undefined, maximumValue)).toBeTruthy();
 });
 
 test('can enable ignore user start nodes', async ({umbracoApi, umbracoUi}) => {
@@ -84,9 +84,7 @@ test('can update hide anchor/query string input', async ({umbracoApi, umbracoUi}
   expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'hideAnchor', true)).toBeTruthy();
 });
 
-// TODO: Remove skip when the front-end is ready. Currently you still can update the minimum greater than the maximum.
-// Issue link: https://github.com/umbraco/Umbraco-CMS/issues/17509
-test.skip('cannot update the minimum number of items greater than the maximum', async ({umbracoApi, umbracoUi}) => {
+test('cannot update the minimum number of items greater than the maximum', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const minimumValue = 5;
   const maximumValue = 2;

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/MultipleTextString.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/MultipleTextString.spec.ts
@@ -45,7 +45,7 @@ test('can update minimum value', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'min', minimumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationLimit', minimumValue)).toBeTruthy();
 });
 
 test('can update maximum value', async ({umbracoApi, umbracoUi}) => {
@@ -59,7 +59,7 @@ test('can update maximum value', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'max', maximumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationLimit', undefined, maximumValue)).toBeTruthy();
 });
 
 test('the default configuration is correct', async ({umbracoApi, umbracoUi}) => {
@@ -76,8 +76,5 @@ test('the default configuration is correct', async ({umbracoApi, umbracoUi}) => 
   const dataTypeData = await umbracoApi.dataType.getByName(customDataTypeName);
   expect(dataTypeData.editorAlias).toBe(editorAlias);
   expect(dataTypeData.editorUiAlias).toBe(editorUiAlias);
-  expect(dataTypeData.values).toEqual([
-    {alias: 'min', value: 0},
-    {alias: 'max', value: 0},
-  ]);
+  expect(dataTypeData.values).toEqual([]);
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/Numeric.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/Numeric.spec.ts
@@ -27,7 +27,7 @@ test('can update minimum value', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'min', minimumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationRange', minimumValue)).toBeTruthy();
 });
 
 test('can update Maximum value', async ({umbracoApi, umbracoUi}) => {
@@ -41,7 +41,7 @@ test('can update Maximum value', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'max', maximumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationRange', undefined, maximumValue)).toBeTruthy();
 });
 
 test('can update step size value', async ({umbracoApi, umbracoUi}) => {
@@ -72,9 +72,7 @@ test.skip('can allow decimals', async ({umbracoApi, umbracoUi}) => {
   expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'allowDecimals', true)).toBeTruthy();
 });
 
-// TODO: Remove skip when the front-end is ready. Currently you still can update the minimum greater than the maximum.
-// Issue link: https://github.com/umbraco/Umbraco-CMS/issues/17509
-test.skip('cannot update the minimum greater than the maximum', async ({umbracoApi, umbracoUi}) => {
+test('cannot update the minimum greater than the maximum', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const minimumValue = 5;
   const maximumValue = 2;

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/Slider.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/Slider.spec.ts
@@ -45,7 +45,7 @@ test('can update minimum value', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'minVal', minimumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationRange', minimumValue)).toBeTruthy();
 });
 
 test('can update maximum value', async ({umbracoApi, umbracoUi}) => {
@@ -59,7 +59,7 @@ test('can update maximum value', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.dataType.clickSaveButtonAndWaitForDataTypeToBeUpdated();
 
   // Assert
-  expect(await umbracoApi.dataType.doesDataTypeHaveValue(customDataTypeName, 'maxVal', maximumValue)).toBeTruthy();
+  expect(await umbracoApi.dataType.doesDataTypeHaveRangeValue(customDataTypeName, 'validationRange', undefined, maximumValue)).toBeTruthy();
 });
 
 test('can update step size value', async ({umbracoApi, umbracoUi}) => {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateBlockGridAreaMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateBlockGridAreaMinMaxToRangeTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V19_0_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MigrateBlockGridAreaMinMaxToRangeTests : MigrateMinMaxToRangeTestBase
+{
+    [Test]
+    public async Task Combines_Area_Min_Max_Into_ValidationLimit_Per_Area()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.BlockGrid,
+            """{ "blocks": [ { "areas": [ { "alias": "main", "minAllowed": 1, "maxAllowed": 3 } ] } ] }""");
+
+        await RunMigration<MigrateBlockGridAreaMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        var area = (JsonObject)((JsonArray)((JsonObject)((JsonArray)config["blocks"]!)[0]!)["areas"]!)[0]!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(area.ContainsKey("minAllowed"), Is.False);
+            Assert.That(area.ContainsKey("maxAllowed"), Is.False);
+            Assert.That(Min(area, "validationLimit"), Is.EqualTo(1));
+            Assert.That(Max(area, "validationLimit"), Is.EqualTo(3));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateDecimalMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateDecimalMinMaxToRangeTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V19_0_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MigrateDecimalMinMaxToRangeTests : MigrateMinMaxToRangeTestBase
+{
+    [Test]
+    public async Task Combines_Into_ValidationRange_And_Preserves_Step()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.Decimal,
+            """{ "min": 0.5, "max": 9.5, "step": 0.1 }""");
+
+        await RunMigration<MigrateDecimalMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(Min(config, "validationRange"), Is.EqualTo(0.5m));
+            Assert.That(Max(config, "validationRange"), Is.EqualTo(9.5m));
+            Assert.That(config["step"]?.GetValue<decimal>(), Is.EqualTo(0.1m));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateIntegerMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateIntegerMinMaxToRangeTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V19_0_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MigrateIntegerMinMaxToRangeTests : MigrateMinMaxToRangeTestBase
+{
+    [Test]
+    public async Task Combines_Into_ValidationRange_And_Preserves_Step()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.Integer,
+            """{ "min": 1, "max": 10, "step": 2 }""");
+
+        await RunMigration<MigrateIntegerMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.ContainsKey("min"), Is.False);
+            Assert.That(config.ContainsKey("max"), Is.False);
+            Assert.That(Min(config, "validationRange"), Is.EqualTo(1));
+            Assert.That(Max(config, "validationRange"), Is.EqualTo(10));
+            Assert.That(config["step"]?.GetValue<int>(), Is.EqualTo(2));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeTestBase.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V19_0_0;
+
+/// <summary>
+/// Shared harness for the min/max-to-range migration integration tests: seeds a data type with a specific
+/// pre-migration configuration JSON, runs a single migration end-to-end, and reads the resulting configuration back.
+/// </summary>
+internal abstract class MigrateMinMaxToRangeTestBase : UmbracoIntegrationTest
+{
+    protected IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
+
+    private PropertyEditorCollection PropertyEditors => GetRequiredService<PropertyEditorCollection>();
+
+    private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer
+        => GetRequiredService<IConfigurationEditorJsonSerializer>();
+
+    private IMigrationBuilder MigrationBuilder => GetRequiredService<IMigrationBuilder>();
+
+    private IUmbracoDatabaseFactory UmbracoDatabaseFactory => GetRequiredService<IUmbracoDatabaseFactory>();
+
+    private IServiceScopeFactory ServiceScopeFactory => GetRequiredService<IServiceScopeFactory>();
+
+    private DistributedCache DistributedCache => GetRequiredService<DistributedCache>();
+
+    private IDatabaseCacheRebuilder DatabaseCacheRebuilder => GetRequiredService<IDatabaseCacheRebuilder>();
+
+    private IPublishedContentTypeFactory PublishedContentTypeFactory => GetRequiredService<IPublishedContentTypeFactory>();
+
+    private IMigrationPlanExecutor MigrationPlanExecutor => new MigrationPlanExecutor(
+        ScopeProvider,
+        ScopeAccessor,
+        LoggerFactory,
+        MigrationBuilder,
+        UmbracoDatabaseFactory,
+        DatabaseCacheRebuilder,
+        DistributedCache,
+        Mock.Of<IKeyValueService>(),
+        ServiceScopeFactory,
+        AppCaches.NoCache,
+        PublishedContentTypeFactory);
+
+    protected static decimal? Min(JsonObject configuration, string rangeKey)
+        => (configuration[rangeKey] as JsonObject)?["min"]?.GetValue<decimal>();
+
+    protected static decimal? Max(JsonObject configuration, string rangeKey)
+        => (configuration[rangeKey] as JsonObject)?["max"]?.GetValue<decimal>();
+
+    protected async Task<int> CreateDataTypeWithRawConfig(string editorAlias, string configJson)
+    {
+        IDataEditor editor = PropertyEditors.First(e => e.Alias == editorAlias);
+        var dataType = new DataType(editor, ConfigurationEditorJsonSerializer)
+        {
+            Name = $"Test {editorAlias}",
+            DatabaseType = ValueStorageType.Nvarchar,
+        };
+
+        await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+
+        // Overwrite with the exact pre-migration configuration JSON, mirroring an upgraded database.
+        using IScope scope = ScopeProvider.CreateScope();
+        scope.Database.Execute(
+            "UPDATE umbracoDataType SET config = @0 WHERE nodeId = @1",
+            configJson,
+            dataType.Id);
+        scope.Complete();
+
+        return dataType.Id;
+    }
+
+    protected Task<JsonObject> GetRawConfig(int nodeId)
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+        var config = scope.Database.ExecuteScalar<string>(
+            "SELECT config FROM umbracoDataType WHERE nodeId = @0",
+            nodeId);
+        scope.Complete();
+
+        return Task.FromResult(JsonNode.Parse(config!)!.AsObject());
+    }
+
+    protected async Task RunMigration<TMigration>()
+        where TMigration : AsyncMigrationBase
+    {
+        var plan = new MigrationPlan(typeof(TMigration).Name)
+            .From(string.Empty)
+            .To<TMigration>("done");
+        var upgrader = new Upgrader(plan);
+        await upgrader.ExecuteAsync(MigrationPlanExecutor, ScopeProvider, Mock.Of<IKeyValueService>());
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultiNodeTreePickerMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultiNodeTreePickerMinMaxToRangeTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V19_0_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MigrateMultiNodeTreePickerMinMaxToRangeTests : MigrateMinMaxToRangeTestBase
+{
+    [Test]
+    public async Task Combines_And_Preserves_Other_Config()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.MultiNodeTreePicker,
+            """{ "minNumber": 1, "maxNumber": 4, "filter": "abc" }""");
+
+        await RunMigration<MigrateMultiNodeTreePickerMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.ContainsKey("minNumber"), Is.False);
+            Assert.That(config.ContainsKey("maxNumber"), Is.False);
+            Assert.That(Min(config, "validationLimit"), Is.EqualTo(1));
+            Assert.That(Max(config, "validationLimit"), Is.EqualTo(4));
+            Assert.That(config["filter"]?.GetValue<string>(), Is.EqualTo("abc"));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultiUrlPickerMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultiUrlPickerMinMaxToRangeTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V19_0_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MigrateMultiUrlPickerMinMaxToRangeTests : MigrateMinMaxToRangeTestBase
+{
+    [Test]
+    public async Task Combines_Min_And_Max_Into_ValidationLimit()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.MultiUrlPicker,
+            """{ "minNumber": 2, "maxNumber": 5 }""");
+
+        await RunMigration<MigrateMultiUrlPickerMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.ContainsKey("minNumber"), Is.False);
+            Assert.That(config.ContainsKey("maxNumber"), Is.False);
+            Assert.That(Min(config, "validationLimit"), Is.EqualTo(2));
+            Assert.That(Max(config, "validationLimit"), Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public async Task Zero_Values_Become_Unbounded()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.MultiUrlPicker,
+            """{ "minNumber": 0, "maxNumber": 0 }""");
+
+        await RunMigration<MigrateMultiUrlPickerMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.ContainsKey("minNumber"), Is.False);
+            Assert.That(config.ContainsKey("maxNumber"), Is.False);
+            Assert.That(config.ContainsKey("validationLimit"), Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Misconfigured_Range_Is_Migrated_Without_Rejection()
+    {
+        // The migration rewrites the config directly, bypassing the data type service - so a legacy
+        // configuration where the minimum exceeds the maximum is carried across faithfully rather than
+        // being rejected by the new range validation.
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.MultiUrlPicker,
+            """{ "minNumber": 5, "maxNumber": 2 }""");
+
+        await RunMigration<MigrateMultiUrlPickerMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(Min(config, "validationLimit"), Is.EqualTo(5));
+            Assert.That(Max(config, "validationLimit"), Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public async Task Is_Idempotent()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.MultiUrlPicker,
+            """{ "minNumber": 2, "maxNumber": 5 }""");
+
+        await RunMigration<MigrateMultiUrlPickerMinMaxToRange>();
+        await RunMigration<MigrateMultiUrlPickerMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(Min(config, "validationLimit"), Is.EqualTo(2));
+            Assert.That(Max(config, "validationLimit"), Is.EqualTo(5));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultipleTextStringMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMultipleTextStringMinMaxToRangeTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V19_0_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MigrateMultipleTextStringMinMaxToRangeTests : MigrateMinMaxToRangeTestBase
+{
+    [Test]
+    public async Task Combines_Min_And_Max_Into_ValidationLimit()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.MultipleTextstring,
+            """{ "min": 1, "max": 3 }""");
+
+        await RunMigration<MigrateMultipleTextStringMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.ContainsKey("min"), Is.False);
+            Assert.That(config.ContainsKey("max"), Is.False);
+            Assert.That(Min(config, "validationLimit"), Is.EqualTo(1));
+            Assert.That(Max(config, "validationLimit"), Is.EqualTo(3));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateSliderMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateSliderMinMaxToRangeTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V19_0_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MigrateSliderMinMaxToRangeTests : MigrateMinMaxToRangeTestBase
+{
+    [Test]
+    public async Task Combines_Into_ValidationRange_And_Preserves_Other_Config()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.Slider,
+            """{ "minVal": 0, "maxVal": 100, "step": 1, "enableRange": true, "minimumRange": 0 }""");
+
+        await RunMigration<MigrateSliderMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(config.ContainsKey("minVal"), Is.False);
+            Assert.That(config.ContainsKey("maxVal"), Is.False);
+
+            // Slider minimum of zero is a real lower bound and must be preserved.
+            Assert.That(Min(config, "validationRange"), Is.EqualTo(0));
+            Assert.That(Max(config, "validationRange"), Is.EqualTo(100));
+            Assert.That(config["enableRange"]?.GetValue<bool>(), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task Zero_Maximum_Becomes_Unbounded()
+    {
+        var id = await CreateDataTypeWithRawConfig(
+            Constants.PropertyEditors.Aliases.Slider,
+            """{ "minVal": 5, "maxVal": 0 }""");
+
+        await RunMigration<MigrateSliderMinMaxToRange>();
+
+        JsonObject config = await GetRawConfig(id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(Min(config, "validationRange"), Is.EqualTo(5));
+            Assert.That(Max(config, "validationRange"), Is.Null);
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DataTypeDefinitionRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DataTypeDefinitionRepositoryTest.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -347,7 +348,7 @@ internal sealed class DataTypeDefinitionRepositoryTest : UmbracoIntegrationTest
         using (ScopeProvider.CreateScope())
         {
             var dataTypeDefinition =
-                new DataType(new IntegerPropertyEditor(DataValueEditorFactory), ConfigurationEditorJsonSerializer)
+                new DataType(new IntegerPropertyEditor(DataValueEditorFactory, GetRequiredService<IIOHelper>()), ConfigurationEditorJsonSerializer)
                 {
                     DatabaseType = ValueStorageType.Integer,
                     Name = "AgeDataType",

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/PropertyEditorSchemaServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/PropertyEditorSchemaServiceTests.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
@@ -54,15 +55,14 @@ internal sealed class PropertyEditorSchemaServiceTests : UmbracoIntegrationTest
     {
         // Arrange
         var dataType = new DataType(
-            new IntegerPropertyEditor(DataValueEditorFactory),
+            new IntegerPropertyEditor(DataValueEditorFactory, GetRequiredService<IIOHelper>()),
             ConfigurationEditorJsonSerializer)
         {
             Name = "Test Integer GetSchemaAsync",
             DatabaseType = ValueStorageType.Integer,
             ConfigurationData = new Dictionary<string, object>
             {
-                { "min", 0 },
-                { "max", 100 },
+                { "validationRange", new Dictionary<string, object> { { "min", 0 }, { "max", 100 } } },
             },
         };
         var createResult = await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
@@ -35,7 +35,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
     private PublishedDataType MultiNodePickerPublishedDataType(bool multiSelect, string entityType) =>
         new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiNodePickerConfiguration
         {
-            MaxNumber = multiSelect ? 10 : 1,
+            ValidationLimit = new NumberRange { Max = multiSelect ? 10 : 1 },
             TreeSource = new MultiNodePickerConfigurationTreeSource
             {
                 ObjectType = entityType

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiUrlPickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiUrlPickerValueConverterTests.cs
@@ -20,7 +20,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [Test]
     public void MultiUrlPickerValueConverter_InSingleMode_ConvertsContentToLinksWithContentInfo()
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -52,7 +52,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [Test]
     public void MultiUrlPickerValueConverter_InSingleMode_ConvertsMediaToLinksWithoutContentInfo()
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -82,7 +82,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [Test]
     public void MultiUrlPickerValueConverter_InMultiMode_CanHandleMixedLinkTypes()
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 10 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 10 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -135,7 +135,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [Test]
     public void MultiUrlPickerValueConverter_ConvertsExternalUrlToLinks()
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -166,7 +166,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [Test]
     public void MultiUrlPickerValueConverter_AppliesExplicitConfigurationToMediaLink()
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -199,7 +199,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [Test]
     public void MultiUrlPickerValueConverter_AppliesExplicitConfigurationToContentLink()
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -231,7 +231,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [Test]
     public void MultiUrlPickerValueConverter_PrioritizesContentUrlOverConfiguredUrl()
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -263,7 +263,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [TestCase(null)]
     public void MultiUrlPickerValueConverter_InSingleMode_ConvertsInvalidValueToEmptyArray(object? inter)
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -279,7 +279,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
     [TestCase(null)]
     public void MultiUrlPickerValueConverter_InMultiMode_ConvertsInvalidValueToEmptyArray(object? inter)
     {
-        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 10 }));
+        var publishedDataType = new PublishedDataType(123, "test", "test", new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 10 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -316,7 +316,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
             123,
             "test",
             "test",
-            new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+            new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
 
@@ -373,7 +373,7 @@ public class MultiUrlPickerValueConverterTests : PropertyValueConverterTests
             123,
             "test",
             "test",
-            new Lazy<object>(() => new MultiUrlPickerConfiguration { MaxNumber = 1 }));
+            new Lazy<object>(() => new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Max = 1 } }));
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
         PublishedUrlProviderMock

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/JsonNodeExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/JsonNodeExtensionsTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
+
+[TestFixture]
+public class JsonNodeExtensionsTests
+{
+    [Test]
+    public void ToDecimal_Returns_Null_For_Null_Node()
+    {
+        JsonNode? node = null;
+
+        Assert.That(node.ToDecimal(), Is.Null);
+    }
+
+    [TestCase("5", 5d)]
+    [TestCase("0", 0d)]
+    [TestCase("-3", -3d)]
+    [TestCase("5.5", 5.5d)]
+    [TestCase("-2.25", -2.25d)]
+    [TestCase("1000000", 1000000d)]
+    public void ToDecimal_Parses_Numeric_Nodes(string json, double expected)
+    {
+        JsonNode? node = JsonNode.Parse(json);
+
+        Assert.That(node.ToDecimal(), Is.EqualTo((decimal)expected));
+    }
+
+    [TestCase("\"7\"", 7d)]
+    [TestCase("\"-2.5\"", -2.5d)]
+    public void ToDecimal_Parses_Numeric_String_Nodes(string json, double expected)
+    {
+        // Legacy configuration sometimes stored numbers as strings; these must still resolve.
+        JsonNode? node = JsonNode.Parse(json);
+
+        Assert.That(node.ToDecimal(), Is.EqualTo((decimal)expected));
+    }
+
+    [TestCase("\"abc\"")]
+    [TestCase("\"\"")]
+    [TestCase("true")]
+    public void ToDecimal_Returns_Null_For_Non_Numeric_Nodes(string json)
+    {
+        JsonNode? node = JsonNode.Parse(json);
+
+        Assert.That(node.ToDecimal(), Is.Null);
+    }
+
+    [Test]
+    public void ToDecimal_Parses_Value_Backed_Node()
+    {
+        // A node created directly from a CLR value (rather than parsed) exercises the string-parsing fallback.
+        JsonNode node = JsonValue.Create(42);
+
+        Assert.That(node.ToDecimal(), Is.EqualTo(42m));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListEditorPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListEditorPropertyValueEditorTests.cs
@@ -303,7 +303,7 @@ public class BlockListEditorPropertyValueEditorTests
         {
             ConfigurationObject = new BlockListConfiguration
             {
-                ValidationLimit = new BlockListConfiguration.NumberRange
+                ValidationLimit = new NumberRange
                 {
                     Min = 2,
                     Max = 4

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DecimalPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DecimalPropertyValueEditorTests.cs
@@ -270,28 +270,21 @@ public class DecimalPropertyValueEditorTests
         // When configuration is populated from the deserialized JSON, whole number values are deserialized as integers.
         // So we want to replicate that in our tests.
         var configuration = new Dictionary<string, object>();
+
+        var range = new Dictionary<string, object>();
         if (min.HasValue)
         {
-            if (min.Value % 1 == 0)
-            {
-                configuration.Add("min", (int)min.Value);
-            }
-            else
-            {
-                configuration.Add("min", min.Value);
-            }
+            range.Add("min", min.Value % 1 == 0 ? (object)(int)min.Value : min.Value);
         }
 
         if (max.HasValue)
         {
-            if (max.Value % 1 == 0)
-            {
-                configuration.Add("max", (int)max.Value);
-            }
-            else
-            {
-                configuration.Add("max", max.Value);
-            }
+            range.Add("max", max.Value % 1 == 0 ? (object)(int)max.Value : max.Value);
+        }
+
+        if (range.Count > 0)
+        {
+            configuration.Add("validationRange", range);
         }
 
         if (step.HasValue)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ElementPickerPropertyEditorMinMaxValidationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ElementPickerPropertyEditorMinMaxValidationTests.cs
@@ -39,7 +39,7 @@ public class ElementPickerPropertyEditorMinMaxValidationTests
     {
         var config = new ElementPickerConfiguration
         {
-            ValidationLimit = new ElementPickerConfiguration.NumberRange { Min = 1 },
+            ValidationLimit = new NumberRange { Min = 1 },
         };
 
         Assert.That(_validator.Validate((List<string>?)null, config, null, PropertyValidationContext.Empty()).Count(), Is.EqualTo(1));
@@ -58,7 +58,7 @@ public class ElementPickerPropertyEditorMinMaxValidationTests
         {
             ValidationLimit = min is null && max is null
                 ? null
-                : new ElementPickerConfiguration.NumberRange { Min = min, Max = max },
+                : new NumberRange { Min = min, Max = max },
         };
 
         List<string> value = Enumerable.Range(0, count).Select(_ => Guid.NewGuid().ToString()).ToList();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/EntityDataPickerPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/EntityDataPickerPropertyValueEditorTests.cs
@@ -84,7 +84,7 @@ public class EntityDataPickerPropertyValueEditorTests
             ConfigurationObject = new EntityDataPickerConfiguration
             {
                 DataSource = "testDataSource",
-                ValidationLimit = new EntityDataPickerConfiguration.NumberRange
+                ValidationLimit = new NumberRange
                 {
                     Min = 2,
                     Max = 4

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/IntegerPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/IntegerPropertyValueEditorTests.cs
@@ -183,8 +183,7 @@ public class IntegerPropertyValueEditorTests
         {
             ConfigurationObject = new Dictionary<string, object>
             {
-                { "min", 10 },
-                { "max", 20 },
+                { "validationRange", new Dictionary<string, object> { { "min", 10 }, { "max", 20 } } },
                 { "step", step }
             }
         };

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/IntegerPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/IntegerPropertyValueEditorTests.cs
@@ -152,6 +152,23 @@ public class IntegerPropertyValueEditorTests
         }
     }
 
+    [TestCase(17, false)] // With no configured minimum, step validation is anchored at zero, so 17 is not a valid step of 2.
+    [TestCase(18, true)]
+    public void Validates_Step_Anchored_At_Zero_When_Minimum_Unset(object value, bool expectedSuccess)
+    {
+        var editor = CreateValueEditor(step: 2, min: null);
+        var result = editor.Validate(value, false, null, PropertyValidationContext.Empty());
+        if (expectedSuccess)
+        {
+            Assert.IsEmpty(result);
+        }
+        else
+        {
+            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual("validation_invalidStep", result.First().ErrorMessage);
+        }
+    }
+
     private static object? FromEditor(object? value)
         => CreateValueEditor().FromEditor(new ContentPropertyData(value, null), null);
 
@@ -165,7 +182,7 @@ public class IntegerPropertyValueEditorTests
         return CreateValueEditor().ToEditor(property.Object);
     }
 
-    private static IntegerPropertyEditor.IntegerPropertyValueEditor CreateValueEditor(int step = 2)
+    private static IntegerPropertyEditor.IntegerPropertyValueEditor CreateValueEditor(int step = 2, int? min = 10)
     {
         var localizedTextServiceMock = new Mock<ILocalizedTextService>();
         localizedTextServiceMock.Setup(x => x.Localize(
@@ -183,9 +200,25 @@ public class IntegerPropertyValueEditorTests
         {
             ConfigurationObject = new Dictionary<string, object>
             {
-                { "validationRange", new Dictionary<string, object> { { "min", 10 }, { "max", 20 } } },
+                { "validationRange", CreateRange(min, 20) },
                 { "step", step }
             }
         };
+    }
+
+    private static Dictionary<string, object> CreateRange(int? min, int? max)
+    {
+        var range = new Dictionary<string, object>();
+        if (min.HasValue)
+        {
+            range["min"] = min.Value;
+        }
+
+        if (max.HasValue)
+        {
+            range["max"] = max.Value;
+        }
+
+        return range;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MediaPicker3ValueEditorValidationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MediaPicker3ValueEditorValidationTests.cs
@@ -227,7 +227,7 @@ internal class MediaPicker3ValueEditorValidationTests
     {
         var (valueEditor, mediaTypeServiceMock, _, mediaNavigationQueryServiceMock) = CreateValueEditor();
 
-        valueEditor.ConfigurationObject = new MediaPicker3Configuration() { Multiple = true, ValidationLimit = new MediaPicker3Configuration.NumberRange { Min = min } };
+        valueEditor.ConfigurationObject = new MediaPicker3Configuration() { Multiple = true, ValidationLimit = new NumberRange { Min = min } };
 
         var result = valueEditor.Validate(value, false, null, PropertyValidationContext.Empty());
 
@@ -245,7 +245,7 @@ internal class MediaPicker3ValueEditorValidationTests
     {
         var (valueEditor, mediaTypeServiceMock, _, mediaNavigationQueryServiceMock) = CreateValueEditor();
 
-        valueEditor.ConfigurationObject = new MediaPicker3Configuration() { Multiple = true, ValidationLimit = new MediaPicker3Configuration.NumberRange { Max = max } };
+        valueEditor.ConfigurationObject = new MediaPicker3Configuration() { Multiple = true, ValidationLimit = new NumberRange { Max = max } };
 
         var result = valueEditor.Validate(value, false, null, PropertyValidationContext.Empty());
         ValidateResult(succeed, result);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiNodeTreePickerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiNodeTreePickerTests.cs
@@ -232,7 +232,7 @@ public class MultiNodeTreePickerTests
 
     private static object? FromEditor(object? value, int max = 0, IJsonSerializer? jsonSerializer = null)
         => CreateValueEditor(jsonSerializer)
-            .FromEditor(new ContentPropertyData(value, new MultipleTextStringConfiguration { Max = max }), null);
+            .FromEditor(new ContentPropertyData(value, new MultipleTextStringConfiguration { ValidationLimit = new NumberRange { Max = max } }), null);
 
     private static object? ToEditor(object? value, IJsonSerializer? jsonSerializer = null)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiNodeTreePickerValidationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiNodeTreePickerValidationTests.cs
@@ -30,7 +30,7 @@ public class MultiNodeTreePickerValidationTests
     public void Validates_Minimum_Entries(int min, bool shouldSucceed, string? value)
     {
         var (valueEditor, _, _, _, _) = CreateValueEditor();
-        valueEditor.ConfigurationObject = new MultiNodePickerConfiguration { MinNumber = min};
+        valueEditor.ConfigurationObject = new MultiNodePickerConfiguration { ValidationLimit = new NumberRange { Min = min } };
 
         var result = valueEditor.Validate(value, false, null, PropertyValidationContext.Empty());
 
@@ -58,7 +58,7 @@ public class MultiNodeTreePickerValidationTests
     public void Validates_Maximum_Entries(int max, bool shouldSucceed, string value)
     {
         var (valueEditor, _, _, _, _) = CreateValueEditor();
-        valueEditor.ConfigurationObject = new MultiNodePickerConfiguration { MaxNumber = max };
+        valueEditor.ConfigurationObject = new MultiNodePickerConfiguration { ValidationLimit = new NumberRange { Max = max } };
 
         var result = valueEditor.Validate(value, false, null, PropertyValidationContext.Empty());
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultipleTextStringPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultipleTextStringPropertyValueEditorTests.cs
@@ -379,8 +379,7 @@ public class MultipleTextStringPropertyValueEditorTests
         {
             ConfigurationObject = new MultipleTextStringConfiguration
             {
-                Min = 2,
-                Max = 4,
+                ValidationLimit = new NumberRange { Min = 2, Max = 4 },
             },
         };
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultipleTextStringPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultipleTextStringPropertyValueEditorTests.cs
@@ -85,7 +85,7 @@ public class MultipleTextStringPropertyValueEditorTests
     public void Can_Parse_More_Items_Than_Allowed_From_Editor()
     {
         var valueEditor = CreateValueEditor();
-        var fromEditor = valueEditor.FromEditor(new ContentPropertyData(new[] { "One", "Two", "Three", "Four", "Five" }, new MultipleTextStringConfiguration { Max = 4 }), null) as string;
+        var fromEditor = valueEditor.FromEditor(new ContentPropertyData(new[] { "One", "Two", "Three", "Four", "Five" }, new MultipleTextStringConfiguration { ValidationLimit = new NumberRange { Max = 4 } }), null) as string;
         Assert.AreEqual("One\nTwo\nThree\nFour\nFive", fromEditor);
 
         var validationResults = valueEditor.Validate(fromEditor, false, null, PropertyValidationContext.Empty());
@@ -305,7 +305,7 @@ public class MultipleTextStringPropertyValueEditorTests
     public void MinMax_Validator_Does_Not_Count_Empty_Strings()
     {
         var editor = CreateValueEditor();
-        editor.ConfigurationObject = new MultipleTextStringConfiguration { Min = 2, Max = 4 };
+        editor.ConfigurationObject = new MultipleTextStringConfiguration { ValidationLimit = new NumberRange { Min = 2, Max = 4 } };
 
         // 2 non-empty + 2 empty = should count as 2, meeting min=2
         var value = new[] { "one", string.Empty, "two", string.Empty };
@@ -317,7 +317,7 @@ public class MultipleTextStringPropertyValueEditorTests
     public void MinMax_Validator_Does_Not_Count_Empty_Strings_Below_Min()
     {
         var editor = CreateValueEditor();
-        editor.ConfigurationObject = new MultipleTextStringConfiguration { Min = 2, Max = 4 };
+        editor.ConfigurationObject = new MultipleTextStringConfiguration { ValidationLimit = new NumberRange { Min = 2, Max = 4 } };
 
         // 1 non-empty + 2 empty = should count as 1, failing min=2
         var value = new[] { "one", string.Empty, string.Empty };
@@ -349,7 +349,7 @@ public class MultipleTextStringPropertyValueEditorTests
     }
 
     private static object? FromEditor(object? value, int max = 0)
-        => CreateValueEditor().FromEditor(new ContentPropertyData(value, new MultipleTextStringConfiguration { Max = max }), null);
+        => CreateValueEditor().FromEditor(new ContentPropertyData(value, new MultipleTextStringConfiguration { ValidationLimit = new NumberRange { Max = max } }), null);
 
     private static object? ToEditor(object? value)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RangeConfigurationEditorValidationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RangeConfigurationEditorValidationTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Nodes;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
+
+/// <summary>
+/// Verifies that the range configuration field is wired up on each converted configuration editor, so that
+/// saving a data type with a maximum lower than the minimum is rejected server-side.
+/// </summary>
+[TestFixture]
+public class RangeConfigurationEditorValidationTests
+{
+    private static IIOHelper IOHelper => Mock.Of<IIOHelper>();
+
+    private static object[] Editors =>
+    [
+        new object[] { new IntegerConfigurationEditor(IOHelper), "validationRange" },
+        new object[] { new DecimalConfigurationEditor(IOHelper), "validationRange" },
+        new object[] { new MediaPicker3ConfigurationEditor(IOHelper), "validationLimit" },
+        new object[] { new MultiUrlPickerConfigurationEditor(IOHelper), "validationLimit" },
+        new object[] { new MultiNodePickerConfigurationEditor(IOHelper), "validationLimit" },
+    ];
+
+    [TestCaseSource(nameof(Editors))]
+    public void Cannot_Validate_When_Max_Is_Less_Than_Min(IConfigurationEditor editor, string rangeKey)
+    {
+        var configuration = new Dictionary<string, object>
+        {
+            [rangeKey] = new JsonObject { ["min"] = 5, ["max"] = 2 },
+        };
+
+        Assert.That(editor.Validate(configuration), Is.Not.Empty);
+    }
+
+    [TestCaseSource(nameof(Editors))]
+    public void Can_Validate_When_Max_Is_Greater_Than_Min(IConfigurationEditor editor, string rangeKey)
+    {
+        var configuration = new Dictionary<string, object>
+        {
+            [rangeKey] = new JsonObject { ["min"] = 2, ["max"] = 5 },
+        };
+
+        Assert.That(editor.Validate(configuration), Is.Empty);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RangeConfigurationHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RangeConfigurationHelperTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
+
+[TestFixture]
+public class RangeConfigurationHelperTests
+{
+    [Test]
+    public void Returns_False_For_Null()
+    {
+        var result = RangeConfigurationHelper.TryGetBounds(null, out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(min, Is.Null);
+            Assert.That(max, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Returns_False_For_Non_Range_Value()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(RangeConfigurationHelper.TryGetBounds("not-a-range", out _, out _), Is.False);
+            Assert.That(RangeConfigurationHelper.TryGetBounds(42, out _, out _), Is.False);
+        });
+    }
+
+    [Test]
+    public void Reads_Typed_NumberRange()
+    {
+        var result = RangeConfigurationHelper.TryGetBounds(new NumberRange { Min = 2, Max = 5 }, out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(min, Is.EqualTo(2));
+            Assert.That(max, Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public void Reads_Typed_DecimalRange()
+    {
+        var result = RangeConfigurationHelper.TryGetBounds(new DecimalRange { Min = 1.5m, Max = 9.5m }, out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(min, Is.EqualTo(1.5m));
+            Assert.That(max, Is.EqualTo(9.5m));
+        });
+    }
+
+    [Test]
+    public void Reads_JsonObject_With_Integer_Bounds()
+    {
+        var value = new JsonObject { ["min"] = 2, ["max"] = 5 };
+
+        var result = RangeConfigurationHelper.TryGetBounds(value, out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(min, Is.EqualTo(2));
+            Assert.That(max, Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public void Reads_JsonObject_With_Decimal_Bounds()
+    {
+        var value = new JsonObject { ["min"] = 0.25m, ["max"] = 7.75m };
+
+        var result = RangeConfigurationHelper.TryGetBounds(value, out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(min, Is.EqualTo(0.25m));
+            Assert.That(max, Is.EqualTo(7.75m));
+        });
+    }
+
+    [Test]
+    public void Reads_JsonObject_With_Only_One_Bound()
+    {
+        var value = new JsonObject { ["min"] = 3 };
+
+        var result = RangeConfigurationHelper.TryGetBounds(value, out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(min, Is.EqualTo(3));
+            Assert.That(max, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Reads_Empty_JsonObject_As_Unbounded()
+    {
+        var result = RangeConfigurationHelper.TryGetBounds(new JsonObject(), out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(min, Is.Null);
+            Assert.That(max, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Reads_JsonElement_Object()
+    {
+        JsonElement value = JsonDocument.Parse("{\"min\":1,\"max\":10}").RootElement.Clone();
+
+        var result = RangeConfigurationHelper.TryGetBounds(value, out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(min, Is.EqualTo(1));
+            Assert.That(max, Is.EqualTo(10));
+        });
+    }
+
+    [Test]
+    public void Reads_Dictionary_With_Mixed_Numeric_Types()
+    {
+        var value = new Dictionary<string, object> { ["min"] = 4, ["max"] = 8.5d };
+
+        var result = RangeConfigurationHelper.TryGetBounds(value, out decimal? min, out decimal? max);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(min, Is.EqualTo(4));
+            Assert.That(max, Is.EqualTo(8.5m));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RangeConfigurationValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RangeConfigurationValidatorTests.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models.Validation;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.Validators;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
+
+[TestFixture]
+public class RangeConfigurationValidatorTests
+{
+    private readonly RangeConfigurationValidator _validator = new();
+
+    private ValidationResult[] Validate(object? value)
+        => _validator.Validate(value, null, null, PropertyValidationContext.Empty()).ToArray();
+
+    [Test]
+    public void Cannot_Validate_When_Max_Is_Less_Than_Min()
+    {
+        var value = new JsonObject { ["min"] = 5, ["max"] = 2 };
+
+        Assert.That(Validate(value), Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public void Can_Validate_When_Max_Is_Greater_Than_Min()
+    {
+        var value = new JsonObject { ["min"] = 2, ["max"] = 5 };
+
+        Assert.That(Validate(value), Is.Empty);
+    }
+
+    [Test]
+    public void Can_Validate_When_Min_Equals_Max()
+    {
+        var value = new JsonObject { ["min"] = 3, ["max"] = 3 };
+
+        Assert.That(Validate(value), Is.Empty);
+    }
+
+    [TestCase(null, 5)]
+    [TestCase(5, null)]
+    [TestCase(null, null)]
+    public void Can_Validate_When_A_Bound_Is_Unset(int? min, int? max)
+    {
+        var value = new JsonObject();
+        if (min.HasValue)
+        {
+            value["min"] = min.Value;
+        }
+
+        if (max.HasValue)
+        {
+            value["max"] = max.Value;
+        }
+
+        Assert.That(Validate(value), Is.Empty);
+    }
+
+    [Test]
+    public void Cannot_Validate_Typed_NumberRange_When_Max_Is_Less_Than_Min()
+    {
+        var value = new NumberRange { Min = 10, Max = 1 };
+
+        Assert.That(Validate(value), Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public void Cannot_Validate_Typed_DecimalRange_When_Max_Is_Less_Than_Min()
+    {
+        var value = new DecimalRange { Min = 1.5m, Max = 0.5m };
+
+        Assert.That(Validate(value), Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public void Can_Validate_When_Value_Is_Not_A_Range()
+    {
+        Assert.That(Validate(null), Is.Empty);
+        Assert.That(Validate("not-a-range"), Is.Empty);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/SliderPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/SliderPropertyValueEditorTests.cs
@@ -339,8 +339,7 @@ public class SliderPropertyValueEditorTests
             ConfigurationObject = new SliderConfiguration
             {
                 EnableRange = enableRange,
-                MinimumValue = 1.1m,
-                MaximumValue = 1.9m,
+                ValidationRange = new DecimalRange { Min = 1.1m, Max = 1.9m },
                 Step = step,
                 MinimumRange = minimumRange,
             },

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/Validators/MultiUrlPickerValueEditorValidationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/Validators/MultiUrlPickerValueEditorValidationTests.cs
@@ -26,7 +26,7 @@ internal class MultiUrlPickerValueEditorValidationTests
     {
         var picker = CreateValueEditor();
 
-        picker.ConfigurationObject = new MultiUrlPickerConfiguration() { MinNumber = min };
+        picker.ConfigurationObject = new MultiUrlPickerConfiguration() { ValidationLimit = new NumberRange { Min = min } };
 
         var result = picker.Validate(value, false, null, PropertyValidationContext.Empty());
         ValidateResult(succeed, result);
@@ -41,7 +41,7 @@ internal class MultiUrlPickerValueEditorValidationTests
     {
         var picker = CreateValueEditor();
 
-        picker.ConfigurationObject = new MultiUrlPickerConfiguration() { MaxNumber = max };
+        picker.ConfigurationObject = new MultiUrlPickerConfiguration() { ValidationLimit = new NumberRange { Max = max } };
 
         var result = picker.Validate(value, false, null, PropertyValidationContext.Empty());
         ValidateResult(succeed, result);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ValueSchemaProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ValueSchemaProviderTests.cs
@@ -51,8 +51,7 @@ public class ValueSchemaProviderTests
         var editor = CreateIntegerPropertyEditor();
         var config = new Dictionary<string, object>
         {
-            { "min", 10 },
-            { "max", 100 },
+            { "validationRange", new Dictionary<string, object> { { "min", 10 }, { "max", 100 } } },
         };
 
         // Act
@@ -71,7 +70,7 @@ public class ValueSchemaProviderTests
         var editor = CreateIntegerPropertyEditor();
         var config = new Dictionary<string, object>
         {
-            { "min", 0 },
+            { "validationRange", new Dictionary<string, object> { { "min", 0 } } },
             { "step", 5 },
         };
 
@@ -124,7 +123,7 @@ public class ValueSchemaProviderTests
                     Mock.Of<IIOHelper>(),
                     new DataEditorAttribute(Constants.PropertyEditors.Aliases.Integer)));
 
-        return new IntegerPropertyEditor(dataValueEditorFactory);
+        return new IntegerPropertyEditor(dataValueEditorFactory, Mock.Of<IIOHelper>());
     }
 
     private static ContentPickerPropertyEditor CreateContentPickerPropertyEditor()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeTests.cs
@@ -146,4 +146,30 @@ public class MigrateMinMaxToRangeTests
 
         Assert.That(MigrateBlockGridAreaMinMaxToRange.MigrateAreas(configuration), Is.False);
     }
+
+    [Test]
+    public void Block_Grid_Migration_Skips_Blocks_Without_Areas_And_Migrates_The_Rest()
+    {
+        var configuration = new JsonObject
+        {
+            ["blocks"] = new JsonArray(
+                new JsonObject { ["contentElementTypeKey"] = "no-areas-block" },
+                new JsonObject
+                {
+                    ["areas"] = new JsonArray(
+                        new JsonObject { ["minAllowed"] = 2, ["maxAllowed"] = 4 }),
+                }),
+        };
+
+        var changed = MigrateBlockGridAreaMinMaxToRange.MigrateAreas(configuration);
+
+        var migratedArea = (JsonObject)((JsonArray)((JsonObject)configuration["blocks"]![1]!)["areas"]!)[0]!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(Min(migratedArea, "validationLimit"), Is.EqualTo(2));
+            Assert.That(Max(migratedArea, "validationLimit"), Is.EqualTo(4));
+        });
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/MigrateMinMaxToRangeTests.cs
@@ -1,0 +1,149 @@
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+[TestFixture]
+public class MigrateMinMaxToRangeTests
+{
+    private static decimal? Min(JsonObject configuration, string rangeKey)
+        => (configuration[rangeKey] as JsonObject)?["min"]?.GetValue<decimal>();
+
+    private static decimal? Max(JsonObject configuration, string rangeKey)
+        => (configuration[rangeKey] as JsonObject)?["max"]?.GetValue<decimal>();
+
+    [Test]
+    public void Count_Editor_Combines_Min_And_Max_Into_Range()
+    {
+        var configuration = new JsonObject { ["minNumber"] = 2, ["maxNumber"] = 5 };
+
+        var changed = MigrateMinMaxToRangeMigrationBase.MigrateTopLevelRange(
+            configuration, "minNumber", "maxNumber", "validationLimit", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(configuration.ContainsKey("minNumber"), Is.False);
+            Assert.That(configuration.ContainsKey("maxNumber"), Is.False);
+            Assert.That(Min(configuration, "validationLimit"), Is.EqualTo(2));
+            Assert.That(Max(configuration, "validationLimit"), Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public void Count_Editor_Treats_Zero_As_Unbounded_And_Omits_Empty_Range()
+    {
+        var configuration = new JsonObject { ["minNumber"] = 0, ["maxNumber"] = 0 };
+
+        var changed = MigrateMinMaxToRangeMigrationBase.MigrateTopLevelRange(
+            configuration, "minNumber", "maxNumber", "validationLimit", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(configuration.ContainsKey("minNumber"), Is.False);
+            Assert.That(configuration.ContainsKey("maxNumber"), Is.False);
+            Assert.That(configuration.ContainsKey("validationLimit"), Is.False);
+        });
+    }
+
+    [Test]
+    public void Migration_Is_A_No_Op_When_Keys_Are_Absent()
+    {
+        var configuration = new JsonObject { ["filter"] = "abc" };
+
+        var changed = MigrateMinMaxToRangeMigrationBase.MigrateTopLevelRange(
+            configuration, "minNumber", "maxNumber", "validationLimit", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.False);
+            Assert.That(configuration.ContainsKey("validationLimit"), Is.False);
+        });
+    }
+
+    [Test]
+    public void Misconfigured_Min_Greater_Than_Max_Is_Carried_Across_Faithfully()
+    {
+        var configuration = new JsonObject { ["minNumber"] = 5, ["maxNumber"] = 2 };
+
+        MigrateMinMaxToRangeMigrationBase.MigrateTopLevelRange(
+            configuration, "minNumber", "maxNumber", "validationLimit", minZeroIsUnbounded: true, maxZeroIsUnbounded: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Min(configuration, "validationLimit"), Is.EqualTo(5));
+            Assert.That(Max(configuration, "validationLimit"), Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void Slider_Preserves_Zero_Minimum_But_Treats_Zero_Maximum_As_Unbounded()
+    {
+        var configuration = new JsonObject { ["minVal"] = 0, ["maxVal"] = 0 };
+
+        MigrateMinMaxToRangeMigrationBase.MigrateTopLevelRange(
+            configuration, "minVal", "maxVal", "validationRange", minZeroIsUnbounded: false, maxZeroIsUnbounded: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Min(configuration, "validationRange"), Is.EqualTo(0));
+            Assert.That(Max(configuration, "validationRange"), Is.Null);
+        });
+    }
+
+    [Test]
+    public void Slider_Preserves_Decimal_Bounds()
+    {
+        var configuration = new JsonObject { ["minVal"] = 1.5, ["maxVal"] = 9.5 };
+
+        MigrateMinMaxToRangeMigrationBase.MigrateTopLevelRange(
+            configuration, "minVal", "maxVal", "validationRange", minZeroIsUnbounded: false, maxZeroIsUnbounded: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Min(configuration, "validationRange"), Is.EqualTo(1.5m));
+            Assert.That(Max(configuration, "validationRange"), Is.EqualTo(9.5m));
+        });
+    }
+
+    [Test]
+    public void Block_Grid_Areas_Are_Migrated_Per_Area()
+    {
+        var configuration = new JsonObject
+        {
+            ["blocks"] = new JsonArray(
+                new JsonObject
+                {
+                    ["areas"] = new JsonArray(
+                        new JsonObject { ["minAllowed"] = 1, ["maxAllowed"] = 3 },
+                        new JsonObject { ["alias"] = "no-limits" }),
+                }),
+        };
+
+        var changed = MigrateBlockGridAreaMinMaxToRange.MigrateAreas(configuration);
+
+        var areas = (JsonArray)((JsonObject)configuration["blocks"]![0]!)["areas"]!;
+        var firstArea = (JsonObject)areas[0]!;
+        var secondArea = (JsonObject)areas[1]!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(firstArea.ContainsKey("minAllowed"), Is.False);
+            Assert.That(firstArea.ContainsKey("maxAllowed"), Is.False);
+            Assert.That(Min(firstArea, "validationLimit"), Is.EqualTo(1));
+            Assert.That(Max(firstArea, "validationLimit"), Is.EqualTo(3));
+            Assert.That(secondArea.ContainsKey("validationLimit"), Is.False);
+        });
+    }
+
+    [Test]
+    public void Block_Grid_Migration_Is_A_No_Op_Without_Blocks()
+    {
+        var configuration = new JsonObject { ["gridColumns"] = 12 };
+
+        Assert.That(MigrateBlockGridAreaMinMaxToRange.MigrateAreas(configuration), Is.False);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactoryTests.cs
@@ -12,11 +12,11 @@ public class JsonTolerantNumberConverterFactoryTests
 
     [TestCase("\"\"")]
     [TestCase("\" \"")]
-    [TestCase("null")]
-    public void Can_Deserialize_Empty_Int_Configuration_As_Zero(string minMaxValue)
+    public void Can_Deserialize_Empty_Int_Range_As_Zero(string minMaxValue)
     {
-        // Legacy (pre-v14) databases stored the picker min/max as empty strings; deserialization must not throw.
-        var json = $"{{\"ignoreUserStartNodes\":false,\"minNumber\":{minMaxValue},\"maxNumber\":{minMaxValue}}}";
+        // Legacy databases stored the picker min/max as empty strings; deserialization must not throw and
+        // an empty string bound resolves to the default (zero).
+        var json = $"{{\"ignoreUserStartNodes\":false,\"validationLimit\":{{\"min\":{minMaxValue},\"max\":{minMaxValue}}}}}";
 
         MultiUrlPickerConfiguration? configuration =
             _serializer.Deserialize<MultiUrlPickerConfiguration>(json);
@@ -24,15 +24,32 @@ public class JsonTolerantNumberConverterFactoryTests
         Assert.IsNotNull(configuration);
         Assert.Multiple(() =>
         {
-            Assert.AreEqual(0, configuration.MinNumber);
-            Assert.AreEqual(0, configuration.MaxNumber);
+            Assert.That(configuration!.ValidationLimit.Min, Is.EqualTo(0));
+            Assert.That(configuration.ValidationLimit.Max, Is.EqualTo(0));
         });
     }
 
     [Test]
-    public void Can_Deserialize_Empty_Int_Configuration_On_MultiNodePicker_As_Zero()
+    public void Can_Deserialize_Null_Int_Range_As_Unbounded()
     {
-        var json = "{\"minNumber\":\"\",\"maxNumber\":\"\",\"filter\":\"\"}";
+        // An explicit JSON null resolves to a null (unbounded) nullable bound.
+        var json = "{\"validationLimit\":{\"min\":null,\"max\":null}}";
+
+        MultiUrlPickerConfiguration? configuration =
+            _serializer.Deserialize<MultiUrlPickerConfiguration>(json);
+
+        Assert.IsNotNull(configuration);
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration!.ValidationLimit.Min, Is.Null);
+            Assert.That(configuration.ValidationLimit.Max, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Can_Deserialize_Empty_Int_Range_On_MultiNodePicker_As_Zero()
+    {
+        var json = "{\"validationLimit\":{\"min\":\"\",\"max\":\"\"},\"filter\":\"\"}";
 
         MultiNodePickerConfiguration? configuration =
             _serializer.Deserialize<MultiNodePickerConfiguration>(json);
@@ -40,24 +57,25 @@ public class JsonTolerantNumberConverterFactoryTests
         Assert.IsNotNull(configuration);
         Assert.Multiple(() =>
         {
-            Assert.AreEqual(0, configuration.MinNumber);
-            Assert.AreEqual(0, configuration.MaxNumber);
+            Assert.That(configuration!.ValidationLimit.Min, Is.EqualTo(0));
+            Assert.That(configuration.ValidationLimit.Max, Is.EqualTo(0));
         });
     }
 
     [Test]
     public void Can_Deserialize_Empty_Decimal_Configuration_As_Zero()
     {
-        var json = "{\"minVal\":\"\",\"maxVal\":\"\",\"step\":\"\",\"minimumRange\":\"\"}";
+        var json = "{\"validationRange\":{\"min\":\"\",\"max\":\"\"},\"step\":\"\",\"minimumRange\":\"\"}";
 
         SliderConfiguration? configuration = _serializer.Deserialize<SliderConfiguration>(json);
 
         Assert.IsNotNull(configuration);
         Assert.Multiple(() =>
         {
-            Assert.AreEqual(0m, configuration.MinimumValue);
-            Assert.AreEqual(0m, configuration.MaximumValue);
-            Assert.AreEqual(0m, configuration.Step);
+            Assert.That(configuration!.ValidationRange.Min, Is.EqualTo(0m));
+            Assert.That(configuration.ValidationRange.Max, Is.EqualTo(0m));
+            Assert.That(configuration.Step, Is.EqualTo(0m));
+            Assert.That(configuration.MinimumRange, Is.EqualTo(0m));
         });
     }
 
@@ -74,9 +92,9 @@ public class JsonTolerantNumberConverterFactoryTests
 
     [TestCase("\"5\"", 5)]
     [TestCase("5", 5)]
-    public void Can_Deserialize_Valid_Number(string minNumberValue, int expected)
+    public void Can_Deserialize_Valid_Number(string minValue, int expected)
     {
-        var json = $"{{\"minNumber\":{minNumberValue},\"maxNumber\":10}}";
+        var json = $"{{\"validationLimit\":{{\"min\":{minValue},\"max\":10}}}}";
 
         MultiUrlPickerConfiguration? configuration =
             _serializer.Deserialize<MultiUrlPickerConfiguration>(json);
@@ -84,8 +102,8 @@ public class JsonTolerantNumberConverterFactoryTests
         Assert.IsNotNull(configuration);
         Assert.Multiple(() =>
         {
-            Assert.AreEqual(expected, configuration.MinNumber);
-            Assert.AreEqual(10, configuration.MaxNumber);
+            Assert.That(configuration!.ValidationLimit.Min, Is.EqualTo(expected));
+            Assert.That(configuration.ValidationLimit.Max, Is.EqualTo(10));
         });
     }
 
@@ -94,7 +112,7 @@ public class JsonTolerantNumberConverterFactoryTests
     {
         // A fractional JSON number cannot represent an int, so it must resolve to the default rather than
         // being silently truncated (e.g. 1.5 -> 1).
-        var json = "{\"minNumber\":1.5,\"maxNumber\":10}";
+        var json = "{\"validationLimit\":{\"min\":1.5,\"max\":10}}";
 
         MultiUrlPickerConfiguration? configuration =
             _serializer.Deserialize<MultiUrlPickerConfiguration>(json);
@@ -102,8 +120,8 @@ public class JsonTolerantNumberConverterFactoryTests
         Assert.IsNotNull(configuration);
         Assert.Multiple(() =>
         {
-            Assert.AreEqual(0, configuration.MinNumber);
-            Assert.AreEqual(10, configuration.MaxNumber);
+            Assert.That(configuration!.ValidationLimit.Min, Is.EqualTo(0));
+            Assert.That(configuration.ValidationLimit.Max, Is.EqualTo(10));
         });
     }
 
@@ -111,25 +129,31 @@ public class JsonTolerantNumberConverterFactoryTests
     public void Can_Deserialize_Fractional_Number_For_Decimal_Field()
     {
         // Floating-point config must retain its fractional value.
-        var json = "{\"step\":0.5,\"minVal\":1,\"maxVal\":10}";
+        var json = "{\"step\":0.5,\"validationRange\":{\"min\":1,\"max\":10}}";
 
         SliderConfiguration? configuration = _serializer.Deserialize<SliderConfiguration>(json);
 
         Assert.IsNotNull(configuration);
-        Assert.AreEqual(0.5m, configuration.Step);
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration!.Step, Is.EqualTo(0.5m));
+            Assert.That(configuration.ValidationRange.Min, Is.EqualTo(1m));
+            Assert.That(configuration.ValidationRange.Max, Is.EqualTo(10m));
+        });
     }
 
     [Test]
     public void Can_Serialize_Number_As_Numeric_Value()
     {
-        var configuration = new MultiUrlPickerConfiguration { MinNumber = 2, MaxNumber = 5 };
+        var configuration = new MultiUrlPickerConfiguration { ValidationLimit = new NumberRange { Min = 2, Max = 5 } };
 
         var serialized = _serializer.Serialize(configuration);
 
         Assert.Multiple(() =>
         {
-            Assert.IsTrue(serialized.Contains("\"minNumber\":2"), serialized);
-            Assert.IsTrue(serialized.Contains("\"maxNumber\":5"), serialized);
+            Assert.IsTrue(serialized.Contains("\"validationLimit\":"), serialized);
+            Assert.IsTrue(serialized.Contains("\"min\":2"), serialized);
+            Assert.IsTrue(serialized.Contains("\"max\":5"), serialized);
         });
     }
 }


### PR DESCRIPTION
## Description

Property editors that exposed **two separate configuration fields** for a lower and upper bound (`minNumber`/`maxNumber`, `min`/`max`, `minVal`/`maxVal`, `minAllowed`/`maxAllowed`) now use a **single range control** — the same `Umb.PropertyEditorUi.NumberRange` control the Media Picker already uses. This makes it impossible to configure a data type with `min > max` (the problem described in #16444 and #17509), as this is now enforced with **both client-side and server-side validation**.

<img width="1452" height="485" alt="image" src="https://github.com/user-attachments/assets/11fea7e3-6236-4bc1-b733-7b7a9388cb03" />

Fixes #16444
Fixes #17509

### Property editors updated

**Converted from separate min/max fields to a single range (data migrated):**

| Editor | Old config keys | New key |
|---|---|---|
| Numeric (Integer) | `min` / `max` | `validationRange` |
| Decimal | `min` / `max` | `validationRange` |
| Slider | `minVal` / `maxVal` | `validationRange` |
| Multiple Text String | `min` / `max` | `validationLimit` |
| Multi URL Picker | `minNumber` / `maxNumber` | `validationLimit` |
| MultiNode Tree Picker (Content Picker) | `minNumber` / `maxNumber` | `validationLimit` |
| Block Grid — per-area limits | `minAllowed` / `maxAllowed` | `validationLimit` (per area) |

**Already used a single range; retyped to the shared type for consistency (no data migration needed):** Media Picker, Block List, Block Grid (top-level block count), Entity Data Picker, Element Picker.

#### Validation

- **Client-side** — the range control rejects `min > max` and blocks save with an inline message.
- **Server-side** — a `RangeConfigurationValidator` attached to each range field makes `IDataTypeService` return `InvalidConfiguration` (HTTP 400) when `max < min`, even if the client is bypassed.

#### Migrations added

One migration per converted editor, sharing an abstract base (`MigrateMinMaxToRangeMigrationBase`). The base rewrites `umbracoDataType.config` JSON **directly**, deliberately bypassing the new validator so a legacy `min > max` configuration doesn't block the upgrade — the value is carried across faithfully and then surfaced as invalid in the UI for an editor to correct. `RebuildCache` is set so caches rebuild after the rewrite.

- `MigrateMultiUrlPickerMinMaxToRange` — `Umbraco.MultiUrlPicker`
- `MigrateMultiNodeTreePickerMinMaxToRange` — `Umbraco.MultiNodeTreePicker`
- `MigrateMultipleTextStringMinMaxToRange` — `Umbraco.MultipleTextstring`
- `MigrateIntegerMinMaxToRange` — `Umbraco.Integer`
- `MigrateDecimalMinMaxToRange` — `Umbraco.Decimal`
- `MigrateSliderMinMaxToRange` — `Umbraco.Slider`
- `MigrateBlockGridAreaMinMaxToRange` — `Umbraco.BlockGrid` (walks `blocks[].areas[]`)

Each migration preserves the **original `0`-semantics** of its editor: count editors and Integer/Decimal treat `0` as "unbounded" (dropped); Slider keeps a `0` minimum (a real floor) but treats a `0` maximum as unbounded; Block Grid areas keep `0` literally (they were already nullable — absence, not `0`, means unlimited).

## ⚠️ Breaking changes

Tagged breaking for two reasons:

1. **Binary-breaking API change.** The `ValidationLimit` property on `MediaPicker3Configuration`, `BlockListConfiguration`, `BlockGridConfiguration`, `EntityDataPickerConfiguration` and `ElementPickerConfiguration` changed type from each editor's nested `NumberRange` to the shared `Umbraco.Cms.Core.PropertyEditors.NumberRange`. The getter/setter signatures change at the IL level, so pre-compiled third-party assemblies that read or write this property break. It is source-breaking only where code explicitly typed a variable as the old nested type — the nested types still exist (now `[Obsolete]`) and derive from the shared type, so most source keeps compiling. All obsoleted members are scheduled for removal in **Umbraco 21**.

2. **Stored configuration shape change.** Persisted data-type configuration no longer contains the old keys (`minNumber`/`maxNumber`, `min`/`max`, `minVal`/`maxVal`, `minAllowed`/`maxAllowed`); they are replaced by a single `validationLimit` / `validationRange` object. The included migrations update existing databases automatically, but anything that reads data-type configuration JSON by the old key names must be updated to the new shape.

## Testing

### Automated

- **Unit** — the range validator, the range-configuration helper, the range-field wiring on each converted config editor (rejecting `max < min`), and the migration transforms.
- **Integration** — one test class per migration sharing a common base, each seeding old-shape configuration via SQL and running the real migration through the upgrader (exercising the DB round-trip and cache rebuild); covers idempotency, `0`→unbounded, and the misconfigured-`min > max`-carried-across case.
- **Frontend** — behavioural tests for the enhanced `umb-input-number-range` (decimals, negatives, `0`, `step`, and the `min > max` invalid state).
- **Acceptance (E2E)** — updated the data-type specs for Numeric, Decimal, Slider, Multiple Text String, Multi URL Picker and Block Grid areas to drive the single range control, and **enabled three previously-skipped tests** that assert `min > max` is rejected (they had been parked against #17509).

### Manual

Verified end-to-end: a pre-19 database whose data types use the old separate min/max fields — including deliberately misconfigured `min > max` cases and `0`/unbounded cases across every affected editor, plus a document populated with values — was pointed at this build. After the upgrade every data type's configuration was rewritten to the range shape, all editors and the content rendered without error, misconfigured data types were flagged invalid in the UI (and blocked on save), and valid data types saved cleanly.

If you want to re-do this, you can download the pre-migrated database [here](https://drive.google.com/file/d/1WohAVTtyLs8Vcf5bFpDvOsmp63Z6gHyZ/view?usp=sharing) (backoffice credentials: `admin@test.com` / `testtesttest`).


---
_This item has been added to our backlog AB#71544_