### PR TITLE
fix: Add CSS property to Light theme manifest

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/themes/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/themes/manifests.ts
@@ -13,6 +13,7 @@ export const themes: Array<UmbExtensionManifest> = [
 		type: 'theme',
 		alias: UMB_THEME_LIGHT_ALIAS,
 		name: 'Light',
+		css: '/umbraco/backoffice/css/light.css',
 		weight: 300,
 	},
 	/*


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
I noticed an issue when opening the Backoffice where light.css file was not found and caused disruption to the UI. I have checked the commit history and noticed that the local *.theme.css files were removed and were now fetched from umbraco-ui 2.0.1 and copied over to "/umbraco/backoffice/css/{theme}.css" path.

I have added the missing path to the manifest file which has fixed this issue.

Steps to reproduce: 
 1. Open Backoffice in light theme -> Developer tools -> light.css not found error in console and network tab.
 2. After this fix, the issue should be resolved.


<!-- Thanks for contributing to Umbraco CMS! -->
