### PR TITLE
Localization: Fix punctuation in resetFocalPoint string

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
@@ -326,7 +326,7 @@ export default {
 		notReadyToPublish: 'Wir sind für Veröffentlichungen bereit',
 		readyToPublish: 'Bereit zu Veröffentlichen?',
 		readyToSave: 'Bereit zu Sichern?',
-		resetFocalPoint: 'Fokus zurücksetzten.',
+		resetFocalPoint: 'Fokus zurücksetzten',
 		sendForApproval: 'Freigabe anfordern',
 		schedulePublishHelp: 'Wählen Sie Datum und Uhrzeit für die Veröffentlichung bzw. deren Rücknahme.',
 		createEmpty: 'Neues Element anlegen',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
@@ -326,7 +326,7 @@ export default {
 		notReadyToPublish: 'Wir sind für Veröffentlichungen bereit',
 		readyToPublish: 'Bereit zu Veröffentlichen?',
 		readyToSave: 'Bereit zu Sichern?',
-		resetFocalPoint: 'Fokus zurücksetzten',
+		resetFocalPoint: 'Fokus zurücksetzen',
 		sendForApproval: 'Freigabe anfordern',
 		schedulePublishHelp: 'Wählen Sie Datum und Uhrzeit für die Veröffentlichung bzw. deren Rücknahme.',
 		createEmpty: 'Neues Element anlegen',


### PR DESCRIPTION
Removed the period from the 'resetFocalPoint' string.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
A minor change not including dot in translation as for other languages.