### PR TITLE
AI Docs: Correct and trim solution- and project-scoped CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,7 +539,7 @@ For integration tests that exercise caching or cache refreshers, see `tests/Umbr
 
 ## 10. Verification Discipline
 
-- **Fresh build before trusting a green.** Never treat `--no-build` or cached/incremental output as proof a change compiles or passes — a stale run can mask a compile error. Rebuild before reporting build or test state. (Integration tests have a related false-green trap — see the caching note in section 9.)
+- **Fresh build before trusting a green.** Never treat `--no-build` or cached/incremental output as proof a change compiles or passes — a stale run can mask a compile error. Rebuild before reporting build or test state. (Integration tests have a related false-green trap — see `tests/Umbraco.Tests.Integration/CLAUDE.md`.)
 - **Grep the branch you think you're on.** A search only supports a claim against the branch actually checked out, so confirm HEAD is where you expect before drawing a conclusion from a grep. Easy to get wrong whenever the tree moves under you — reviewing a PR head, switching worktrees, or mid merge-up/rebase.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,23 +515,11 @@ Labels are only added, never removed. Claude applies only labels it is confident
 
 ## 8. Code Comment Policy
 
-**Default to no comment.** Applies to all code in this repository — C#, TypeScript, Razor, build scripts. Well-named identifiers and small functions are the primary form of self-documentation; comments are a fallback for the rare cases where the code itself cannot carry the meaning.
+**Default to no comment.** Applies to all code in this repository — C#, TypeScript, Razor, build scripts. Well-named identifiers and small functions carry the meaning; a comment is a fallback for what the code genuinely cannot say — a non-obvious *why*, a subtle invariant the types don't enforce, or a surprising edge case the code handles deliberately. Add XML doc / JSDoc on public members, but keep it concise.
 
-### When NOT to comment
+Linking a tracked issue (`(#21996)`, `https://...`) to explain a non-obvious *why* is welcome — for example, on a section of code or to explain why a regression test exists. Such a link stays useful even after the issue is closed, since it documents why the code is the way it is.
 
-- **Don't restate what the code does.** A line calling `resetState()` does not need `// Reset state`. A method named `validateInput` does not need `// Validate input`.
-- **Don't narrate a sequence of calls.** If three lines run in order, the order is in the code — don't paraphrase it above.
-- **Don't reference the current task, fix, callers, or PR.** No `// Fix for X`, `// Used by Y`, `// Added for the Z flow`, `// See PR #1234`. That belongs in commit messages and PR descriptions; in source it rots as the codebase evolves.
-
-### When a comment IS justified
-
-Write a comment only when **removing it would leave a future reader confused**. Concretely:
-
-- **A non-obvious WHY.** A hidden constraint, business rule, or ordering requirement that is not visible from the code.
-- **A workaround for a specific bug or platform quirk.** Link the issue (`(#21996)`, `https://...`) so the comment can be deleted once the upstream fix lands.
-- **A subtle invariant** that the type system or method names do not enforce.
-- **An edge case the code intentionally handles** that would surprise a reader (e.g. "must run before X because Y").
-- **API documentation** — XML doc comments on C# members, JSDoc on exported TypeScript symbols. Required for the public contract; still keep them concise.
+**Don't leave provenance noise.** No `// Fix for X`, `// Used by Y`, `// Added for the Z flow`, `// See PR #1234`. The transient task or PR that produced a change belongs in commit messages and PR descriptions; in source it rots as the codebase evolves.
 
 ### TODOs
 
@@ -546,6 +534,13 @@ Allowed, but cheap to write and cheaper to leave behind. Keep them short and tra
 Verify any test you add for a bug fix actually catches the bug: either write the failing test first (TDD), or temporarily revert the production change and confirm the test fails before re-applying. A test that passes both ways proves nothing. Watch for coincidental passes — default seed/sort orders can make a buggy path produce the right answer for the test's specific inputs; construct inputs so the broken and fixed behaviours give visibly different results.
 
 For integration tests that exercise caching or cache refreshers, see `tests/Umbraco.Tests.Integration/CLAUDE.md` — the harness disables caching by default, which can produce false greens.
+
+---
+
+## 10. Verification Discipline
+
+- **Fresh build before trusting a green.** Never treat `--no-build` or cached/incremental output as proof a change compiles or passes — a stale run can mask a compile error. Rebuild before reporting build or test state. (Integration tests have a related false-green trap — see the caching note in section 9.)
+- **Grep the branch you think you're on.** A search only supports a claim against the branch actually checked out, so confirm HEAD is where you expect before drawing a conclusion from a grep. Easy to get wrong whenever the tree moves under you — reviewing a PR head, switching worktrees, or mid merge-up/rebase.
 
 ---
 

--- a/src/Umbraco.Cms.Api.Management/CLAUDE.md
+++ b/src/Umbraco.Cms.Api.Management/CLAUDE.md
@@ -19,7 +19,7 @@ RESTful API for Umbraco backoffice operations. Manages content, media, users, an
 **REST API Library** - Plugged into Umbraco.Web.UI, provides the Management API surface for backoffice operations.
 
 ### Key Technologies
-- **Web Framework**: ASP.NET Core MVC with `Asp.Versioning.Mvc` (v1.0 currently)
+- **Web Framework**: ASP.NET Core MVC with `Asp.Versioning.Mvc` (v1.0 and v1.1)
 - **OpenAPI**: Swashbuckle.AspNetCore with custom schema/operation filters
 - **Authentication**: OpenIddict via `Umbraco.Cms.Api.Common` (reference tokens, not JWT)
 - **Authorization**: Policy-based with `IAuthorizationService`

--- a/src/Umbraco.Cms.StaticAssets/CLAUDE.md
+++ b/src/Umbraco.Cms.StaticAssets/CLAUDE.md
@@ -28,9 +28,9 @@ This project packages all static assets required for Umbraco CMS at runtime:
 Umbraco.Cms.StaticAssets/
 ├── umbraco/                                # Razor Views (server-rendered)
 │   ├── UmbracoBackOffice/
-│   │   └── Index.cshtml                    # Backoffice SPA shell (69 lines)
+│   │   └── Index.cshtml                    # Backoffice SPA shell
 │   ├── UmbracoLogin/
-│   │   └── Index.cshtml                    # Login page (99 lines)
+│   │   └── Index.cshtml                    # Login page
 │   └── UmbracoWebsite/
 │       ├── NoNodes.cshtml                  # "No published content" page
 │       ├── NotFound.cshtml                 # 404 error page
@@ -49,7 +49,7 @@ Umbraco.Cms.StaticAssets/
 │       ├── login/                          # Built login SPA (from Umbraco.Web.UI.Login)
 │       └── website/                        # Frontend website assets (fonts, CSS)
 │
-└── Umbraco.Cms.StaticAssets.csproj         # Build configuration (149 lines)
+└── Umbraco.Cms.StaticAssets.csproj         # Build configuration
 ```
 
 ### Project Dependencies
@@ -71,13 +71,13 @@ Umbraco.Cms.StaticAssets/
 
 ### Razor Views
 
-| View | Purpose | Line Count |
-|------|---------|------------|
-| `UmbracoBackOffice/Index.cshtml` | Backoffice SPA entry point with `<umb-app>` web component | 69 |
-| `UmbracoLogin/Index.cshtml` | Login page with `<umb-auth>` web component | 99 |
-| `UmbracoWebsite/NoNodes.cshtml` | Welcome page when no content published | 59 |
-| `UmbracoWebsite/NotFound.cshtml` | 404 error page (debug info in debug mode) | 79 |
-| `UmbracoWebsite/Maintenance.cshtml` | Maintenance mode during upgrades | 65 |
+| View | Purpose |
+|------|---------|
+| `UmbracoBackOffice/Index.cshtml` | Backoffice SPA entry point with `<umb-app>` web component |
+| `UmbracoLogin/Index.cshtml` | Login page with `<umb-auth>` web component |
+| `UmbracoWebsite/NoNodes.cshtml` | Welcome page when no content published |
+| `UmbracoWebsite/NotFound.cshtml` | 404 error page (debug info in debug mode) |
+| `UmbracoWebsite/Maintenance.cshtml` | Maintenance mode during upgrades |
 
 ### Backoffice Index View (umbraco/UmbracoBackOffice/Index.cshtml)
 

--- a/src/Umbraco.Core/CLAUDE.md
+++ b/src/Umbraco.Core/CLAUDE.md
@@ -91,12 +91,12 @@ public interface IContentService
     Task<Attempt<IContent?, ContentEditingOperationStatus>> CreateAsync(...);
 }
 
-// Implementation lives in Umbraco.Infrastructure
+// Implementation lives in Umbraco.Core/Services/ (see root CLAUDE.md §4)
 // Service operations return Attempt<T, TStatus> for typed results
 ```
 
 **Key conventions**:
-- Interfaces in Umbraco.Core, implementations in Umbraco.Infrastructure
+- Interfaces in Umbraco.Core; most service implementations live in Umbraco.Core/Services/ too, moving to Umbraco.Infrastructure only when a concrete dependency requires it (see root CLAUDE.md §4)
 - Use `Attempt<TResult, TStatus>` for operations that can fail with specific reasons
 - OperationStatus enums provide detailed failure reasons
 - Services are registered via DI in builder extensions
@@ -369,7 +369,7 @@ public enum MyOperationStatus
     ValidationFailed
 }
 
-// 3. Implement in Umbraco.Infrastructure
+// 3. Implement in Umbraco.Core/Services/ (or Umbraco.Infrastructure if it needs Infrastructure concerns)
 // 4. Register in a Composer
 builder.Services.AddScoped<IMyService, MyService>();
 ```
@@ -538,4 +538,4 @@ Internal types are accessible in test projects for more thorough testing.
 
 ---
 
-**Remember**: Umbraco.Core is about **defining what**, not **implementing how**. Keep implementations in Infrastructure!
+**Remember**: Umbraco.Core defines the contracts. Domain **service** implementations mostly live here too (`Services/`); repository and other Infrastructure-backed implementations live in Umbraco.Infrastructure. See root CLAUDE.md §4.

--- a/src/Umbraco.Infrastructure/CLAUDE.md
+++ b/src/Umbraco.Infrastructure/CLAUDE.md
@@ -227,13 +227,12 @@ internal class ContentFactory : IEntityFactory<IContent, ContentDto>
 - Converts DTO → Domain entity
 - Always `internal` (implementation detail)
 
-**Service Naming** (from Services/Implement/):
+**Service Naming** (`Services/Implement/`):
 ```csharp
-internal sealed class ContentService : RepositoryService, IContentService
+internal sealed class ContentSearchService : ContentSearchServiceBase<IContent>, IContentSearchService
 ```
-- Pattern: `{Domain}Service : RepositoryService, I{Domain}Service`
-- Inherits `RepositoryService` for scope/repository access
-- Always `internal sealed`
+- Pattern: `{Domain}Service : I{Domain}Service` (base class varies by concern)
+- Only services with genuine Infrastructure dependencies live here (search, packaging, webhooks, log viewing); the `RepositoryService`-based domain services (`ContentService`, `MediaService`, …) live in `Umbraco.Core/Services/` — see root CLAUDE.md §4
 
 ### Key Code Patterns
 
@@ -375,7 +374,7 @@ using (ICoreScope scope = ScopeProvider.CreateCoreScope())
 - 16 service implementations
 - Services fire notifications before/after operations
 - Services manage scopes (not repositories)
-- Example: `ContentService`, `MediaService`, `UserService`
+- Example: `ContentSearchService`, `PackagingService`, `WebhookFiringService` — the Infrastructure-dependent services; the main domain services (`ContentService`, `MediaService`, …) live in `Umbraco.Core/Services/`
 
 ### Code Smells to Watch For
 
@@ -794,7 +793,7 @@ dotnet pack src/Umbraco.Infrastructure -c Release
 - **Scope Provider**: `src/Umbraco.Infrastructure/Scoping/ScopeProvider.cs`
 - **Database Factory**: `src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs`
 - **Migration Executor**: `src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs`
-- **Content Service**: `src/Umbraco.Infrastructure/Services/Implement/ContentService.cs`
+- **Content Search Service**: `src/Umbraco.Infrastructure/Services/Implement/ContentSearchService.cs`
 - **User Repository**: `src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs`
 
 ### Critical Patterns

--- a/src/Umbraco.PublishedCache.HybridCache/CLAUDE.md
+++ b/src/Umbraco.PublishedCache.HybridCache/CLAUDE.md
@@ -320,7 +320,7 @@ stored content without decompressing or walking the converted graph, so it omits
 conversion blow-up); true per-object bytes come from a GC dump. Note the tiers: **L0** is the
 converted-`IPublishedContent` cache reported above; **L1** is Microsoft HybridCache's in-process tier of
 `ContentCacheNode` entries (behind L0); **L2** is the optional distributed tier. The HybridCache **L1** has
-no exposed count/size — measure it from the GC dump until a sized backing cache is wired up (PR 3).
+no exposed count/size — measure it from the GC dump until a sized backing cache is wired up.
 
 ### Known Technical Debt
 

--- a/src/Umbraco.Web.UI.Login/CLAUDE.md
+++ b/src/Umbraco.Web.UI.Login/CLAUDE.md
@@ -98,7 +98,7 @@ Umbraco.Web.UI.Login/
 ├── package.json                      # npm configuration (29 lines)
 ├── tsconfig.json                     # TypeScript config (25 lines)
 ├── vite.config.ts                    # Vite build config (20 lines)
-├── .nvmrc                            # Node version (22)
+├── .nvmrc                            # Node version (24)
 └── .prettierrc.json                  # Prettier config
 ```
 
@@ -230,11 +230,12 @@ Form waits for localization availability before rendering. Retries 40 times with
 
 ### External Dependencies
 
-- `@umbraco-cms/backoffice` ^16.2.0 - Umbraco UI components, Lit element base
-- `vite` ^7.2.0 - Build tooling
-- `typescript` ^5.9.3 - Type checking
-- `msw` ^2.11.3 - API mocking
-- `@hey-api/openapi-ts` ^0.85.0 - API client generation
+- `vite` - Build tooling
+- `typescript` - Type checking
+- `msw` - API mocking
+- `@hey-api/openapi-ts` - API client generation
+
+`@umbraco-cms/backoffice` is **not** an npm dependency — its types resolve from the sibling Client's source via generated tsconfig path aliases (see the type-resolution section above).
 
 ### Known Technical Debt
 
@@ -298,4 +299,4 @@ Built files go to:
 | -------------------------- | ------------------------------------- |
 | `Umbraco.Cms.StaticAssets` | Receives built output                 |
 | `Umbraco.Web.UI.Client`    | Backoffice SPA (similar architecture) |
-| `@umbraco-cms/backoffice`  | NPM dependency for UI components      |
+| `@umbraco-cms/backoffice`  | Type source via tsconfig path aliases (not an npm dep) |

--- a/src/Umbraco.Web.UI.Login/CLAUDE.md
+++ b/src/Umbraco.Web.UI.Login/CLAUDE.md
@@ -235,7 +235,7 @@ Form waits for localization availability before rendering. Retries 40 times with
 - `msw` - API mocking
 - `@hey-api/openapi-ts` - API client generation
 
-`@umbraco-cms/backoffice` is **not** an npm dependency — its types resolve from the sibling Client's source via generated tsconfig path aliases (see the type-resolution section above).
+`@umbraco-cms/backoffice` is **not** an npm dependency — its types resolve from the sibling Client's source via generated tsconfig path aliases.
 
 ### Known Technical Debt
 


### PR DESCRIPTION
## Description

This PR follows a review and update of the repository's `CLAUDE.md` guidance files — the root file plus six project-scoped files — for accuracy and to align with current context-engineering best practice. Documentation-only; no product code changes.

The updates come from two inputs:

1. **A local Claude Code `/insights` report** over recent sessions, which surfaced recurring, repo-specific issues worth encoding as durable guidance.
2. **Anthropic's [new rules of context engineering for Claude 5](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models)" article, whose guidance is to encode genuine gotchas, trust model judgement over prescriptive guardrails, avoid repetition, and keep facts correct and singly-sourced.

### Root `CLAUDE.md`

- **New "Verification Discipline" section** capturing two gotchas the insights report flagged: never trust `--no-build`/cached output as a green build/test signal, and confirm you are on the intended branch / PR head before drawing conclusions from a `grep`.
- **Trimmed the "Code Comment Policy" section** — dropped generic bullets the model already follows, kept the repo-specific opinions: no task/PR/caller references in comments; added that linking a tracked issue to explain a durable *why* is welcome; kept that a TODO needs an author or version trigger.

### Project-scoped files (factual corrections, each verified against the tree)

- **Umbraco.Core / Umbraco.Infrastructure** — corrected service-location guideance: most domain services (`ContentService`, `MediaService`, …) now live in `Umbraco.Core/Services/`, not `Umbraco.Infrastructure`; only Infrastructure-dependent services (`ContentSearchService`, `PackagingService`, `WebhookFiringService`) remain in `Services/Implement/`. Fixed stale claims, examples, and a dead file path.
- **Umbraco.Web.UI.Login** — fixed the Node version note (`.nvmrc` is `24`, not `22`) and removed an incorrect `@umbraco-cms/backoffice` npm-dependency claim: its types resolve via generated tsconfig path aliases, not an npm dependency. Dropped stale pinned versions.
- **Umbraco.Cms.Api.Management** — versioning note now reflects v1.0 **and** v1.1 (previously said v1.0 only, contradicting the same file later on).
- **Umbraco.PublishedCache.HybridCache** — removed a transient `(PR 3)` reference.
- **Umbraco.Cms.StaticAssets** — dropped rot-prone line-count figures from the file tree and Razor-views table.