### PR TITLE
Scoping: Isolate the ambient scope stacks across execution context flows (closes #23366)

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore/Scoping/AmbientEFCoreScopeStack.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Scoping/AmbientEFCoreScopeStack.cs
@@ -48,9 +48,19 @@ public class AmbientEFCoreScopeStack<TDbContext> : IAmbientEFCoreScopeStack<TDbC
     {
         lock (_lock)
         {
-            _stack.Value ??= new ConcurrentStack<IEFCoreScope<TDbContext>>();
+            ConcurrentStack<IEFCoreScope<TDbContext>>? stack = _stack.Value;
 
-            _stack.Value.Push(scope);
+            // An empty stack was inherited from an ancestor execution context, because popping the last entry
+            // leaves the instance in place. AsyncLocal copy-on-write protects the reference and not the instance
+            // it points at, so pushing onto it would share this flow's scopes with every sibling flow that
+            // inherited it. A non-empty stack is genuine nesting within this flow and is kept.
+            if (stack is null || stack.IsEmpty)
+            {
+                stack = new ConcurrentStack<IEFCoreScope<TDbContext>>();
+                _stack.Value = stack;
+            }
+
+            stack.Push(scope);
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Scoping/AmbientScopeContextStack.cs
+++ b/src/Umbraco.Infrastructure/Scoping/AmbientScopeContextStack.cs
@@ -54,9 +54,19 @@ internal sealed class AmbientScopeContextStack : IAmbientScopeContextStack
     {
         lock (_lock)
         {
-            _stack.Value ??= new ConcurrentStack<IScopeContext>();
+            ConcurrentStack<IScopeContext>? stack = _stack.Value;
 
-            _stack.Value.Push(scope);
+            // An empty stack was inherited from an ancestor execution context, because popping the last entry
+            // leaves the instance in place. AsyncLocal copy-on-write protects the reference and not the instance
+            // it points at, so pushing onto it would share this flow's contexts with every sibling flow that
+            // inherited it. A non-empty stack is genuine nesting within this flow and is kept.
+            if (stack is null || stack.IsEmpty)
+            {
+                stack = new ConcurrentStack<IScopeContext>();
+                _stack.Value = stack;
+            }
+
+            stack.Push(scope);
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Scoping/AmbientScopeStack.cs
+++ b/src/Umbraco.Infrastructure/Scoping/AmbientScopeStack.cs
@@ -54,7 +54,19 @@ namespace Umbraco.Cms.Infrastructure.Scoping
         {
             lock (_lock)
             {
-                (_stack.Value ??= new ConcurrentStack<IScope>()).Push(scope);
+                ConcurrentStack<IScope>? stack = _stack.Value;
+
+                // An empty stack was inherited from an ancestor execution context, because popping the last entry
+                // leaves the instance in place. AsyncLocal copy-on-write protects the reference and not the instance
+                // it points at, so pushing onto it would share this flow's scopes with every sibling flow that
+                // inherited it. A non-empty stack is genuine nesting within this flow and is kept.
+                if (stack is null || stack.IsEmpty)
+                {
+                    stack = new ConcurrentStack<IScope>();
+                    _stack.Value = stack;
+                }
+
+                stack.Push(scope);
             }
         }
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/Scoping/AmbientEFCoreScopeStackTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/Scoping/AmbientEFCoreScopeStackTests.cs
@@ -25,36 +25,25 @@ internal sealed class AmbientEFCoreScopeStackTests
 
         IEFCoreScope<TestUmbracoDbContext> scopeA = Mock.Of<IEFCoreScope<TestUmbracoDbContext>>();
         IEFCoreScope<TestUmbracoDbContext> scopeB = Mock.Of<IEFCoreScope<TestUmbracoDbContext>>();
-        var pushedA = new TaskCompletionSource();
-        var pushedB = new TaskCompletionSource();
-        var readA = new TaskCompletionSource();
-        var readB = new TaskCompletionSource();
+        (FlowBarriers barriersA, FlowBarriers barriersB) = FlowBarriers.CreatePair();
 
-        // Two barriers, both load-bearing. Every flow pushes before any flow reads, so a shared stack yields the
-        // wrong entry to at least one of them. Every flow also reads before any flow pops, otherwise a pop could
-        // remove the other flow's entry first and leave the remaining read coincidentally correct.
         async Task<IEFCoreScope<TestUmbracoDbContext>?> RunFlow(
             IEFCoreScope<TestUmbracoDbContext> scope,
-            TaskCompletionSource pushed,
-            Task otherPushed,
-            TaskCompletionSource read,
-            Task otherRead)
+            FlowBarriers barriers)
         {
             sut.Push(scope);
-            pushed.SetResult();
-            await otherPushed;
+            await barriers.EveryFlowHasPushed();
 
             IEFCoreScope<TestUmbracoDbContext>? ambientScope = sut.AmbientScope;
-            read.SetResult();
-            await otherRead;
+            await barriers.EveryFlowHasRead();
 
             sut.Pop();
             return ambientScope;
         }
 
         IEFCoreScope<TestUmbracoDbContext>?[] ambient = await Task.WhenAll(
-            Task.Run(() => RunFlow(scopeA, pushedA, pushedB.Task, readA, readB.Task)),
-            Task.Run(() => RunFlow(scopeB, pushedB, pushedA.Task, readB, readA.Task)));
+            Task.Run(() => RunFlow(scopeA, barriersA)),
+            Task.Run(() => RunFlow(scopeB, barriersB)));
 
         Assert.Multiple(() =>
         {
@@ -93,5 +82,40 @@ internal sealed class AmbientEFCoreScopeStackTests
         {
             stack.Pop();
         }
+    }
+}
+
+/// <summary>
+/// The two rendezvous points that make an ambient stack isolation test meaningful. Both are load-bearing:
+/// every flow pushes before any flow reads, so a stack shared between flows hands the wrong entry to at least
+/// one of them; and every flow reads before any flow pops, because a pop that lands first removes the other
+/// flow's entry and leaves the remaining read coincidentally correct, hiding the defect.
+/// </summary>
+internal sealed class FlowBarriers
+{
+    private readonly TaskCompletionSource _pushed = new();
+    private readonly TaskCompletionSource _read = new();
+    private FlowBarriers _other = null!;
+
+    public static (FlowBarriers First, FlowBarriers Second) CreatePair()
+    {
+        var first = new FlowBarriers();
+        var second = new FlowBarriers();
+        first._other = second;
+        second._other = first;
+
+        return (first, second);
+    }
+
+    public Task EveryFlowHasPushed()
+    {
+        _pushed.SetResult();
+        return _other._pushed.Task;
+    }
+
+    public Task EveryFlowHasRead()
+    {
+        _read.SetResult();
+        return _other._read.Task;
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/Scoping/AmbientEFCoreScopeStackTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/Scoping/AmbientEFCoreScopeStackTests.cs
@@ -1,0 +1,83 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Persistence.EFCore.Scoping;
+using Umbraco.Cms.Tests.Integration.Umbraco.Persistence.EFCore.DbContext;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Persistence.EFCore.Scoping;
+
+/// <summary>
+/// Shares the defect and the fix of <c>AmbientScopeStack</c>: an empty stack inherited from an ancestor execution
+/// context is shared by every flow that branches off it, because AsyncLocal copy-on-write protects the reference
+/// and not the instance. Lives here rather than in the unit test project, which does not reference EF Core.
+/// </summary>
+[TestFixture]
+internal sealed class AmbientEFCoreScopeStackTests
+{
+    [Test]
+    public async Task Push_IsolatesConcurrentFlowsThatInheritedAnEmptyStack()
+    {
+        var sut = new AmbientEFCoreScopeStack<TestUmbracoDbContext>();
+
+        Drain(sut);
+
+        sut.Push(Mock.Of<IEFCoreScope<TestUmbracoDbContext>>());
+        sut.Pop();
+
+        IEFCoreScope<TestUmbracoDbContext> scopeA = Mock.Of<IEFCoreScope<TestUmbracoDbContext>>();
+        IEFCoreScope<TestUmbracoDbContext> scopeB = Mock.Of<IEFCoreScope<TestUmbracoDbContext>>();
+        var pushedA = new TaskCompletionSource();
+        var pushedB = new TaskCompletionSource();
+
+        async Task<IEFCoreScope<TestUmbracoDbContext>?> PushThenReadAmbient(
+            IEFCoreScope<TestUmbracoDbContext> scope,
+            TaskCompletionSource pushed,
+            Task otherPushed)
+        {
+            sut.Push(scope);
+            pushed.SetResult();
+            await otherPushed;
+            return sut.AmbientScope;
+        }
+
+        IEFCoreScope<TestUmbracoDbContext>?[] ambient = await Task.WhenAll(
+            Task.Run(() => PushThenReadAmbient(scopeA, pushedA, pushedB.Task)),
+            Task.Run(() => PushThenReadAmbient(scopeB, pushedB, pushedA.Task)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreSame(scopeA, ambient[0], "Flow A observed another flow's ambient scope.");
+            Assert.AreSame(scopeB, ambient[1], "Flow B observed another flow's ambient scope.");
+        });
+    }
+
+    [Test]
+    public void Push_KeepsNestedScopesOnTheSameStack()
+    {
+        var sut = new AmbientEFCoreScopeStack<TestUmbracoDbContext>();
+
+        Drain(sut);
+
+        IEFCoreScope<TestUmbracoDbContext> outer = Mock.Of<IEFCoreScope<TestUmbracoDbContext>>();
+        IEFCoreScope<TestUmbracoDbContext> inner = Mock.Of<IEFCoreScope<TestUmbracoDbContext>>();
+
+        sut.Push(outer);
+        sut.Push(inner);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreSame(inner, sut.AmbientScope);
+            Assert.AreSame(inner, sut.Pop());
+            Assert.AreSame(outer, sut.AmbientScope);
+            Assert.AreSame(outer, sut.Pop());
+            Assert.IsNull(sut.AmbientScope);
+        });
+    }
+
+    private static void Drain(AmbientEFCoreScopeStack<TestUmbracoDbContext> stack)
+    {
+        while (stack.AmbientScope is not null)
+        {
+            stack.Pop();
+        }
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/Scoping/AmbientEFCoreScopeStackTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/Scoping/AmbientEFCoreScopeStackTests.cs
@@ -27,26 +27,40 @@ internal sealed class AmbientEFCoreScopeStackTests
         IEFCoreScope<TestUmbracoDbContext> scopeB = Mock.Of<IEFCoreScope<TestUmbracoDbContext>>();
         var pushedA = new TaskCompletionSource();
         var pushedB = new TaskCompletionSource();
+        var readA = new TaskCompletionSource();
+        var readB = new TaskCompletionSource();
 
-        async Task<IEFCoreScope<TestUmbracoDbContext>?> PushThenReadAmbient(
+        // Two barriers, both load-bearing. Every flow pushes before any flow reads, so a shared stack yields the
+        // wrong entry to at least one of them. Every flow also reads before any flow pops, otherwise a pop could
+        // remove the other flow's entry first and leave the remaining read coincidentally correct.
+        async Task<IEFCoreScope<TestUmbracoDbContext>?> RunFlow(
             IEFCoreScope<TestUmbracoDbContext> scope,
             TaskCompletionSource pushed,
-            Task otherPushed)
+            Task otherPushed,
+            TaskCompletionSource read,
+            Task otherRead)
         {
             sut.Push(scope);
             pushed.SetResult();
             await otherPushed;
-            return sut.AmbientScope;
+
+            IEFCoreScope<TestUmbracoDbContext>? ambientScope = sut.AmbientScope;
+            read.SetResult();
+            await otherRead;
+
+            sut.Pop();
+            return ambientScope;
         }
 
         IEFCoreScope<TestUmbracoDbContext>?[] ambient = await Task.WhenAll(
-            Task.Run(() => PushThenReadAmbient(scopeA, pushedA, pushedB.Task)),
-            Task.Run(() => PushThenReadAmbient(scopeB, pushedB, pushedA.Task)));
+            Task.Run(() => RunFlow(scopeA, pushedA, pushedB.Task, readA, readB.Task)),
+            Task.Run(() => RunFlow(scopeB, pushedB, pushedA.Task, readB, readA.Task)));
 
         Assert.Multiple(() =>
         {
             Assert.AreSame(scopeA, ambient[0], "Flow A observed another flow's ambient scope.");
             Assert.AreSame(scopeB, ambient[1], "Flow B observed another flow's ambient scope.");
+            Assert.IsNull(sut.AmbientScope, "A scope pushed in a branching flow leaked into the calling context.");
         });
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/AmbientScopeStackTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/AmbientScopeStackTests.cs
@@ -27,36 +27,23 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 
             IScope scopeA = Mock.Of<IScope>();
             IScope scopeB = Mock.Of<IScope>();
-            var pushedA = new TaskCompletionSource();
-            var pushedB = new TaskCompletionSource();
-            var readA = new TaskCompletionSource();
-            var readB = new TaskCompletionSource();
+            (FlowBarriers barriersA, FlowBarriers barriersB) = FlowBarriers.CreatePair();
 
-            // Two barriers, both load-bearing. Every flow pushes before any flow reads, so a shared stack yields
-            // the wrong entry to at least one of them. Every flow also reads before any flow pops, otherwise a pop
-            // could remove the other flow's entry first and leave the remaining read coincidentally correct.
-            async Task<IScope?> RunFlow(
-                IScope scope,
-                TaskCompletionSource pushed,
-                Task otherPushed,
-                TaskCompletionSource read,
-                Task otherRead)
+            async Task<IScope?> RunFlow(IScope scope, FlowBarriers barriers)
             {
                 sut.Push(scope);
-                pushed.SetResult();
-                await otherPushed;
+                await barriers.EveryFlowHasPushed();
 
                 IScope? ambientScope = sut.AmbientScope;
-                read.SetResult();
-                await otherRead;
+                await barriers.EveryFlowHasRead();
 
                 sut.Pop();
                 return ambientScope;
             }
 
             IScope?[] ambient = await Task.WhenAll(
-                Task.Run(() => RunFlow(scopeA, pushedA, pushedB.Task, readA, readB.Task)),
-                Task.Run(() => RunFlow(scopeB, pushedB, pushedA.Task, readB, readA.Task)));
+                Task.Run(() => RunFlow(scopeA, barriersA)),
+                Task.Run(() => RunFlow(scopeB, barriersB)));
 
             Assert.Multiple(() =>
             {
@@ -116,33 +103,23 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 
             IScopeContext contextA = Mock.Of<IScopeContext>();
             IScopeContext contextB = Mock.Of<IScopeContext>();
-            var pushedA = new TaskCompletionSource();
-            var pushedB = new TaskCompletionSource();
-            var readA = new TaskCompletionSource();
-            var readB = new TaskCompletionSource();
+            (FlowBarriers barriersA, FlowBarriers barriersB) = FlowBarriers.CreatePair();
 
-            async Task<IScopeContext?> RunFlow(
-                IScopeContext context,
-                TaskCompletionSource pushed,
-                Task otherPushed,
-                TaskCompletionSource read,
-                Task otherRead)
+            async Task<IScopeContext?> RunFlow(IScopeContext context, FlowBarriers barriers)
             {
                 sut.Push(context);
-                pushed.SetResult();
-                await otherPushed;
+                await barriers.EveryFlowHasPushed();
 
                 IScopeContext? ambientContext = sut.AmbientContext;
-                read.SetResult();
-                await otherRead;
+                await barriers.EveryFlowHasRead();
 
                 sut.Pop();
                 return ambientContext;
             }
 
             IScopeContext?[] ambient = await Task.WhenAll(
-                Task.Run(() => RunFlow(contextA, pushedA, pushedB.Task, readA, readB.Task)),
-                Task.Run(() => RunFlow(contextB, pushedB, pushedA.Task, readB, readA.Task)));
+                Task.Run(() => RunFlow(contextA, barriersA)),
+                Task.Run(() => RunFlow(contextB, barriersB)));
 
             Assert.Multiple(() =>
             {
@@ -176,6 +153,41 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
                 Assert.AreSame(outer, sut.Pop());
                 Assert.IsNull(sut.AmbientContext);
             });
+        }
+    }
+
+    /// <summary>
+    /// The two rendezvous points that make an ambient stack isolation test meaningful. Both are load-bearing:
+    /// every flow pushes before any flow reads, so a stack shared between flows hands the wrong entry to at least
+    /// one of them; and every flow reads before any flow pops, because a pop that lands first removes the other
+    /// flow's entry and leaves the remaining read coincidentally correct, hiding the defect.
+    /// </summary>
+    internal sealed class FlowBarriers
+    {
+        private readonly TaskCompletionSource _pushed = new();
+        private readonly TaskCompletionSource _read = new();
+        private FlowBarriers _other = null!;
+
+        public static (FlowBarriers First, FlowBarriers Second) CreatePair()
+        {
+            var first = new FlowBarriers();
+            var second = new FlowBarriers();
+            first._other = second;
+            second._other = first;
+
+            return (first, second);
+        }
+
+        public Task EveryFlowHasPushed()
+        {
+            _pushed.SetResult();
+            return _other._pushed.Task;
+        }
+
+        public Task EveryFlowHasRead()
+        {
+            _read.SetResult();
+            return _other._read.Task;
         }
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/AmbientScopeStackTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/AmbientScopeStackTests.cs
@@ -29,23 +29,40 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
             IScope scopeB = Mock.Of<IScope>();
             var pushedA = new TaskCompletionSource();
             var pushedB = new TaskCompletionSource();
+            var readA = new TaskCompletionSource();
+            var readB = new TaskCompletionSource();
 
-            async Task<IScope?> PushThenReadAmbient(IScope scope, TaskCompletionSource pushed, Task otherPushed)
+            // Two barriers, both load-bearing. Every flow pushes before any flow reads, so a shared stack yields
+            // the wrong entry to at least one of them. Every flow also reads before any flow pops, otherwise a pop
+            // could remove the other flow's entry first and leave the remaining read coincidentally correct.
+            async Task<IScope?> RunFlow(
+                IScope scope,
+                TaskCompletionSource pushed,
+                Task otherPushed,
+                TaskCompletionSource read,
+                Task otherRead)
             {
                 sut.Push(scope);
                 pushed.SetResult();
                 await otherPushed;
-                return sut.AmbientScope;
+
+                IScope? ambientScope = sut.AmbientScope;
+                read.SetResult();
+                await otherRead;
+
+                sut.Pop();
+                return ambientScope;
             }
 
             IScope?[] ambient = await Task.WhenAll(
-                Task.Run(() => PushThenReadAmbient(scopeA, pushedA, pushedB.Task)),
-                Task.Run(() => PushThenReadAmbient(scopeB, pushedB, pushedA.Task)));
+                Task.Run(() => RunFlow(scopeA, pushedA, pushedB.Task, readA, readB.Task)),
+                Task.Run(() => RunFlow(scopeB, pushedB, pushedA.Task, readB, readA.Task)));
 
             Assert.Multiple(() =>
             {
                 Assert.AreSame(scopeA, ambient[0], "Flow A observed another flow's ambient scope.");
                 Assert.AreSame(scopeB, ambient[1], "Flow B observed another flow's ambient scope.");
+                Assert.IsNull(sut.AmbientScope, "A scope pushed in a branching flow leaked into the calling context.");
             });
         }
 
@@ -101,26 +118,37 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
             IScopeContext contextB = Mock.Of<IScopeContext>();
             var pushedA = new TaskCompletionSource();
             var pushedB = new TaskCompletionSource();
+            var readA = new TaskCompletionSource();
+            var readB = new TaskCompletionSource();
 
-            async Task<IScopeContext?> PushThenReadAmbient(
+            async Task<IScopeContext?> RunFlow(
                 IScopeContext context,
                 TaskCompletionSource pushed,
-                Task otherPushed)
+                Task otherPushed,
+                TaskCompletionSource read,
+                Task otherRead)
             {
                 sut.Push(context);
                 pushed.SetResult();
                 await otherPushed;
-                return sut.AmbientContext;
+
+                IScopeContext? ambientContext = sut.AmbientContext;
+                read.SetResult();
+                await otherRead;
+
+                sut.Pop();
+                return ambientContext;
             }
 
             IScopeContext?[] ambient = await Task.WhenAll(
-                Task.Run(() => PushThenReadAmbient(contextA, pushedA, pushedB.Task)),
-                Task.Run(() => PushThenReadAmbient(contextB, pushedB, pushedA.Task)));
+                Task.Run(() => RunFlow(contextA, pushedA, pushedB.Task, readA, readB.Task)),
+                Task.Run(() => RunFlow(contextB, pushedB, pushedA.Task, readB, readA.Task)));
 
             Assert.Multiple(() =>
             {
                 Assert.AreSame(contextA, ambient[0], "Flow A observed another flow's ambient context.");
                 Assert.AreSame(contextB, ambient[1], "Flow B observed another flow's ambient context.");
+                Assert.IsNull(sut.AmbientContext, "A context pushed in a branching flow leaked into the calling context.");
             });
         }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/AmbientScopeStackTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/AmbientScopeStackTests.cs
@@ -1,0 +1,153 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
+using IScope = Umbraco.Cms.Infrastructure.Scoping.IScope;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
+{
+    [TestFixture]
+    public class AmbientScopeStackTests
+    {
+        [Test]
+        public async Task Push_IsolatesConcurrentFlowsThatInheritedAnEmptyStack()
+        {
+            var sut = new AmbientScopeStack();
+
+            while (sut.AmbientScope is not null)
+            {
+                sut.Pop();
+            }
+
+            // Any scope used before hosted services start leaves a non-null but empty stack on the execution
+            // context. Every flow branching off that context inherits the same instance, because AsyncLocal
+            // copy-on-write protects the reference, not the object it points at.
+            sut.Push(Mock.Of<IScope>());
+            sut.Pop();
+
+            IScope scopeA = Mock.Of<IScope>();
+            IScope scopeB = Mock.Of<IScope>();
+            var pushedA = new TaskCompletionSource();
+            var pushedB = new TaskCompletionSource();
+
+            async Task<IScope?> PushThenReadAmbient(IScope scope, TaskCompletionSource pushed, Task otherPushed)
+            {
+                sut.Push(scope);
+                pushed.SetResult();
+                await otherPushed;
+                return sut.AmbientScope;
+            }
+
+            IScope?[] ambient = await Task.WhenAll(
+                Task.Run(() => PushThenReadAmbient(scopeA, pushedA, pushedB.Task)),
+                Task.Run(() => PushThenReadAmbient(scopeB, pushedB, pushedA.Task)));
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreSame(scopeA, ambient[0], "Flow A observed another flow's ambient scope.");
+                Assert.AreSame(scopeB, ambient[1], "Flow B observed another flow's ambient scope.");
+            });
+        }
+
+        [Test]
+        public void Push_KeepsNestedScopesOnTheSameStack()
+        {
+            var sut = new AmbientScopeStack();
+
+            while (sut.AmbientScope is not null)
+            {
+                sut.Pop();
+            }
+
+            IScope outer = Mock.Of<IScope>();
+            IScope inner = Mock.Of<IScope>();
+
+            sut.Push(outer);
+            sut.Push(inner);
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreSame(inner, sut.AmbientScope);
+                Assert.AreSame(inner, sut.Pop());
+                Assert.AreSame(outer, sut.AmbientScope);
+                Assert.AreSame(outer, sut.Pop());
+                Assert.IsNull(sut.AmbientScope);
+            });
+        }
+    }
+
+    /// <summary>
+    /// The scope context stack shares the defect and the fix of <see cref="AmbientScopeStack" />. It is covered
+    /// separately because isolating only the scope stack moves the corruption here: scopes that stop being wrongly
+    /// treated as nested start pushing a context of their own, onto a stack that is still shared between flows.
+    /// </summary>
+    [TestFixture]
+    public class AmbientScopeContextStackTests
+    {
+        [Test]
+        public async Task Push_IsolatesConcurrentFlowsThatInheritedAnEmptyStack()
+        {
+            var sut = new AmbientScopeContextStack();
+
+            while (sut.AmbientContext is not null)
+            {
+                sut.Pop();
+            }
+
+            sut.Push(Mock.Of<IScopeContext>());
+            sut.Pop();
+
+            IScopeContext contextA = Mock.Of<IScopeContext>();
+            IScopeContext contextB = Mock.Of<IScopeContext>();
+            var pushedA = new TaskCompletionSource();
+            var pushedB = new TaskCompletionSource();
+
+            async Task<IScopeContext?> PushThenReadAmbient(
+                IScopeContext context,
+                TaskCompletionSource pushed,
+                Task otherPushed)
+            {
+                sut.Push(context);
+                pushed.SetResult();
+                await otherPushed;
+                return sut.AmbientContext;
+            }
+
+            IScopeContext?[] ambient = await Task.WhenAll(
+                Task.Run(() => PushThenReadAmbient(contextA, pushedA, pushedB.Task)),
+                Task.Run(() => PushThenReadAmbient(contextB, pushedB, pushedA.Task)));
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreSame(contextA, ambient[0], "Flow A observed another flow's ambient context.");
+                Assert.AreSame(contextB, ambient[1], "Flow B observed another flow's ambient context.");
+            });
+        }
+
+        [Test]
+        public void Push_KeepsNestedContextsOnTheSameStack()
+        {
+            var sut = new AmbientScopeContextStack();
+
+            while (sut.AmbientContext is not null)
+            {
+                sut.Pop();
+            }
+
+            IScopeContext outer = Mock.Of<IScopeContext>();
+            IScopeContext inner = Mock.Of<IScopeContext>();
+
+            sut.Push(outer);
+            sut.Push(inner);
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreSame(inner, sut.AmbientContext);
+                Assert.AreSame(inner, sut.Pop());
+                Assert.AreSame(outer, sut.AmbientContext);
+                Assert.AreSame(outer, sut.Pop());
+                Assert.IsNull(sut.AmbientContext);
+            });
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/AmbientScopeStackTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/AmbientScopeStackTests.cs
@@ -6,154 +6,122 @@ using IScope = Umbraco.Cms.Infrastructure.Scoping.IScope;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 {
-    [TestFixture]
-    public class AmbientScopeStackTests
+    /// <summary>
+    /// Both ambient stacks keep their state in a static <see cref="AsyncLocal{T}" /> and share the same defect and
+    /// the same fix, so they share these tests. They expose no common interface, so each concrete stack is reached
+    /// through the abstract members below.
+    /// </summary>
+    /// <typeparam name="TItem">The type the stack holds.</typeparam>
+    public abstract class AmbientStackTestsBase<TItem>
+        where TItem : class
     {
         [Test]
         public async Task Push_IsolatesConcurrentFlowsThatInheritedAnEmptyStack()
         {
-            var sut = new AmbientScopeStack();
-
-            while (sut.AmbientScope is not null)
-            {
-                sut.Pop();
-            }
+            Drain();
 
             // Any scope used before hosted services start leaves a non-null but empty stack on the execution
             // context. Every flow branching off that context inherits the same instance, because AsyncLocal
             // copy-on-write protects the reference, not the object it points at.
-            sut.Push(Mock.Of<IScope>());
-            sut.Pop();
+            Push(CreateItem());
+            Pop();
 
-            IScope scopeA = Mock.Of<IScope>();
-            IScope scopeB = Mock.Of<IScope>();
+            TItem itemA = CreateItem();
+            TItem itemB = CreateItem();
             (FlowBarriers barriersA, FlowBarriers barriersB) = FlowBarriers.CreatePair();
 
-            async Task<IScope?> RunFlow(IScope scope, FlowBarriers barriers)
+            async Task<TItem?> RunFlow(TItem item, FlowBarriers barriers)
             {
-                sut.Push(scope);
+                Push(item);
                 await barriers.EveryFlowHasPushed();
 
-                IScope? ambientScope = sut.AmbientScope;
+                TItem? ambient = Peek();
                 await barriers.EveryFlowHasRead();
 
-                sut.Pop();
-                return ambientScope;
+                Pop();
+                return ambient;
             }
 
-            IScope?[] ambient = await Task.WhenAll(
-                Task.Run(() => RunFlow(scopeA, barriersA)),
-                Task.Run(() => RunFlow(scopeB, barriersB)));
+            TItem?[] ambient = await Task.WhenAll(
+                Task.Run(() => RunFlow(itemA, barriersA)),
+                Task.Run(() => RunFlow(itemB, barriersB)));
 
             Assert.Multiple(() =>
             {
-                Assert.AreSame(scopeA, ambient[0], "Flow A observed another flow's ambient scope.");
-                Assert.AreSame(scopeB, ambient[1], "Flow B observed another flow's ambient scope.");
-                Assert.IsNull(sut.AmbientScope, "A scope pushed in a branching flow leaked into the calling context.");
+                Assert.AreSame(itemA, ambient[0], "Flow A observed another flow's ambient entry.");
+                Assert.AreSame(itemB, ambient[1], "Flow B observed another flow's ambient entry.");
+                Assert.IsNull(Peek(), "An entry pushed in a branching flow leaked into the calling context.");
             });
         }
 
         [Test]
-        public void Push_KeepsNestedScopesOnTheSameStack()
+        public void Push_KeepsNestedEntriesOnTheSameStack()
         {
-            var sut = new AmbientScopeStack();
+            Drain();
 
-            while (sut.AmbientScope is not null)
-            {
-                sut.Pop();
-            }
+            TItem outer = CreateItem();
+            TItem inner = CreateItem();
 
-            IScope outer = Mock.Of<IScope>();
-            IScope inner = Mock.Of<IScope>();
-
-            sut.Push(outer);
-            sut.Push(inner);
+            Push(outer);
+            Push(inner);
 
             Assert.Multiple(() =>
             {
-                Assert.AreSame(inner, sut.AmbientScope);
-                Assert.AreSame(inner, sut.Pop());
-                Assert.AreSame(outer, sut.AmbientScope);
-                Assert.AreSame(outer, sut.Pop());
-                Assert.IsNull(sut.AmbientScope);
+                Assert.AreSame(inner, Peek());
+                Assert.AreSame(inner, Pop());
+                Assert.AreSame(outer, Peek());
+                Assert.AreSame(outer, Pop());
+                Assert.IsNull(Peek());
             });
+        }
+
+        protected abstract TItem? Peek();
+
+        protected abstract void Push(TItem item);
+
+        protected abstract TItem Pop();
+
+        protected abstract TItem CreateItem();
+
+        /// <summary>
+        /// The stack is held in a static <see cref="AsyncLocal{T}" />, so a synchronous test can observe entries
+        /// left behind by an earlier one.
+        /// </summary>
+        private void Drain()
+        {
+            while (Peek() is not null)
+            {
+                Pop();
+            }
         }
     }
 
-    /// <summary>
-    /// The scope context stack shares the defect and the fix of <see cref="AmbientScopeStack" />. It is covered
-    /// separately because isolating only the scope stack moves the corruption here: scopes that stop being wrongly
-    /// treated as nested start pushing a context of their own, onto a stack that is still shared between flows.
-    /// </summary>
     [TestFixture]
-    public class AmbientScopeContextStackTests
+    public class AmbientScopeStackTests : AmbientStackTestsBase<IScope>
     {
-        [Test]
-        public async Task Push_IsolatesConcurrentFlowsThatInheritedAnEmptyStack()
-        {
-            var sut = new AmbientScopeContextStack();
+        private readonly AmbientScopeStack _sut = new();
 
-            while (sut.AmbientContext is not null)
-            {
-                sut.Pop();
-            }
+        protected override IScope? Peek() => _sut.AmbientScope;
 
-            sut.Push(Mock.Of<IScopeContext>());
-            sut.Pop();
+        protected override void Push(IScope item) => _sut.Push(item);
 
-            IScopeContext contextA = Mock.Of<IScopeContext>();
-            IScopeContext contextB = Mock.Of<IScopeContext>();
-            (FlowBarriers barriersA, FlowBarriers barriersB) = FlowBarriers.CreatePair();
+        protected override IScope Pop() => _sut.Pop();
 
-            async Task<IScopeContext?> RunFlow(IScopeContext context, FlowBarriers barriers)
-            {
-                sut.Push(context);
-                await barriers.EveryFlowHasPushed();
+        protected override IScope CreateItem() => Mock.Of<IScope>();
+    }
 
-                IScopeContext? ambientContext = sut.AmbientContext;
-                await barriers.EveryFlowHasRead();
+    [TestFixture]
+    public class AmbientScopeContextStackTests : AmbientStackTestsBase<IScopeContext>
+    {
+        private readonly AmbientScopeContextStack _sut = new();
 
-                sut.Pop();
-                return ambientContext;
-            }
+        protected override IScopeContext? Peek() => _sut.AmbientContext;
 
-            IScopeContext?[] ambient = await Task.WhenAll(
-                Task.Run(() => RunFlow(contextA, barriersA)),
-                Task.Run(() => RunFlow(contextB, barriersB)));
+        protected override void Push(IScopeContext item) => _sut.Push(item);
 
-            Assert.Multiple(() =>
-            {
-                Assert.AreSame(contextA, ambient[0], "Flow A observed another flow's ambient context.");
-                Assert.AreSame(contextB, ambient[1], "Flow B observed another flow's ambient context.");
-                Assert.IsNull(sut.AmbientContext, "A context pushed in a branching flow leaked into the calling context.");
-            });
-        }
+        protected override IScopeContext Pop() => _sut.Pop();
 
-        [Test]
-        public void Push_KeepsNestedContextsOnTheSameStack()
-        {
-            var sut = new AmbientScopeContextStack();
-
-            while (sut.AmbientContext is not null)
-            {
-                sut.Pop();
-            }
-
-            IScopeContext outer = Mock.Of<IScopeContext>();
-            IScopeContext inner = Mock.Of<IScopeContext>();
-
-            sut.Push(outer);
-            sut.Push(inner);
-
-            Assert.Multiple(() =>
-            {
-                Assert.AreSame(inner, sut.AmbientContext);
-                Assert.AreSame(inner, sut.Pop());
-                Assert.AreSame(outer, sut.AmbientContext);
-                Assert.AreSame(outer, sut.Pop());
-                Assert.IsNull(sut.AmbientContext);
-            });
-        }
+        protected override IScopeContext CreateItem() => Mock.Of<IScopeContext>();
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

All three ambient scope stacks share a `ConcurrentStack` instance between unrelated execution flows, so concurrently-running hosted services can observe each other's ambient scope. When that happens `Scope.Dispose()` throws before it releases anything, stranding the transaction and whatever distributed lock it held until the process restarts.

Related: #23366, which reports the same defect becoming reachable after #22331.

#### Root cause

`Push` does `(_stack.Value ??= new ConcurrentStack<IScope>()).Push(scope)`, and `Pop` never resets `_stack.Value` to `null` — popping the last entry leaves the instance in place. So the first scope used on any execution context leaves behind a **non-null but empty** stack.

`AsyncLocal` copy-on-write protects the *reference*, not the instance it points at. Every flow that later branches off that context therefore inherits and mutates the **same** `ConcurrentStack`. Because a `ConcurrentStack` is globally LIFO rather than per-flow, pushes and pops from unrelated hosted services interleave.

This is why the failure is timing-sensitive. If `_stack.Value` happens to be `null` when a service starts, that service allocates its own stack and behaves correctly; if something had already used a scope on that context — `DistributedJobService.EnsureJobsAsync` during start-up, for instance — it silently shares.

#### Why a failed dispose strands the lock

When the mismatch is detected, `Scope.Dispose()` throws *before* `Locks.ClearLocks(InstanceId)`, before `Locks.EnsureLocksCleared(InstanceId)`, and before `_scopeProvider.PopAmbientScope()`. So a failed dispose leaves the locks held, the transaction uncompleted, **and** the stack still corrupted for everything that follows. On SQL Server that strands the lock row; on SQLite it leaves an open write transaction.

There is a quieter second symptom. `Scope.Database` fetches the *parent's* database when `ParentScope != null` and calls `GetCurrentTransactionIsolationLevel()`, which touches `Transaction.IsolationLevel`. A scope wrongly parented to a foreign scope whose transaction has since completed throws `InvalidOperationException: This SqlTransaction has completed`. Worth noting because such a scope also does not own its transaction, so its `scope.Complete()` becomes a no-op against the real one — a correctness exposure, not only a liveness one.

#### All three stacks need the fix

```
src/Umbraco.Infrastructure/Scoping/AmbientScopeStack.cs
src/Umbraco.Infrastructure/Scoping/AmbientScopeContextStack.cs
src/Umbraco.Cms.Persistence.EFCore/Scoping/AmbientEFCoreScopeStack.cs
```

**A partial fix is worse than no fix.** We deployed a build with only `AmbientScopeStack` fixed to an affected production site and immediately got a new exception:

```
System.InvalidOperationException: No AmbientContext was found.
   at Umbraco.Cms.Infrastructure.Scoping.AmbientScopeContextStack.Pop()
   at Umbraco.Cms.Persistence.EFCore.Scoping.EFCoreScopeProvider`1.PopAmbientScopeContext()
   at Umbraco.Cms.Persistence.EFCore.Scoping.EFCoreScope`1.HandleScopeContext()
   at Umbraco.Cms.Persistence.EFCore.Scoping.EFCoreScope`1.Dispose()
   at ...AIUsageHourlyAggregationJob.ProcessMissingHoursAsync()
   at Umbraco.Cms.Infrastructure.HostedServices.RecurringHostedServiceBase.ExecuteAsync()
```

Whether a scope pushes a scope *context* depends on whether it sees an ambient scope. Before the fix, flows sharing a stack wrongly saw each other's scopes and became nested children, which do not push a context. Once the scope stack is isolated those scopes correctly become root scopes and start pushing contexts of their own — onto a context stack that is *still* shared between flows. They then pop each other's entries until one finds it empty and throws. The corruption moves one layer down rather than disappearing.

#### The change

Identical in all three: when the inherited stack is empty there is no genuine nesting to preserve, so allocating a fresh one lets `AsyncLocal` copy-on-write isolate the flow. A non-empty stack is real nesting within the same flow and is kept, so a child scope still nests under the current ambient one.

```csharp
ConcurrentStack<IScope>? stack = _stack.Value;

if (stack is null || stack.IsEmpty)
{
    stack = new ConcurrentStack<IScope>();
    _stack.Value = stack;
}

stack.Push(scope);
```

#### Why not restore `ExecutionContext.SuppressFlow()` instead

#22331 removed `SuppressFlow` from `RecurringHostedServiceBase` and simultaneously added an equivalent to `RecurringBackgroundJobHostedService.StartAsync`. The protection was relocated rather than deleted, so the `IRecurringBackgroundJob` wrapper stayed safe while external subclasses of the public `RecurringHostedServiceBase` lost protection they had in 17.4.

Restoring it there would close that regression, but it is not sufficient:

- `DistributedBackgroundJobHostedService` has **never** had `SuppressFlow` in any version, including current `main`, and it participates in most of the traces we collected.
- `AmbientScopeStack.cs` is byte-identical across `release-17.4.2`, `release-17.5.3` and `main`, so the defect is version-invariant rather than a regression.

Fixing the stacks covers every caller at once, including third-party hosted services, instead of requiring each entry point to remember to suppress flow. It is also the only option available to affected sites, since `IAmbientScopeStack` and `AmbientScopeContextStack` are `internal` — the DI registration cannot be overridden from a consumer project, so there is no supported workaround.

#### Affected versions

Confirmed in production on 17.5.2 and 17.5.3, and present unchanged on `main`. This PR targets `main` per the contributing guide, but it cherry-picks cleanly to the v17 branches:

- `AmbientScopeStack.cs` and `AmbientScopeContextStack.cs` are byte-identical between `main` and `v17/dev`.
- `AmbientEFCoreScopeStack.cs` differs only by the `IEfCoreScope` → `IEFCoreScope` rename, so the v17 variant needs the lower-case spelling in both the fix and the new test.

### How to test

Run the new tests:

```bash
dotnet test tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj --filter "FullyQualifiedName~AmbientScope"
dotnet test tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj --filter "FullyQualifiedName~AmbientEFCoreScopeStackTests"
```

To confirm the tests actually catch the defect, revert the three `Push` methods to `_stack.Value ??= new ConcurrentStack<…>()` and re-run. Each stack has one isolation test that fails and one nesting guard that passes either way, so the guards cannot mask an over-correction:

| Run | Without the fix | With the fix |
|---|---|---|
| Unit, `~AmbientScope` | Failed 2, Passed 2 | Passed 4 |
| Integration, EF Core stack | Failed 1, Passed 1 | Passed 2 |

Each isolation test reproduces the defect deterministically: it leaves a non-null empty stack on the execution context, starts two flows from it, has both push and wait for each other, then asserts each flow still sees its own entry as ambient.

Wider suites on this branch: **6,393 unit tests** and **106 scoping integration tests** passing, 0 failures (6 and 3 skipped respectively, unrelated).

For a real-world reproduction, run two hosted services concurrently — `DistributedBackgroundJobHostedService` plus any `RecurringHostedServiceBase` subclass that opens a scope — on a site where a scope was used during start-up. Before the fix, one of them eventually throws `"The Scope … is not the Ambient Scope …"` from `Scope.Dispose()`, after which every server polling the `-347` DistributedJobs lock times out every few seconds indefinitely, because the poll interval and the write-lock timeout are both 5 seconds.

Fixes #23336