### PR TITLE
Auth: Do not treat a boot-time token refresh rejection as a session timeout (closes #23462)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.test.ts
@@ -205,6 +205,12 @@ describe('UmbAuthContext', () => {
 
 		it('times the user out on a definitive invalid_grant failure', async () => {
 			fetchResponder = invalidGrantResponse;
+
+			// A peer tab establishes the session that is about to be rejected
+			const now = Math.floor(Date.now() / 1000);
+			channel.postMessage({ type: 'sessionUpdate', accessTokenExpiresAt: now + 60, expiresAt: now + 240 });
+			await aTimeout(50);
+
 			let timeOutCalls = 0;
 			context.timeOut = () => {
 				timeOutCalls++;
@@ -213,6 +219,19 @@ describe('UmbAuthContext', () => {
 			await context.validateToken();
 
 			expect(timeOutCalls).to.equal(1);
+		});
+
+		it('does not time the user out when there was no session to lose', async () => {
+			fetchResponder = invalidGrantResponse;
+			let timeOutCalls = 0;
+			context.timeOut = () => {
+				timeOutCalls++;
+			};
+
+			await context.setInitialState();
+
+			expect(timeOutCalls).to.equal(0);
+			expect(context.getIsAuthorized()).to.be.false;
 		});
 
 		it('retries /token after a transient network failure', async () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -518,13 +518,18 @@ export class UmbAuthContext extends UmbContextBase {
 
 	/**
 	 * Performs the actual refresh request and applies the result.
-	 * A definitive rejection (e.g. `invalid_grant`) marks the session as dead and times the
-	 * user out, so the re-authentication flow starts instead of every subsequent API request
-	 * firing its own doomed refresh attempt. Transient failures (network errors, 5xx) leave
-	 * the session state untouched so a later attempt can retry.
+	 * A definitive rejection (e.g. `invalid_grant`) marks the session as dead, so every
+	 * subsequent API request does not fire its own doomed refresh attempt. When the rejected
+	 * refresh belonged to an established session, the user is also timed out so the
+	 * re-authentication flow starts. Transient failures (network errors, 5xx) leave the
+	 * session state untouched so a later attempt can retry.
 	 * @returns {Promise<boolean>} True if the refresh succeeded, otherwise false.
 	 */
 	async #performRefresh(): Promise<boolean> {
+		// A rejection with no session in hand means nobody is signed in — not that a session
+		// expired. Timing out there re-authenticates in a popup and leaves the caller to
+		// navigate, where a cold boot needs the ordinary login redirect.
+		const hadSession = !!this.#session.getValue();
 		const result = await this.#client.refreshToken();
 		if (result.response) {
 			this.#updateSession(result.response.expiresIn, result.response.issuedAt);
@@ -532,7 +537,9 @@ export class UmbAuthContext extends UmbContextBase {
 		}
 		if (result.fatal) {
 			this.#sessionDead = true;
-			this.timeOut();
+			if (hadSession) {
+				this.timeOut();
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
## What

Fixes #23462 — a 17.6.0-rc regression where signing out lands you on a "Your session has timed out" screen, and signing in from there never returns you to the backoffice.

Targeting `release/17.6` because the regression is only on that line (introduced by #23079, which is in `17.6.0-rc` but not in `17.5.3`), so it would otherwise ship in 17.6.0.

## Why it happens

Sign-out sends the browser to `/umbraco/logout`, a full page load, so the app boots and runs its normal session probe (`setInitialState()` → `/token`, `grant_type=refresh_token`). There is no cookie any more, so OpenIddict answers `400 {"error":"invalid_grant"}` — and since #23079, `#performRefresh()` treats *any* definitive rejection as an expired session and calls `timeOut()`, even when there was no session in the first place.

Both reported symptoms follow from that one call:

1. `timeoutSignal` makes `UmbAppAuthController` open the login modal in `timedOut` state — hence the "Your session has timed out" wording on a deliberate sign-out.
2. The `timedOut` state deliberately re-authenticates in a **popup** rather than redirecting, so a timed-out editor does not lose unsaved work, and on success it only closes the modal — navigation is the caller's job. Here the caller is the timeout observer, and the `logout` route has no auth guard, so nothing navigates. The popup closes and you are left on `/umbraco/logout`.

Two things kept this quiet:

- An ordinary cold-boot login is unaffected, because on the wildcard route the auth guard fires its full-page login redirect immediately and wins the race against the 1s `auditTime` on `timeoutSignal`. Only the guard-less routes (`logout`, `error`, and the redirect-flow `oauth_complete`) are exposed.
- `BackOfficeLogout.spec.ts` asserts the landing URL, then re-navigates to `/umbraco` and asserts the login page — it never signs in *from* the landing page.

## The fix

`#performRefresh()` only times the user out when a session actually existed. A rejected refresh with nothing in hand means nobody is signed in, which the ordinary login redirect already handles. #23079's actual fix (live session, rejected refresh → time out) and the `#sessionDead` latch are untouched.

This restores the pre-17.6 behaviour on the sign-out landing page, and it is the same distinction the v19 cookie-auth work (#23484) makes explicitly: a cold boot has nothing to preserve and takes the full-page redirect, while a timed-out session gets the modal and the popup.

## Testing

- New unit test `does not time the user out when there was no session to lose` fails before the fix (`expected 1 to equal 0`) and passes after.
- Corrected the existing `times the user out on a definitive invalid_grant failure` test: it asserted the timeout with *no session established*, which is exactly why it did not catch this. It now seeds a session via the `sessionUpdate` broadcast first, matching the #22986 scenario it exists for.
- Full client suite green (2557 passed, 0 failed across 348 files). No new lint warnings.
- Verified in a browser against a real backend with the production client build: with the pre-fix bundle the reported screen reproduces exactly; with the fix, sign-out lands on the ordinary login screen, sign-in does a full-page redirect and ends up in the backoffice. Cold-boot login unchanged.
- Checked the genuine timeout still fires: revoked the refresh token in SQLite under a live session, then made an API call — the timeout modal still appears, over the backoffice as intended.

## Follow-up

`main` (v18) carries the identical `#performRefresh`, so it needs this on the merge-up. v19's cookie-auth branch removes the machinery entirely, so nothing to do there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
