### PR TITLE
Tiptap RTE: Load configured stylesheets regardless of extension styles (closes #21819)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -26,11 +26,7 @@ import '../statusbar/tiptap-statusbar.element.js';
 
 const TIPTAP_CORE_EXTENSION_ALIAS = 'Umb.Tiptap.RichTextEssentials';
 
-/**
- * The default root path for the stylesheets on the server.
- * This is used as a fallback if the server configuration is not available.
- */
-const DEFAULT_STYLESHEET_ROOT_PATH = '/css';
+const RTE_CONTENT_STYLESHEET = '/umbraco/backoffice/css/rte-content.css';
 
 @customElement('umb-input-tiptap')
 export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof UmbLitElement, string>(UmbLitElement) {
@@ -39,8 +35,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	#hasToolbar = false;
 
 	#hasStatusbar = false;
-
-	#stylesheetRootPath = DEFAULT_STYLESHEET_ROOT_PATH;
 
 	@property({ type: String })
 	override set value(value: string) {
@@ -80,7 +74,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	readonly = false;
 
 	@state()
-	private _stylesheets = new Set(['/umbraco/backoffice/css/rte-content.css']);
+	private _stylesheets = new Set([RTE_CONTENT_STYLESHEET]);
 
 	@state()
 	private _editor?: Editor;
@@ -108,8 +102,8 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	}
 
 	protected override async firstUpdated() {
-		// no need to await loading of the stylesheet.
-		this.#loadStylesheetPath();
+		// no need to await observing the stylesheet root path.
+		this.#observeStylesheetRootPath();
 		await this.#loadExtensions();
 		await this.#loadEditor();
 	}
@@ -129,26 +123,25 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		return this._editor?.isEmpty ?? false;
 	}
 
-	async #loadStylesheetPath() {
-		await this.observe(this.#context.stylesheetRootPath, (stylesheetRootPath) => {
-			if (stylesheetRootPath) {
-				this.#stylesheetRootPath = stylesheetRootPath;
-			}
-		}).asPromise();
+	#observeStylesheetRootPath() {
+		this.observe(this.#context.stylesheetRootPath, (stylesheetRootPath) => {
+			if (stylesheetRootPath === undefined) return;
+			this.#applyConfiguredStylesheets(stylesheetRootPath);
+		});
+	}
 
+	#applyConfiguredStylesheets(rootPath: string) {
 		const stylesheets = this.configuration?.getValueByAlias<Array<string>>('stylesheets');
-		if (stylesheets?.length) {
-			const linkHrefs = stylesheets.map((stylesheet) =>
-				stylesheet.startsWith('http') || stylesheet.startsWith(this.#stylesheetRootPath)
-					? stylesheet
-					: `${this.#stylesheetRootPath}${stylesheet}`,
-			);
+		if (!stylesheets?.length) return;
 
-			// Reassign a new Set so Lit's `@state()` identity check detects the change and re-renders;
-			// `Set.add()` would mutate in place and the configured stylesheets could be missed if the
-			// editor finishes loading before this (parallel) path resolves.
-			this._stylesheets = new Set([...this._stylesheets, ...linkHrefs]);
-		}
+		const linkHrefs = stylesheets.map((stylesheet) =>
+			stylesheet.startsWith('http') || stylesheet.startsWith(rootPath) ? stylesheet : `${rootPath}${stylesheet}`,
+		);
+
+		// Reassign a new Set so Lit's `@state()` identity check detects the change and re-renders;
+		// `Set.add()` would mutate in place and the configured stylesheets could be missed if the
+		// editor finishes loading before this (parallel) path resolves.
+		this._stylesheets = new Set([RTE_CONTENT_STYLESHEET, ...linkHrefs]);
 	}
 
 	async #loadExtensions() {
@@ -257,16 +250,20 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	}
 
 	#renderStyles() {
-		if (!this._extensionStyles) return;
 		return html`
 			${repeat(
 				this._stylesheets,
 				(stylesheet) => stylesheet,
 				(stylesheet) => html`<link rel="stylesheet" href=${stylesheet} />`,
 			)}
-			<style>
-				${this._extensionStyles}
-			</style>
+			${when(
+				this._extensionStyles,
+				(styles) => html`
+					<style>
+						${styles}
+					</style>
+				`,
+			)}
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -30,7 +30,7 @@ const RTE_CONTENT_STYLESHEET = '/umbraco/backoffice/css/rte-content.css';
 
 @customElement('umb-input-tiptap')
 export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof UmbLitElement, string>(UmbLitElement) {
-	#context = new UmbTiptapRteContext(this);
+	readonly #context = new UmbTiptapRteContext(this);
 
 	#hasToolbar = false;
 
@@ -126,20 +126,15 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	#observeStylesheetRootPath() {
 		this.observe(this.#context.stylesheetRootPath, (stylesheetRootPath) => {
 			if (stylesheetRootPath === undefined) return;
-			this.#applyConfiguredStylesheets(stylesheetRootPath);
+			this.#applyConfiguredStylesheets();
 		});
 	}
 
-	#applyConfiguredStylesheets(rootPath: string) {
+	#applyConfiguredStylesheets() {
 		const stylesheets = this.configuration?.getValueByAlias<Array<string>>('stylesheets');
 		if (!stylesheets?.length) return;
 
-		const serverUrl = this.#context.getServerUrl();
-		const linkHrefs = stylesheets.map((stylesheet) => {
-			if (stylesheet.startsWith('http') || stylesheet.startsWith('//')) return stylesheet;
-			const relativeHref = stylesheet.startsWith(rootPath) ? stylesheet : `${rootPath}${stylesheet}`;
-			return `${serverUrl}${relativeHref}`;
-		});
+		const linkHrefs = stylesheets.map((stylesheet) => this.#context.resolveStylesheetHref(stylesheet));
 
 		// Reassign a new Set so Lit's `@state()` identity check detects the change and re-renders;
 		// `Set.add()` would mutate in place and the configured stylesheets could be missed if the

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -134,9 +134,12 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		const stylesheets = this.configuration?.getValueByAlias<Array<string>>('stylesheets');
 		if (!stylesheets?.length) return;
 
-		const linkHrefs = stylesheets.map((stylesheet) =>
-			stylesheet.startsWith('http') || stylesheet.startsWith(rootPath) ? stylesheet : `${rootPath}${stylesheet}`,
-		);
+		const serverUrl = this.#context.getServerUrl();
+		const linkHrefs = stylesheets.map((stylesheet) => {
+			if (stylesheet.startsWith('http')) return stylesheet;
+			const relativeHref = stylesheet.startsWith(rootPath) ? stylesheet : `${rootPath}${stylesheet}`;
+			return `${serverUrl}${relativeHref}`;
+		});
 
 		// Reassign a new Set so Lit's `@state()` identity check detects the change and re-renders;
 		// `Set.add()` would mutate in place and the configured stylesheets could be missed if the

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -136,7 +136,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 		const serverUrl = this.#context.getServerUrl();
 		const linkHrefs = stylesheets.map((stylesheet) => {
-			if (stylesheet.startsWith('http')) return stylesheet;
+			if (stylesheet.startsWith('http') || stylesheet.startsWith('//')) return stylesheet;
 			const relativeHref = stylesheet.startsWith(rootPath) ? stylesheet : `${rootPath}${stylesheet}`;
 			return `${serverUrl}${relativeHref}`;
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
@@ -58,12 +58,12 @@ describe('UmbInputTiptapElement (stylesheets)', () => {
 		provider?.hostDisconnected();
 	});
 
-	async function renderElement(cssPath: string | undefined, serverUrl = '') {
+	async function renderElement(cssPath: string | undefined, serverUrl = '', stylesheets: Array<string> = ['/rte-test.css']) {
 		stubServerContext(cssPath, serverUrl);
 
 		const config = new UmbPropertyEditorConfigCollection([
 			{ alias: 'extensions', value: ['Umb.Tiptap.Bold', 'Umb.Tiptap.Italic'] },
-			{ alias: 'stylesheets', value: ['/rte-test.css'] },
+			{ alias: 'stylesheets', value: stylesheets },
 		]);
 
 		const element = await fixture<UmbInputTiptapElement>(html`
@@ -102,5 +102,13 @@ describe('UmbInputTiptapElement (stylesheets)', () => {
 		// The base RTE stylesheet is a client-bundled asset (served by Vite itself in dev),
 		// so it must stay origin-relative rather than being prefixed with the server URL.
 		expect(hrefs).to.include('/umbraco/backoffice/css/rte-content.css');
+	});
+
+	it('does not double up the root path when a configured stylesheet already includes it, and still resolves against the server origin', async function () {
+		this.timeout(20000);
+		const hrefs = await renderElement('/mycss', 'https://localhost:44339', ['/mycss/already-prefixed.css']);
+
+		expect(hrefs).to.include('https://localhost:44339/mycss/already-prefixed.css');
+		expect(hrefs).not.to.include('https://localhost:44339/mycss/mycss/already-prefixed.css');
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
@@ -1,14 +1,19 @@
 import { UmbInputTiptapElement } from './input-tiptap.element.js';
-import { expect } from '@open-wc/testing';
+import { manifests as tiptapManifests } from '../../umbraco-package.js';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { UmbContextProvider } from '@umbraco-cms/backoffice/context-api';
+import { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
+import type { UmbServerContext } from '@umbraco-cms/backoffice/server';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { of } from '@umbraco-cms/backoffice/external/rxjs';
 
 describe('UmbInputTiptapElement (standalone)', () => {
 	// Proves that `<umb-input-tiptap>` is usable on its own — i.e. not gated on being
 	// rendered inside `<umb-property-editor-ui-tiptap>`. We deliberately don't mount
 	// the element here: mounting it spins up an `UmbTiptapRteContext` that consumes
-	// `UMB_SERVER_CONTEXT` (not provided in unit tests), and the pending context
-	// request would surface as an unhandled rejection after the fixture tears down.
-	// The visual end-to-end load path is covered by the Storybook stories instead;
-	// this just nails down the contract that standalone consumers depend on.
+	// `UMB_SERVER_CONTEXT`, so a mounted test has to provide a stub — see the
+	// 'stylesheets' suite below for that setup.
 
 	it('exports the element class so a standalone consumer can import it', () => {
 		expect(UmbInputTiptapElement).to.be.a('function');
@@ -16,5 +21,74 @@ describe('UmbInputTiptapElement (standalone)', () => {
 
 	it('registers the `umb-input-tiptap` custom element at module load time', () => {
 		expect(customElements.get('umb-input-tiptap')).to.equal(UmbInputTiptapElement);
+	});
+});
+
+describe('UmbInputTiptapElement (stylesheets)', () => {
+	// Regression coverage for #21819: a minimal extension configuration (no extension
+	// contributes `getStyles()`) must still load the configured stylesheets, not just
+	// Umbraco's own base RTE stylesheet.
+	//
+	// The first mount in this suite pays for a cold dynamic import of the shared
+	// `extension-apis.bundle` chunk (Tiptap core + 50+ extension APIs), which can take
+	// several seconds to transform on an uncached test run — hence the generous timeouts.
+
+	let provider: UmbContextProvider;
+
+	function stubServerContext(cssPath: string | undefined) {
+		const stub = {
+			getHostElement: () => document.body,
+			getServerConnection: () => ({ umbracoCssPath: of(cssPath) }),
+		} as unknown as UmbServerContext;
+		provider = new UmbContextProvider(document.body, UMB_SERVER_CONTEXT, stub);
+		provider.hostConnected();
+	}
+
+	before(() => {
+		umbExtensionsRegistry.registerMany(tiptapManifests);
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregisterMany(tiptapManifests.map((manifest) => manifest.alias));
+	});
+
+	afterEach(() => {
+		provider?.hostDisconnected();
+	});
+
+	async function renderElement(cssPath: string | undefined) {
+		stubServerContext(cssPath);
+
+		const config = new UmbPropertyEditorConfigCollection([
+			{ alias: 'extensions', value: ['Umb.Tiptap.Bold', 'Umb.Tiptap.Italic'] },
+			{ alias: 'stylesheets', value: ['/rte-test.css'] },
+		]);
+
+		const element = await fixture<UmbInputTiptapElement>(html`
+			<umb-input-tiptap .label=${'Rich Text Editor'} .configuration=${config}></umb-input-tiptap>
+		`);
+
+		await waitUntil(() => !!element.shadowRoot?.querySelector('#editor[data-loaded]'), 'editor did not finish loading', {
+			timeout: 15000,
+		});
+
+		return Array.from(element.shadowRoot!.querySelectorAll('link[rel="stylesheet"]')).map((link) =>
+			link.getAttribute('href'),
+		);
+	}
+
+	it('loads the configured stylesheet alongside the base RTE stylesheet, even when no enabled extension contributes styles', async function () {
+		this.timeout(20000);
+		const hrefs = await renderElement('/mycss');
+
+		expect(hrefs).to.include('/umbraco/backoffice/css/rte-content.css');
+		expect(hrefs).to.include('/mycss/rte-test.css');
+	});
+
+	it('falls back to the default stylesheet root path when the server reports none', async function () {
+		this.timeout(20000);
+		const hrefs = await renderElement(undefined);
+
+		expect(hrefs).to.include('/css/rte-test.css');
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
@@ -111,4 +111,11 @@ describe('UmbInputTiptapElement (stylesheets)', () => {
 		expect(hrefs).to.include('https://localhost:44339/mycss/already-prefixed.css');
 		expect(hrefs).not.to.include('https://localhost:44339/mycss/mycss/already-prefixed.css');
 	});
+
+	it('leaves a protocol-relative stylesheet URL untouched', async function () {
+		this.timeout(20000);
+		const hrefs = await renderElement('/mycss', 'https://localhost:44339', ['//cdn.example.com/style.css']);
+
+		expect(hrefs).to.include('//cdn.example.com/style.css');
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
@@ -27,24 +27,20 @@ describe('UmbInputTiptapElement (standalone)', () => {
 describe('UmbInputTiptapElement (stylesheets)', () => {
 	// Regression coverage for #21819: a minimal extension configuration (no extension
 	// contributes `getStyles()`) must still load the configured stylesheets, not just
-	// Umbraco's own base RTE stylesheet. Also covers resolving the configured stylesheet
-	// against the server origin, so it doesn't 404 against a split Vite dev client's own origin.
+	// Umbraco's own base RTE stylesheet. This is specifically a render-path bug —
+	// `#renderStyles()` used to early-return when no extension contributed `getStyles()`,
+	// so the `<link>` elements were never emitted at all — so it needs a real mounted
+	// element with a minimal extension set to catch it. The stylesheet href resolution
+	// itself (root path prefixing, server origin, protocol-relative/absolute URLs) is a
+	// pure string transform covered without mounting anything in
+	// `resolve-stylesheet-href.function.test.ts`, and the root-path fallback is covered
+	// in `tiptap-rte.context.test.ts`.
 	//
-	// The first mount in this suite pays for a cold dynamic import of the shared
-	// `extension-apis.bundle` chunk (Tiptap core + 50+ extension APIs), which can take
-	// several seconds to transform on an uncached test run — hence the generous timeouts.
+	// The mount pays for a cold dynamic import of the shared `extension-apis.bundle` chunk
+	// (Tiptap core + 50+ extension APIs), which can take several seconds to transform on an
+	// uncached test run — hence the generous timeout.
 
 	let provider: UmbContextProvider;
-
-	function stubServerContext(cssPath: string | undefined, serverUrl: string) {
-		const stub = {
-			getHostElement: () => document.body,
-			getServerUrl: () => serverUrl,
-			getServerConnection: () => ({ umbracoCssPath: of(cssPath) }),
-		} as unknown as UmbServerContext;
-		provider = new UmbContextProvider(document.body, UMB_SERVER_CONTEXT, stub);
-		provider.hostConnected();
-	}
 
 	before(() => {
 		umbExtensionsRegistry.registerMany(tiptapManifests);
@@ -58,12 +54,20 @@ describe('UmbInputTiptapElement (stylesheets)', () => {
 		provider?.hostDisconnected();
 	});
 
-	async function renderElement(cssPath: string | undefined, serverUrl = '', stylesheets: Array<string> = ['/rte-test.css']) {
-		stubServerContext(cssPath, serverUrl);
+	it('loads the configured stylesheet alongside the base RTE stylesheet, even when no enabled extension contributes styles', async function () {
+		this.timeout(20000);
+
+		const stub = {
+			getHostElement: () => document.body,
+			getServerUrl: () => '',
+			getServerConnection: () => ({ umbracoCssPath: of('/mycss') }),
+		} as unknown as UmbServerContext;
+		provider = new UmbContextProvider(document.body, UMB_SERVER_CONTEXT, stub);
+		provider.hostConnected();
 
 		const config = new UmbPropertyEditorConfigCollection([
 			{ alias: 'extensions', value: ['Umb.Tiptap.Bold', 'Umb.Tiptap.Italic'] },
-			{ alias: 'stylesheets', value: stylesheets },
+			{ alias: 'stylesheets', value: ['/rte-test.css'] },
 		]);
 
 		const element = await fixture<UmbInputTiptapElement>(html`
@@ -74,48 +78,11 @@ describe('UmbInputTiptapElement (stylesheets)', () => {
 			timeout: 15000,
 		});
 
-		return Array.from(element.shadowRoot!.querySelectorAll('link[rel="stylesheet"]')).map((link) =>
+		const hrefs = Array.from(element.shadowRoot!.querySelectorAll('link[rel="stylesheet"]')).map((link) =>
 			link.getAttribute('href'),
 		);
-	}
-
-	it('loads the configured stylesheet alongside the base RTE stylesheet, even when no enabled extension contributes styles', async function () {
-		this.timeout(20000);
-		const hrefs = await renderElement('/mycss');
 
 		expect(hrefs).to.include('/umbraco/backoffice/css/rte-content.css');
-		expect(hrefs).to.include('/mycss/rte-test.css');
-	});
-
-	it('falls back to the default stylesheet root path when the server reports none', async function () {
-		this.timeout(20000);
-		const hrefs = await renderElement(undefined);
-
-		expect(hrefs).to.include('/css/rte-test.css');
-	});
-
-	it('resolves the configured stylesheet against the server origin, e.g. when running a split Vite dev client', async function () {
-		this.timeout(20000);
-		const hrefs = await renderElement('/mycss', 'https://localhost:44339');
-
-		expect(hrefs).to.include('https://localhost:44339/mycss/rte-test.css');
-		// The base RTE stylesheet is a client-bundled asset (served by Vite itself in dev),
-		// so it must stay origin-relative rather than being prefixed with the server URL.
-		expect(hrefs).to.include('/umbraco/backoffice/css/rte-content.css');
-	});
-
-	it('does not double up the root path when a configured stylesheet already includes it, and still resolves against the server origin', async function () {
-		this.timeout(20000);
-		const hrefs = await renderElement('/mycss', 'https://localhost:44339', ['/mycss/already-prefixed.css']);
-
-		expect(hrefs).to.include('https://localhost:44339/mycss/already-prefixed.css');
-		expect(hrefs).not.to.include('https://localhost:44339/mycss/mycss/already-prefixed.css');
-	});
-
-	it('leaves a protocol-relative stylesheet URL untouched', async function () {
-		this.timeout(20000);
-		const hrefs = await renderElement('/mycss', 'https://localhost:44339', ['//cdn.example.com/style.css']);
-
-		expect(hrefs).to.include('//cdn.example.com/style.css');
+		expect(hrefs).to.include(`${window.location.origin}/mycss/rte-test.css`);
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.test.ts
@@ -27,7 +27,8 @@ describe('UmbInputTiptapElement (standalone)', () => {
 describe('UmbInputTiptapElement (stylesheets)', () => {
 	// Regression coverage for #21819: a minimal extension configuration (no extension
 	// contributes `getStyles()`) must still load the configured stylesheets, not just
-	// Umbraco's own base RTE stylesheet.
+	// Umbraco's own base RTE stylesheet. Also covers resolving the configured stylesheet
+	// against the server origin, so it doesn't 404 against a split Vite dev client's own origin.
 	//
 	// The first mount in this suite pays for a cold dynamic import of the shared
 	// `extension-apis.bundle` chunk (Tiptap core + 50+ extension APIs), which can take
@@ -35,9 +36,10 @@ describe('UmbInputTiptapElement (stylesheets)', () => {
 
 	let provider: UmbContextProvider;
 
-	function stubServerContext(cssPath: string | undefined) {
+	function stubServerContext(cssPath: string | undefined, serverUrl: string) {
 		const stub = {
 			getHostElement: () => document.body,
+			getServerUrl: () => serverUrl,
 			getServerConnection: () => ({ umbracoCssPath: of(cssPath) }),
 		} as unknown as UmbServerContext;
 		provider = new UmbContextProvider(document.body, UMB_SERVER_CONTEXT, stub);
@@ -56,8 +58,8 @@ describe('UmbInputTiptapElement (stylesheets)', () => {
 		provider?.hostDisconnected();
 	});
 
-	async function renderElement(cssPath: string | undefined) {
-		stubServerContext(cssPath);
+	async function renderElement(cssPath: string | undefined, serverUrl = '') {
+		stubServerContext(cssPath, serverUrl);
 
 		const config = new UmbPropertyEditorConfigCollection([
 			{ alias: 'extensions', value: ['Umb.Tiptap.Bold', 'Umb.Tiptap.Italic'] },
@@ -90,5 +92,15 @@ describe('UmbInputTiptapElement (stylesheets)', () => {
 		const hrefs = await renderElement(undefined);
 
 		expect(hrefs).to.include('/css/rte-test.css');
+	});
+
+	it('resolves the configured stylesheet against the server origin, e.g. when running a split Vite dev client', async function () {
+		this.timeout(20000);
+		const hrefs = await renderElement('/mycss', 'https://localhost:44339');
+
+		expect(hrefs).to.include('https://localhost:44339/mycss/rte-test.css');
+		// The base RTE stylesheet is a client-bundled asset (served by Vite itself in dev),
+		// so it must stay origin-relative rather than being prefixed with the server URL.
+		expect(hrefs).to.include('/umbraco/backoffice/css/rte-content.css');
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/resolve-stylesheet-href.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/resolve-stylesheet-href.function.test.ts
@@ -1,0 +1,29 @@
+import { resolveStylesheetHref } from './resolve-stylesheet-href.function.js';
+import { expect } from '@open-wc/testing';
+
+describe('resolveStylesheetHref', () => {
+	it('prefixes the root path onto a configured stylesheet', () => {
+		const href = resolveStylesheetHref('/rte-test.css', '/mycss', '');
+		expect(href).to.equal(`${window.location.origin}/mycss/rte-test.css`);
+	});
+
+	it('does not double up the root path when the configured stylesheet already includes it', () => {
+		const href = resolveStylesheetHref('/mycss/already-prefixed.css', '/mycss', '');
+		expect(href).to.equal(`${window.location.origin}/mycss/already-prefixed.css`);
+	});
+
+	it('resolves against the server origin when one is set, e.g. a split Vite dev client', () => {
+		const href = resolveStylesheetHref('/rte-test.css', '/mycss', 'https://localhost:44339');
+		expect(href).to.equal('https://localhost:44339/mycss/rte-test.css');
+	});
+
+	it('leaves a protocol-relative stylesheet URL untouched', () => {
+		const href = resolveStylesheetHref('//cdn.example.com/style.css', '/mycss', 'https://localhost:44339');
+		expect(href).to.equal('//cdn.example.com/style.css');
+	});
+
+	it('leaves an absolute stylesheet URL untouched', () => {
+		const href = resolveStylesheetHref('https://cdn.example.com/style.css', '/mycss', 'https://localhost:44339');
+		expect(href).to.equal('https://cdn.example.com/style.css');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/resolve-stylesheet-href.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/resolve-stylesheet-href.function.ts
@@ -1,0 +1,12 @@
+/**
+ * Resolves a configured stylesheet path to an absolute href on the Umbraco server.
+ * @param {string} stylesheet The configured stylesheet path, relative to `rootPath`.
+ * @param {string} rootPath The stylesheet root path reported by the server, e.g. `/css`.
+ * @param {string} serverUrl The Umbraco server origin. Falls back to `window.location.origin` if empty.
+ * @returns {string} The resolved href to use for the stylesheet link.
+ */
+export function resolveStylesheetHref(stylesheet: string, rootPath: string, serverUrl: string): string {
+	if (stylesheet.startsWith('http') || stylesheet.startsWith('//')) return stylesheet;
+	const relativeHref = stylesheet.startsWith(rootPath) ? stylesheet : `${rootPath}${stylesheet}`;
+	return new URL(relativeHref, serverUrl || window.location.origin).href;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.test.ts
@@ -1,0 +1,74 @@
+import { UmbTiptapRteContext } from './tiptap-rte.context.js';
+import { expect } from '@open-wc/testing';
+import { UmbContextProvider } from '@umbraco-cms/backoffice/context-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import { filter, firstValueFrom, of } from '@umbraco-cms/backoffice/external/rxjs';
+import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
+import type { UmbServerContext } from '@umbraco-cms/backoffice/server';
+
+// Regression coverage for #21819: the server-resolved stylesheet root path must fall back
+// to a sane default rather than being left `undefined` for the whole session, which is what
+// dropped configured stylesheets on `v17/dev` when the server never reported `umbracoCssPath`.
+
+@customElement('umb-test-tiptap-rte-context-host')
+class UmbTestHostElement extends UmbElementMixin(HTMLElement) {}
+
+// `stylesheetRootPath` starts as `undefined` and only resolves once the async context-request
+// for `UMB_SERVER_CONTEXT` completes, so wait for the first defined emission rather than the
+// first emission outright.
+function firstResolvedRootPath(context: UmbTiptapRteContext) {
+	return firstValueFrom(context.stylesheetRootPath.pipe(filter((value) => value !== undefined)));
+}
+
+describe('UmbTiptapRteContext', () => {
+	let host: UmbTestHostElement;
+	let provider: UmbContextProvider;
+
+	function stubServerContext(cssPath: string | undefined) {
+		const stub = {
+			getHostElement: () => document.body,
+			getServerUrl: () => '',
+			getServerConnection: () => ({ umbracoCssPath: of(cssPath) }),
+		} as unknown as UmbServerContext;
+		provider = new UmbContextProvider(document.body, UMB_SERVER_CONTEXT, stub);
+		provider.hostConnected();
+	}
+
+	beforeEach(() => {
+		host = new UmbTestHostElement();
+		document.body.appendChild(host);
+	});
+
+	afterEach(() => {
+		provider?.hostDisconnected();
+		host.remove();
+	});
+
+	it('reports the server-configured stylesheet root path', async () => {
+		stubServerContext('/mycss');
+		const context = new UmbTiptapRteContext(host);
+
+		expect(await firstResolvedRootPath(context)).to.equal('/mycss');
+	});
+
+	it('falls back to the default root path when the server reports none', async () => {
+		stubServerContext(undefined);
+		const context = new UmbTiptapRteContext(host);
+
+		expect(await firstResolvedRootPath(context)).to.equal('/css');
+	});
+
+	it('falls back to the default root path when there is no server connection at all', async () => {
+		const stub = {
+			getHostElement: () => document.body,
+			getServerUrl: () => '',
+			getServerConnection: () => undefined,
+		} as unknown as UmbServerContext;
+		provider = new UmbContextProvider(document.body, UMB_SERVER_CONTEXT, stub);
+		provider.hostConnected();
+		const context = new UmbTiptapRteContext(host);
+
+		expect(await firstResolvedRootPath(context)).to.equal('/css');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
@@ -1,4 +1,5 @@
 import type { Editor } from '../externals.js';
+import { resolveStylesheetHref } from './resolve-stylesheet-href.function.js';
 import { UMB_TIPTAP_RTE_CONTEXT } from './tiptap-rte.context-token.js';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbStringState } from '@umbraco-cms/backoffice/observable-api';
@@ -16,7 +17,7 @@ export class UmbTiptapRteContext extends UmbContextBase {
 
 	#serverUrl = '';
 
-	#stylesheetRootPath = new UmbStringState(undefined);
+	readonly #stylesheetRootPath = new UmbStringState(undefined);
 	stylesheetRootPath = this.#stylesheetRootPath.asObservable();
 
 	constructor(host: UmbControllerHost) {
@@ -27,7 +28,7 @@ export class UmbTiptapRteContext extends UmbContextBase {
 			// requests hit the real Umbraco server instead of resolving against the Vite
 			// client's own origin; a no-op prefix in production, where it equals `location.origin`.
 			// Kept separate from `stylesheetRootPath` below, which stays origin-relative so
-			// consumers can still detect whether a configured stylesheet already includes it.
+			// `resolveStylesheetHref` can still detect whether a configured stylesheet already includes it.
 			this.#serverUrl = serverContext?.getServerUrl() ?? '';
 
 			const serverConnection = serverContext?.getServerConnection();
@@ -42,11 +43,16 @@ export class UmbTiptapRteContext extends UmbContextBase {
 	}
 
 	/**
-	 * Returns the Umbraco server origin, used to resolve stylesheet URLs against the real server in split-dev setups.
-	 * @returns {string} The server origin, or an empty string if not yet resolved.
+	 * Resolves a configured stylesheet path to an href on the Umbraco server.
+	 * @param {string} stylesheet The configured stylesheet path, relative to the stylesheet root path.
+	 * @returns {string} The href to use for the stylesheet link.
 	 */
-	public getServerUrl(): string {
-		return this.#serverUrl;
+	public resolveStylesheetHref(stylesheet: string): string {
+		return resolveStylesheetHref(
+			stylesheet,
+			this.#stylesheetRootPath.getValue() ?? DEFAULT_STYLESHEET_ROOT_PATH,
+			this.#serverUrl,
+		);
 	}
 
 	public getEditor(): Editor | undefined {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
@@ -5,6 +5,12 @@ import { UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
+/**
+ * The default root path for the stylesheets on the server.
+ * This is used as a fallback if the server configuration is not available.
+ */
+const DEFAULT_STYLESHEET_ROOT_PATH = '/css';
+
 export class UmbTiptapRteContext extends UmbContextBase {
 	#editor?: Editor;
 
@@ -16,8 +22,12 @@ export class UmbTiptapRteContext extends UmbContextBase {
 
 		this.consumeContext(UMB_SERVER_CONTEXT, (serverContext) => {
 			const serverConnection = serverContext?.getServerConnection();
-			this.observe(serverConnection?.umbracoCssPath, (umbracoCssPath) => {
-				this.#stylesheetRootPath.setValue(umbracoCssPath);
+			if (!serverConnection) {
+				this.#stylesheetRootPath.setValue(DEFAULT_STYLESHEET_ROOT_PATH);
+				return;
+			}
+			this.observe(serverConnection.umbracoCssPath, (umbracoCssPath) => {
+				this.#stylesheetRootPath.setValue(umbracoCssPath ?? DEFAULT_STYLESHEET_ROOT_PATH);
 			});
 		});
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
@@ -21,13 +21,17 @@ export class UmbTiptapRteContext extends UmbContextBase {
 		super(host, UMB_TIPTAP_RTE_CONTEXT);
 
 		this.consumeContext(UMB_SERVER_CONTEXT, (serverContext) => {
+			// Absolute in split-dev-server setups (e.g. `VITE_UMBRACO_API_URL`) so stylesheet
+			// requests hit the real Umbraco server instead of resolving against the Vite
+			// client's own origin; a no-op prefix in production, where it equals `location.origin`.
+			const serverUrl = serverContext?.getServerUrl() ?? '';
 			const serverConnection = serverContext?.getServerConnection();
 			if (!serverConnection) {
-				this.#stylesheetRootPath.setValue(DEFAULT_STYLESHEET_ROOT_PATH);
+				this.#stylesheetRootPath.setValue(serverUrl + DEFAULT_STYLESHEET_ROOT_PATH);
 				return;
 			}
 			this.observe(serverConnection.umbracoCssPath, (umbracoCssPath) => {
-				this.#stylesheetRootPath.setValue(umbracoCssPath ?? DEFAULT_STYLESHEET_ROOT_PATH);
+				this.#stylesheetRootPath.setValue(serverUrl + (umbracoCssPath ?? DEFAULT_STYLESHEET_ROOT_PATH));
 			});
 		});
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
@@ -41,6 +41,10 @@ export class UmbTiptapRteContext extends UmbContextBase {
 		});
 	}
 
+	/**
+	 * Returns the Umbraco server origin, used to resolve stylesheet URLs against the real server in split-dev setups.
+	 * @returns {string} The server origin, or an empty string if not yet resolved.
+	 */
 	public getServerUrl(): string {
 		return this.#serverUrl;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
@@ -14,6 +14,8 @@ const DEFAULT_STYLESHEET_ROOT_PATH = '/css';
 export class UmbTiptapRteContext extends UmbContextBase {
 	#editor?: Editor;
 
+	#serverUrl = '';
+
 	#stylesheetRootPath = new UmbStringState(undefined);
 	stylesheetRootPath = this.#stylesheetRootPath.asObservable();
 
@@ -24,16 +26,23 @@ export class UmbTiptapRteContext extends UmbContextBase {
 			// Absolute in split-dev-server setups (e.g. `VITE_UMBRACO_API_URL`) so stylesheet
 			// requests hit the real Umbraco server instead of resolving against the Vite
 			// client's own origin; a no-op prefix in production, where it equals `location.origin`.
-			const serverUrl = serverContext?.getServerUrl() ?? '';
+			// Kept separate from `stylesheetRootPath` below, which stays origin-relative so
+			// consumers can still detect whether a configured stylesheet already includes it.
+			this.#serverUrl = serverContext?.getServerUrl() ?? '';
+
 			const serverConnection = serverContext?.getServerConnection();
 			if (!serverConnection) {
-				this.#stylesheetRootPath.setValue(serverUrl + DEFAULT_STYLESHEET_ROOT_PATH);
+				this.#stylesheetRootPath.setValue(DEFAULT_STYLESHEET_ROOT_PATH);
 				return;
 			}
 			this.observe(serverConnection.umbracoCssPath, (umbracoCssPath) => {
-				this.#stylesheetRootPath.setValue(serverUrl + (umbracoCssPath ?? DEFAULT_STYLESHEET_ROOT_PATH));
+				this.#stylesheetRootPath.setValue(umbracoCssPath ?? DEFAULT_STYLESHEET_ROOT_PATH);
 			});
 		});
+	}
+
+	public getServerUrl(): string {
+		return this.#serverUrl;
 	}
 
 	public getEditor(): Editor | undefined {


### PR DESCRIPTION
## Description

Fixes #21819.

The Tiptap RTE was only loading configured stylesheets if at least one enabled extension contributed its own CSS (via `getStyles()`). With a minimal config (e.g. just Bold + Italic), that block never rendered, so both the user's configured stylesheets *and* Umbraco's own base RTE stylesheet were silently dropped.

While fixing that up, also found and fixed the stylesheet root path resolution getting stuck forever if the server never reports an `UmbracoCssPath` (dropping configured stylesheets for the whole session), plus a follow-on issue found while manually testing against a split Vite dev client: configured stylesheet URLs were rendered origin-relative, so they resolved against the Vite client's own origin instead of the real Umbraco server and 404'd. Fixed by resolving them against the server origin via `new URL()` instead, so the rendered `<link href>` is now always absolute rather than only being prefixed in split-dev setups — functionally equivalent in a normal installation, since the server origin is already `location.origin` there.

### How to test?

1. Add a stylesheet to `wwwroot/css`, e.g. `rte.css` with `:host { background-color: red; }`.
2. Create an RTE data type, add that stylesheet under its config, and reduce its Capabilities/toolbar down to just Bold + Italic (no Heading, no other extensions with custom styles).
3. Use that data type on a document type, create a document, and open it — the RTE background should be red.
4. Bonus: if you can run the backoffice via the split Vite dev client against a real server, confirm the configured stylesheet loads there too (previously 404'd against the Vite origin).
