### PR TITLE
Auth: Deprecate five UmbAuthContext members so v19 can remove them

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/app/app-auth.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app-auth.controller.ts
@@ -1,5 +1,5 @@
 import { UMB_AUTH_CONTEXT, UMB_MODAL_APP_AUTH } from '@umbraco-cms/backoffice/auth';
-import type { UmbUserLoginState } from '@umbraco-cms/backoffice/auth';
+import type { ManifestAuthProvider, UmbUserLoginState } from '@umbraco-cms/backoffice/auth';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
@@ -67,8 +67,12 @@ export class UmbAppAuthController extends UmbControllerBase {
 		}
 		setStoredPath(currentUrl);
 
-		// Figure out which providers are available
-		const availableProviders = await firstValueFrom(this.#authContext.getAuthProviders(umbExtensionsRegistry));
+		// Figure out which providers are available. Queried straight from the registry: app.element.ts
+		// awaits app entry points before routing, so any providers they register (or unregister) have
+		// already settled by the time this runs.
+		const availableProviders = await firstValueFrom(
+			umbExtensionsRegistry.byType<'authProvider', ManifestAuthProvider>('authProvider'),
+		);
 
 		if (availableProviders.length === 0) {
 			throw new Error('[Fatal] No auth providers available');

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.test.ts
@@ -30,6 +30,18 @@ describe('UmbAuthContext', () => {
 			expect(context).to.have.property('isInitialized');
 		});
 
+		// setInitialized() used to be driven from the core entry point. It now runs in the constructor,
+		// so guard the property that makes that safe: #isInitialized is a ReplaySubject(1), meaning a
+		// subscriber attaching after construction still receives the emission rather than hanging.
+		it('emits isInitialized to a subscriber that attaches after construction', async () => {
+			let emitted = false;
+			context.isInitialized.subscribe(() => {
+				emitted = true;
+			});
+			await aTimeout(0);
+			expect(emitted).to.be.true;
+		});
+
 		it('has a getIsAuthorized method', () => {
 			expect(context).to.have.property('getIsAuthorized').that.is.a('function');
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.test.ts
@@ -33,6 +33,8 @@ describe('UmbAuthContext', () => {
 		// setInitialized() used to be driven from the core entry point. It now runs in the constructor,
 		// so guard the property that makes that safe: #isInitialized is a ReplaySubject(1), meaning a
 		// subscriber attaching after construction still receives the emission rather than hanging.
+		// Reading the deprecated getter logs a deprecation warning here — expected, since the test
+		// runner's origin resolves to 'unknown' rather than 'core' so the warning isn't suppressed.
 		it('emits isInitialized to a subscriber that attaches after construction', async () => {
 			let emitted = false;
 			context.isInitialized.subscribe(() => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -11,7 +11,6 @@ import { UmbBooleanState, UmbObjectState } from '@umbraco-cms/backoffice/observa
 import {
 	ReplaySubject,
 	Subject,
-	switchMap,
 	distinctUntilChanged,
 	throttleTime,
 	auditTime,
@@ -91,7 +90,7 @@ export class UmbAuthContext extends UmbContextBase {
 	#postLogoutRedirectUri;
 
 	/**
-	 * Observable that emits true when the auth context is initialized.
+	 * Observable that emits once, without a value, when the auth context is initialized.
 	 * @internal This was only ever public so the core entry point could drive it. It gates nothing
 	 * for consumers: the boot sequence already awaits app entry points before the router evaluates
 	 * its guards, so by the time any extension code runs this has long since completed.
@@ -715,7 +714,8 @@ export class UmbAuthContext extends UmbContextBase {
 	 * @internal Only public because the core entry point calls it from outside this class. Nothing
 	 * outside Umbraco core should ever call this — doing so opens the provider-discovery gate early.
 	 * @deprecated Internal boot hook, never intended for public use. Scheduled for removal in Umbraco 19.
-	 * @remark This is used to let the app context know that the core module is ready, which means that the core auth providers are available.
+	 * @remark The constructor already does this, so calling it again is a no-op on an
+	 * already-completed subject. It emits once, without a value.
 	 */
 	setInitialized() {
 		new UmbDeprecation({
@@ -750,11 +750,14 @@ export class UmbAuthContext extends UmbContextBase {
 		return this.#getAuthProviders(extensionsRegistry);
 	}
 
-	/** Internal, non-warning implementation of {@link getAuthProviders}. */
+	/**
+	 * Internal, non-warning implementation of {@link getAuthProviders}.
+	 * No initialization gate: the constructor completes #isInitialized, so piping through it only
+	 * added a micro-task delay. Ordering is guaranteed by the boot sequence awaiting app entry
+	 * points before the router evaluates its guards.
+	 */
 	#getAuthProviders(extensionsRegistry: UmbBackofficeExtensionRegistry) {
-		return this.#isInitialized.pipe(
-			switchMap(() => extensionsRegistry.byType<'authProvider', ManifestAuthProvider>('authProvider')),
-		);
+		return extensionsRegistry.byType<'authProvider', ManifestAuthProvider>('authProvider');
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -186,52 +186,7 @@ export class UmbAuthContext extends UmbContextBase {
 
 		// Set up cross-tab coordination via BroadcastChannel
 		this.#channel = new BroadcastChannel('umb:auth');
-		this.#channel.onmessage = (evt: MessageEvent) => {
-			switch (evt.data?.type) {
-				case 'authorized': {
-					// Apply locally — do NOT call #updateSession which would re-broadcast.
-					this.#setSessionLocally(evt.data.expiresIn, evt.data.issuedAt);
-					this.#authorizationSignal.next();
-					break;
-				}
-				case 'sessionUpdate':
-					// Peer broadcast already-computed timestamps, so set the session
-					// directly. We still go through the `#inSessionUpdateCallback` guard
-					// so observers triggered re-entrantly skip a redundant /token call.
-					this.#sessionDead = false;
-					this.#inSessionUpdateCallback = true;
-					try {
-						this.#session.setValue({
-							accessTokenExpiresAt: evt.data.accessTokenExpiresAt,
-							expiresAt: evt.data.expiresAt,
-						});
-						this.#isAuthorized.setValue(true);
-					} finally {
-						this.#inSessionUpdateCallback = false;
-					}
-					break;
-				case 'sessionCleared':
-					this.#session.setValue(undefined);
-					this.#isAuthorized.setValue(false);
-					break;
-				case 'signedOut':
-					this.#session.setValue(undefined);
-					this.#isAuthorized.setValue(false);
-					// Redirect to logout page — cookies already cleared by the tab that initiated sign-out
-					location.href = this.#postLogoutRedirectUri;
-					break;
-				case 'sessionRequest': {
-					// Another tab is asking for the current session state (e.g. new tab opening).
-					// Only share the session if it is still valid — an expired session would cause
-					// the recipient (e.g. a popup) to believe it is already authorized and skip
-					// the authorization code exchange.
-					if (this.#isSessionValid()) {
-						this.#channel.postMessage({ type: 'sessionResponse', session: this.#session.getValue()! });
-					}
-					break;
-				}
-			}
-		};
+		this.#channel.onmessage = (evt: MessageEvent) => this.#handleChannelMessage(evt);
 
 		if (!isTestEnvironment()) {
 			// Start the session timeout controller
@@ -870,6 +825,56 @@ export class UmbAuthContext extends UmbContextBase {
 		await this.signOut();
 
 		return true;
+	}
+
+	/**
+	 * Handles a cross-tab message from the `umb:auth` BroadcastChannel.
+	 */
+	#handleChannelMessage(evt: MessageEvent) {
+		switch (evt.data?.type) {
+			case 'authorized': {
+				// Apply locally — do NOT call #updateSession which would re-broadcast.
+				this.#setSessionLocally(evt.data.expiresIn, evt.data.issuedAt);
+				this.#authorizationSignal.next();
+				break;
+			}
+			case 'sessionUpdate':
+				// Peer broadcast already-computed timestamps, so set the session
+				// directly. We still go through the `#inSessionUpdateCallback` guard
+				// so observers triggered re-entrantly skip a redundant /token call.
+				this.#sessionDead = false;
+				this.#inSessionUpdateCallback = true;
+				try {
+					this.#session.setValue({
+						accessTokenExpiresAt: evt.data.accessTokenExpiresAt,
+						expiresAt: evt.data.expiresAt,
+					});
+					this.#isAuthorized.setValue(true);
+				} finally {
+					this.#inSessionUpdateCallback = false;
+				}
+				break;
+			case 'sessionCleared':
+				this.#session.setValue(undefined);
+				this.#isAuthorized.setValue(false);
+				break;
+			case 'signedOut':
+				this.#session.setValue(undefined);
+				this.#isAuthorized.setValue(false);
+				// Redirect to logout page — cookies already cleared by the tab that initiated sign-out
+				location.href = this.#postLogoutRedirectUri;
+				break;
+			case 'sessionRequest': {
+				// Another tab is asking for the current session state (e.g. new tab opening).
+				// Only share the session if it is still valid — an expired session would cause
+				// the recipient (e.g. a popup) to believe it is already authorized and skip
+				// the authorization code exchange.
+				if (this.#isSessionValid()) {
+					this.#channel.postMessage({ type: 'sessionResponse', session: this.#session.getValue()! });
+				}
+				break;
+			}
+		}
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -92,9 +92,24 @@ export class UmbAuthContext extends UmbContextBase {
 
 	/**
 	 * Observable that emits true when the auth context is initialized.
+	 * @internal This was only ever public so the core entry point could drive it. It gates nothing
+	 * for consumers: the boot sequence already awaits app entry points before the router evaluates
+	 * its guards, so by the time any extension code runs this has long since completed.
+	 * @deprecated Internal boot signal, never intended for public use. Scheduled for removal in Umbraco 19.
 	 * @remark It will only emit once and then complete itself.
 	 */
-	readonly isInitialized = this.#isInitialized.asObservable();
+	get isInitialized(): Observable<void> {
+		new UmbDeprecation({
+			deprecated: 'UmbAuthContext.isInitialized',
+			solution:
+				'Remove the dependency on this signal. It is an internal boot detail — the app awaits app entry points before routing, so extension code always runs after initialization. Scheduled for removal in Umbraco 19.',
+			removeInVersion: '19.0.0',
+		}).warn();
+		return this.#isInitializedObservable;
+	}
+
+	/** Internal, non-warning view of {@link isInitialized} for use inside this class. */
+	readonly #isInitializedObservable = this.#isInitialized.asObservable();
 
 	/**
 	 * Observable that emits true if the user is authorized, otherwise false.
@@ -210,7 +225,7 @@ export class UmbAuthContext extends UmbContextBase {
 					// Only share the session if it is still valid — an expired session would cause
 					// the recipient (e.g. a popup) to believe it is already authorized and skip
 					// the authorization code exchange.
-					if (this.isSessionValid()) {
+					if (this.#isSessionValid()) {
 						this.#channel.postMessage({ type: 'sessionResponse', session: this.#session.getValue()! });
 					}
 					break;
@@ -222,6 +237,12 @@ export class UmbAuthContext extends UmbContextBase {
 			// Start the session timeout controller
 			new UmbAuthSessionTimeoutController(this);
 		}
+
+		// The context is usable as soon as it is constructed. This used to be driven from the core
+		// entry point via setInitialized(), but the gate is redundant: app.element.ts awaits app entry
+		// points before the router evaluates its guards, so provider discovery has already settled by
+		// the time anything consumes this.
+		this.#setInitialized();
 
 		// When an HTTP interceptor is active it registers an UmbAuthSignalerContext on the host.
 		// Consume it to keep authorization state in sync and to react to timeout requests.
@@ -546,9 +567,21 @@ export class UmbAuthContext extends UmbContextBase {
 
 	/**
 	 * Checks if the current session is still valid.
+	 * @deprecated Use {@link getIsAuthorized} or observe {@link session$} instead. Scheduled for removal in Umbraco 19.
 	 * @returns True if the session has not expired.
 	 */
 	isSessionValid(): boolean {
+		new UmbDeprecation({
+			deprecated: 'UmbAuthContext.isSessionValid()',
+			solution:
+				'Use getIsAuthorized() for a synchronous check, or observe session$ to react to session changes. Scheduled for removal in Umbraco 19.',
+			removeInVersion: '19.0.0',
+		}).warn();
+		return this.#isSessionValid();
+	}
+
+	/** Internal, non-warning implementation of {@link isSessionValid}. */
+	#isSessionValid(): boolean {
 		const session = this.#session.getValue();
 		return !!session && session.expiresAt > Math.floor(Date.now() / 1000);
 	}
@@ -645,9 +678,16 @@ export class UmbAuthContext extends UmbContextBase {
 	 * 		headers: { Authorization: `Bearer ${await config.token()}` },
 	 * 	});
 	 * ```
+	 * @deprecated Consume {@link UMB_SERVER_CONTEXT} and use its `getServerUrl()` — the canonical source for the server URL. Scheduled for removal in Umbraco 19.
 	 * @returns The server url to the Management API
 	 */
 	getServerUrl() {
+		new UmbDeprecation({
+			deprecated: 'UmbAuthContext.getServerUrl()',
+			solution:
+				'Consume UMB_SERVER_CONTEXT from @umbraco-cms/backoffice/server and use its getServerUrl(), which is the canonical source. Scheduled for removal in Umbraco 19.',
+			removeInVersion: '19.0.0',
+		}).warn();
 		return this.#serverUrl;
 	}
 
@@ -717,18 +757,46 @@ export class UmbAuthContext extends UmbContextBase {
 
 	/**
 	 * Sets the auth context as initialized, which means that the auth context is ready to be used.
+	 * @internal Only public because the core entry point calls it from outside this class. Nothing
+	 * outside Umbraco core should ever call this — doing so opens the provider-discovery gate early.
+	 * @deprecated Internal boot hook, never intended for public use. Scheduled for removal in Umbraco 19.
 	 * @remark This is used to let the app context know that the core module is ready, which means that the core auth providers are available.
 	 */
 	setInitialized() {
+		new UmbDeprecation({
+			deprecated: 'UmbAuthContext.setInitialized()',
+			solution:
+				'Do not call this. It is an internal boot hook owned by the core entry point. Scheduled for removal in Umbraco 19.',
+			removeInVersion: '19.0.0',
+		}).warn();
+		this.#setInitialized();
+	}
+
+	/** Internal, non-warning implementation of {@link setInitialized}. */
+	#setInitialized() {
 		this.#isInitialized.next();
 		this.#isInitialized.complete();
 	}
 
 	/**
 	 * Gets all registered auth providers.
+	 * @deprecated Query the extension registry directly: `umbExtensionsRegistry.byType('authProvider')`. Scheduled for removal in Umbraco 19.
+	 * @remark The initialization gate this used to add is redundant — the app awaits app entry points
+	 * before the router evaluates its guards, so the provider list has already settled by then.
 	 * @param extensionsRegistry
 	 */
 	getAuthProviders(extensionsRegistry: UmbBackofficeExtensionRegistry) {
+		new UmbDeprecation({
+			deprecated: 'UmbAuthContext.getAuthProviders()',
+			solution:
+				"Query the extension registry directly with byType('authProvider'). The boot sequence already awaits app entry points before routing, so the provider list has settled. Scheduled for removal in Umbraco 19.",
+			removeInVersion: '19.0.0',
+		}).warn();
+		return this.#getAuthProviders(extensionsRegistry);
+	}
+
+	/** Internal, non-warning implementation of {@link getAuthProviders}. */
+	#getAuthProviders(extensionsRegistry: UmbBackofficeExtensionRegistry) {
 		return this.#isInitialized.pipe(
 			switchMap(() => extensionsRegistry.byType<'authProvider', ManifestAuthProvider>('authProvider')),
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entry-point.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entry-point.ts
@@ -5,7 +5,6 @@ import {
 	UmbBackofficeModalContainerElement,
 } from '@umbraco-cms/backoffice/components';
 import { UmbInteractionMemoryContext } from '@umbraco-cms/backoffice/interaction-memory';
-import { UMB_AUTH_CONTEXT } from '@umbraco-cms/backoffice/auth';
 import { UmbExtensionsApiInitializer } from '@umbraco-cms/backoffice/extension-api';
 import { UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import { UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
@@ -44,8 +43,4 @@ export const onInit: UmbEntryPointOnInit = (host, extensionRegistry) => {
 	new UmbActionEventContext(host);
 	new UmbInteractionMemoryContext(host);
 
-	host.consumeContext(UMB_AUTH_CONTEXT, (authContext) => {
-		// Initialize the auth context to let the app context know that the core module is ready
-		authContext?.setInitialized();
-	});
 };


### PR DESCRIPTION
Groundwork for #23484. Independent of #23498/#23499/#23501.

Enables AB#70427 — the v19 removal of these members, which cannot happen until they are deprecated in v17.

## Why now

#23484 deprecates 11 `UmbAuthContext` members as part of the cookie-auth work, all marked `removeInVersion: '21.0.0'` — because deprecated-in-v19 means removal in v21 under the 2-major rule.

Deprecating them in **v17** is the only thing that makes a **v19** removal legal. This PR pulls forward the five where a viable v17 replacement already exists, so #23484 can change their marker to `19.0.0` and delete them outright.

## What's deprecated

| Member | Replacement | Why it's safe in v17 |
|---|---|---|
| `getServerUrl()` | `UMB_SERVER_CONTEXT.getServerUrl()` | Zero real callers — every internal consumer already uses the server context |
| `isSessionValid()` | `getIsAuthorized()` / observe `session$` | No callers outside `auth.context.ts` |
| `setInitialized()` | none — internal boot hook | Only public because the core entry point drove it from outside the class |
| `isInitialized` | none — internal boot signal | As above |
| `getAuthProviders()` | `umbExtensionsRegistry.byType('authProvider')` | The gate it added is redundant (below) |

The last three are the interesting ones. Their initialization gate is **vestigial**: since #23167, `app.element.ts` awaits app entry points before the router evaluates its guards, so the `authProvider` list has already settled by the time anything consumes it. That is the same guarantee #23484 relies on — its comment credits "public extensions have registered", but the real mechanism is that entry-point await, which v19 keeps.

All three carry `@internal` alongside `@deprecated`, recording an intent that should have been expressed when they were first written.

## Internal callers migrated

Per the root `CLAUDE.md` rule that no internal code should use obsolete members:

- `core/entry-point.ts` no longer calls `setInitialized()`; the context completes the signal in its own constructor.
- `app-auth.controller.ts` queries the extension registry directly instead of `getAuthProviders()`.
- Uses inside `auth.context.ts` route through non-warning private implementations.

Note `UmbDeprecation.warn()` suppresses **core-origin** warnings in production builds, so even where core still touched a deprecated member no consumer would see noise. The callers were migrated anyway, so dev builds stay quiet too.

## The one behavioural nuance

`#isInitialized` now completes in the constructor rather than at core `onInit()`. Both are far earlier than anything that consumes it, and because `#isInitialized` is a `ReplaySubject(1)` a subscriber attaching later still receives the replayed emission rather than hanging.

That's the property the whole change rests on, so it has a regression test — and I verified it genuinely fails without the constructor call:

```
❌ emits isInitialized to a subscriber that attaches after construction
   AssertionError: expected false to be true
```

The public `setInitialized()` also still exists and still delegates, so an external caller keeps working; calling it on an already-completed subject is a harmless no-op.

## Not included

The other six from #23484 each carry a specific cost and are better decided together:

- **`getLatestToken()`, `UmbOpenApiConfiguration.token`** — the live [Fetch API docs page](https://docs.umbraco.com/umbraco-cms/17.latest/extend-your-project/backoffice-extensions/foundation/fetching-data/fetch-api) still teaches `getLatestToken()` as best practice, and #22736 un-deprecated it precisely because guides pointed at it. Needs an UmbracoDocs change first.
- **`validateToken()`, `makeRefreshTokenRequest()`** — both point at `keepAlive`, which is v19-only. Deprecating both would leave v17 with no public way to force a refresh.
- **`clearTokenStorage()`, `completeAuthorizationRequest()`** — core legitimately must keep calling these (the `logout` route and install path need local-clear semantics; the latter *is* the PKCE exchange), and there is no non-deprecated equivalent to migrate them to.

## Also in this PR

- **`UmbAuthContext.constructor` extracted.** Adding the `#setInitialized()` call tipped an already-borderline constructor over CodeScene's Complex Method rule, so the cross-tab `BroadcastChannel` message switch moved into `#handleChannelMessage()` rather than suppressing the rule.
- **Review follow-ups.** Dropped the now-vestigial `#isInitialized` pipe from `#getAuthProviders` (the constructor completes the subject, so it only added a micro-task delay), corrected two stale JSDoc claims — the signal emits once *without a value* rather than "emits true", and `setInitialized()` no longer describes an entry-point handshake it doesn't perform — and noted in the test why reading the deprecated getter logs a warning under the test runner.

## Testing

- `npm run build`, `lint:errors`, `check:circular` — clean
- `npm test` — **2558 passed, 0 failed** (one new test)
- Confirmed no internal callers remain on any of the five

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

