### PR TITLE
Block Grid: Use the content element type name in the invalid-location tag (closes #23092)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -103,7 +103,7 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	@state()
 	private _isSortMode?: boolean;
 
-	// TODO: consumed by <umb-entity-frame> label, landing in a follow-up PR; add `@state()` when used in render [LK]
+	@state()
 	private _name?: string;
 
 	@state()
@@ -496,7 +496,9 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 						this._invalidLocation,
 						() => html`
 							<uui-tag id="invalidLocation" color="danger">
-								<umb-localize key="blockEditor_invalidDropPosition" .args=${[this._label]}></umb-localize>
+								<umb-localize
+									key="blockEditor_invalidDropPosition"
+									.args=${[this._name || this._contentTypeName]}></umb-localize>
 							</uui-tag>
 						`,
 					)}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -103,7 +103,7 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	@state()
 	private _isSortMode?: boolean;
 
-	@state()
+	// TODO: consumed by <umb-entity-frame> label, landing in a follow-up PR; add `@state()` when used in render [LK]
 	private _name?: string;
 
 	@state()
@@ -498,7 +498,9 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 							<uui-tag id="invalidLocation" color="danger">
 								<umb-localize
 									key="blockEditor_invalidDropPosition"
-									.args=${[this._name || this._contentTypeName]}></umb-localize>
+									.args=${[
+										this._contentTypeName ?? this.localize.term('blockEditor_unsupportedBlockName'),
+									]}></umb-localize>
 							</uui-tag>
 						`,
 					)}


### PR DESCRIPTION
### Description

When a Block Grid block sits somewhere it is no longer allowed, the entry shows a danger tag reading _"**X** is not allowed at this spot."_. The `X` was taken from `_label` — the **unrendered** UFM markdown source — so any block whose label uses UFM showed the raw expression instead of readable text:

> **{= headline}** is not allowed at this spot.

Reported with screenshots in #23092 by @bjarnef, on a site upgraded from v13 to v17 where stricter validation started surfacing these tags on existing blocks.

#### Fix

The tag now names the **content element type**:

> **Hero** is not allowed at this spot.

The element type name is short, stable, and identifies the thing that is actually not allowed at that spot — which is what the editor needs in order to act on it. A resolved label would not be: it is an arbitrary property value, potentially hundreds of characters, and often reads oddly mid-sentence.

`_contentTypeName` is already observed on the element (from `contentElementTypeName` on the entry context) and already used for the expose button, so no new state is introduced. It falls back to the localised `blockEditor_unsupportedBlockName` ("Unsupported") when the content element type no longer exists, so the localize argument is never `undefined`.

Only Block Grid uses `blockEditor_invalidDropPosition` — Block List and Block RTE do not render this tag, so there is no equivalent change needed there.

### Testing

Verified in the backoffice against a Block Grid whose Hero block has `label: "{= headline}"` and `allowAtRoot: false`, with an existing Hero block at root:

- **Before:** `{= headline} is not allowed at this spot.`
- **After:** `Hero is not allowed at this spot.`

`tsc`, ESLint and Prettier are clean on the changed file.

Fixes #23092
