### PR TITLE
Build: Build the Static Web Apps bundles with npm ci instead of Oryx's npm install

### DIFF
--- a/.github/workflows/azure-backoffice.yml
+++ b/.github/workflows/azure-backoffice.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Build Backoffice
         run: npm run build:for:static
         working-directory: src/Umbraco.Web.UI.Client
+      # Static Web Apps reads this from the uploaded directory, so it has to travel with the build output.
+      - name: Copy Static Web Apps routing config
+        run: cp staticwebapp.config.json dist/
+        working-directory: src/Umbraco.Web.UI.Client
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-backoffice.yml
+++ b/.github/workflows/azure-backoffice.yml
@@ -26,6 +26,21 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: src/Umbraco.Web.UI.Client/.nvmrc
+          cache: npm
+          cache-dependency-path: ./src/Umbraco.Web.UI.Client/package-lock.json
+      # Build here rather than letting Oryx do it: Oryx runs `npm install`, which drops
+      # rollup's platform-specific optional dependencies (npm/cli#4828). `npm ci` installs
+      # the lockfile verbatim, so the native binaries are always present.
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund --prefer-offline
+        working-directory: src/Umbraco.Web.UI.Client
+      - name: Build Backoffice
+        run: npm run build:for:static
+        working-directory: src/Umbraco.Web.UI.Client
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -36,9 +51,9 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "src/Umbraco.Web.UI.Client" # App source code path
-          app_build_command: "npm run build:for:static"
-          output_location: "dist" # Built app content directory - optional
+          app_location: "src/Umbraco.Web.UI.Client/dist" # Pre-built app content directory
+          output_location: "" # Must be empty when skip_app_build is set
+          skip_app_build: true # The build already ran above
           skip_api_build: true # Set to true if you do not have an Azure Functions API in your repo
           ###### End of Repository/Build Configurations ######
 

--- a/.github/workflows/azure-storybook.yml
+++ b/.github/workflows/azure-storybook.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Build Storybook
         run: npm run storybook:build
         working-directory: src/Umbraco.Web.UI.Client
+      # Static Web Apps reads this from the uploaded directory, so it has to travel with the build output.
+      - name: Copy Static Web Apps routing config
+        run: cp staticwebapp.config.json storybook-static/
+        working-directory: src/Umbraco.Web.UI.Client
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-storybook.yml
+++ b/.github/workflows/azure-storybook.yml
@@ -27,6 +27,21 @@ jobs:
     name: Build and Deploy Job
     steps:
       - uses: actions/checkout@v6
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: src/Umbraco.Web.UI.Client/.nvmrc
+          cache: npm
+          cache-dependency-path: ./src/Umbraco.Web.UI.Client/package-lock.json
+      # Build here rather than letting Oryx do it: Oryx runs `npm install`, which drops
+      # rollup's platform-specific optional dependencies (npm/cli#4828). `npm ci` installs
+      # the lockfile verbatim, so the native binaries are always present.
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund --prefer-offline
+        working-directory: src/Umbraco.Web.UI.Client
+      - name: Build Storybook
+        run: npm run storybook:build
+        working-directory: src/Umbraco.Web.UI.Client
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -37,9 +52,9 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "src/Umbraco.Web.UI.Client" # App source code path
-          app_build_command: "npm run storybook:build"
-          output_location: "/storybook-static" # Built app content directory - optional
+          app_location: "src/Umbraco.Web.UI.Client/storybook-static" # Pre-built app content directory
+          output_location: "" # Must be empty when skip_app_build is set
+          skip_app_build: true # The build already ran above
           skip_api_build: true # Set to true if you do not have an Azure Functions API in your repo
           ###### End of Repository/Build Configurations ######
 


### PR DESCRIPTION
### Description

Both Static Web Apps deploys (Storybook and Backoffice) started failing with:

```
Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug
related to optional dependencies (https://github.com/npm/cli/issues/4828).
```

#### What it is not

The lockfile is fine. At the first failing commit it already listed all 25 `@rollup/rollup-*` platform packages, `rollup` declared all 26 `optionalDependencies`, and the Linux entry carried the correct `cpu: ["x64"]` / `os: ["linux"]` plus resolved and integrity. Regenerating `package-lock.json` does not help and only produces churn.

The toolchain did not change either — the last green and first red runs both used **Node v24.13.0 and npm 11.19.0**. Neither run restored a cached `node_modules`; both installed from scratch.

#### What it is

Oryx runs its **own `npm install`** before the configured build command:

```
Found npm version spec to follow in package.json: '>=11'
Running 'npm install'...
```

`npm install` re-resolves the tree and prunes optional dependencies it decides aren't needed — the long-standing npm/cli#4828. The green run installed 1223 packages; the red run installed 1189 from the same lockfile. What changed in between is that **rollup moved 4.60.2 → 4.62.3**, and the new platform binary was among the ones dropped, so `rollup/dist/native.js` couldn't find a matching module.

This is why `test-backoffice.yml` passes on the exact same lockfile: it uses `npm ci`, which installs the lockfile verbatim rather than re-resolving.

#### Fix

Do the install and build in the workflow with `npm ci` — mirroring `test-backoffice.yml`, including the `.nvmrc` node version and npm caching — and hand Oryx the finished output via `skip_app_build: true`. This is the [documented way](https://learn.microsoft.com/en-us/azure/static-web-apps/build-configuration) to build a Static Web App externally.

Node setup and install flags are copied from `test-backoffice.yml` so the two stay consistent. There are no `prepare`/`postinstall` scripts, so `npm ci` alone reproduces what Oryx was doing.

### Testing

These jobs only run on a PR when it carries `preview/storybook` / `preview/backoffice`, so both labels are applied here to exercise them.