### PR TITLE
Block Editors: Expose pasted blocks for the active variant (closes #20327)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-actions/block-grid-paste-from-clipboard.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-actions/block-grid-paste-from-clipboard.ts
@@ -1,15 +1,15 @@
 import { UMB_BLOCK_GRID_PROPERTY_EDITOR_SCHEMA_ALIAS } from '../property-editors/block-grid-editor/constants.js';
 import type { UmbBlockGridValueModel } from '../types.js';
 import type { UmbBlockGridPropertyEditorConfig } from '../property-editors/block-grid-editor/types.js';
-import { UmbPasteFromClipboardPropertyAction } from '@umbraco-cms/backoffice/clipboard';
+import { UmbBlockPasteFromClipboardPropertyAction } from '../../block/property-actions/block-paste-from-clipboard.js';
 
 /**
  * The Block Grid Paste From Clipboard Property Action.
  * @exports
  * @class UmbBlockGridPasteFromClipboardPropertyAction
- * @augments UmbPasteFromClipboardPropertyAction
+ * @augments UmbBlockPasteFromClipboardPropertyAction
  */
-export class UmbBlockGridPasteFromClipboardPropertyAction extends UmbPasteFromClipboardPropertyAction {
+export class UmbBlockGridPasteFromClipboardPropertyAction extends UmbBlockPasteFromClipboardPropertyAction {
 	/**
 	 * Filters the picker based on the block grid property editor config.
 	 * @param {UmbBlockGridValueModel} propertyValue The property editor value.

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/clipboard/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/clipboard/manifests.ts
@@ -31,6 +31,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'propertyAction',
 		kind: 'pasteFromClipboard',
+		api: () => import('../../block/property-actions/block-paste-from-clipboard.js'),
 		alias: 'Umb.PropertyAction.BlockList.Clipboard.Paste',
 		name: 'Block List Paste From Clipboard Property Action',
 		forPropertyEditorUis,

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/clipboard/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/clipboard/manifests.ts
@@ -31,6 +31,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'propertyAction',
 		kind: 'pasteFromClipboard',
+		api: () => import('../../block/property-actions/block-paste-from-clipboard.js'),
 		alias: 'Umb.PropertyAction.BlockSingle.Clipboard.Paste',
 		name: 'Block Single Paste From Clipboard Property Action',
 		forPropertyEditorUis,

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/property-actions/block-paste-from-clipboard.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/property-actions/block-paste-from-clipboard.test.ts
@@ -1,0 +1,74 @@
+import { UmbBlockPasteFromClipboardPropertyAction } from './block-paste-from-clipboard.js';
+import type { UmbBlockValueDataPropertiesBaseType } from '../types.js';
+import { expect } from '@open-wc/testing';
+import { customElement } from 'lit/decorators.js';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+
+@customElement('test-block-paste-controller-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+/** Exposes the protected hook and lets a test stand in a variant without a real property context. */
+class TestableAction extends UmbBlockPasteFromClipboardPropertyAction {
+	setVariantId(variantId?: UmbVariantId) {
+		this._propertyContext = variantId
+			? ({ getVariantId: () => variantId } as unknown as typeof this._propertyContext)
+			: undefined;
+	}
+
+	prepare(value: UmbBlockValueDataPropertiesBaseType) {
+		return this._prepareValue(value);
+	}
+}
+
+describe('UmbBlockPasteFromClipboardPropertyAction', () => {
+	let hostElement: UmbTestControllerHostElement;
+	let action: TestableAction;
+
+	const value = (): UmbBlockValueDataPropertiesBaseType => ({
+		contentData: [
+			{ key: 'contentKey1', contentTypeKey: 'contentTypeKey', values: [] },
+			{ key: 'contentKey2', contentTypeKey: 'contentTypeKey', values: [] },
+		],
+		settingsData: [],
+		expose: [],
+	});
+
+	beforeEach(async () => {
+		hostElement = new UmbTestControllerHostElement();
+		document.body.innerHTML = '';
+		document.body.appendChild(hostElement);
+		action = new TestableAction(hostElement, { meta: {} } as never);
+	});
+
+	it('exposes every pasted block for the variant being edited', async () => {
+		action.setVariantId(UmbVariantId.Create({ culture: 'en-US', segment: null }));
+
+		const result = await action.prepare(value());
+
+		expect(result.expose).to.deep.equal([
+			{ contentKey: 'contentKey1', culture: 'en-US', segment: null },
+			{ contentKey: 'contentKey2', culture: 'en-US', segment: null },
+		]);
+	});
+
+	it('exposes as invariant when the property is invariant', async () => {
+		action.setVariantId(UmbVariantId.CreateInvariant());
+
+		const result = await action.prepare(value());
+
+		expect(result.expose).to.deep.equal([
+			{ contentKey: 'contentKey1', culture: null, segment: null },
+			{ contentKey: 'contentKey2', culture: null, segment: null },
+		]);
+	});
+
+	it('does not touch a value without content data', async () => {
+		action.setVariantId(UmbVariantId.CreateInvariant());
+
+		const empty: UmbBlockValueDataPropertiesBaseType = { contentData: [], settingsData: [], expose: [] };
+		const result = await action.prepare(empty);
+
+		expect(result.expose).to.deep.equal([]);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/property-actions/block-paste-from-clipboard.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/property-actions/block-paste-from-clipboard.ts
@@ -1,0 +1,43 @@
+import type { UmbBlockExposeModel, UmbBlockValueDataPropertiesBaseType } from '../types.js';
+import { UmbPasteFromClipboardPropertyAction } from '@umbraco-cms/backoffice/clipboard';
+
+/**
+ * Paste From Clipboard Property Action for Block property editors.
+ *
+ * A clipboard entry carries no `expose` entries, because whether a block is created is a property of
+ * the variant it is pasted into, not of the copied block. Without them the pasted blocks land
+ * uncreated and each one has to be created by hand before it can be published (#20327, #21855).
+ * @exports
+ * @class UmbBlockPasteFromClipboardPropertyAction
+ * @augments UmbPasteFromClipboardPropertyAction
+ */
+export class UmbBlockPasteFromClipboardPropertyAction extends UmbPasteFromClipboardPropertyAction {
+	/**
+	 * Exposes every pasted block for the variant being edited, mirroring what creating the block by
+	 * hand would have done. Other variants are deliberately left untouched, so a paste never creates
+	 * content in a language the editor is not working in.
+	 * @param {UmbBlockValueDataPropertiesBaseType} value The translated block property value.
+	 * @returns {Promise<UmbBlockValueDataPropertiesBaseType>} The value with `expose` populated.
+	 * @protected
+	 * @memberof UmbBlockPasteFromClipboardPropertyAction
+	 */
+	protected override async _prepareValue(
+		value: UmbBlockValueDataPropertiesBaseType,
+	): Promise<UmbBlockValueDataPropertiesBaseType> {
+		if (!value?.contentData?.length) return value;
+
+		const variantId = this._propertyContext?.getVariantId();
+		const culture = variantId?.culture ?? null;
+		const segment = variantId?.segment ?? null;
+
+		const expose: Array<UmbBlockExposeModel> = value.contentData.map((content) => ({
+			contentKey: content.key,
+			culture,
+			segment,
+		}));
+
+		return { ...value, expose };
+	}
+}
+
+export { UmbBlockPasteFromClipboardPropertyAction as api };

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/paste/paste-from-clipboard.property-action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/paste/paste-from-clipboard.property-action.ts
@@ -8,7 +8,7 @@ import { UmbPropertyActionBase, type UmbPropertyActionArgs } from '@umbraco-cms/
 
 export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<MetaPropertyActionPasteFromClipboardKind> {
 	#init: Promise<unknown>;
-	#propertyContext?: typeof UMB_PROPERTY_CONTEXT.TYPE;
+	protected _propertyContext?: typeof UMB_PROPERTY_CONTEXT.TYPE;
 	#clipboardContext?: typeof UMB_CLIPBOARD_PROPERTY_CONTEXT.TYPE;
 
 	constructor(host: UmbControllerHost, args: UmbPropertyActionArgs<MetaPropertyActionPasteFromClipboardKind>) {
@@ -16,7 +16,7 @@ export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<M
 
 		this.#init = Promise.all([
 			this.consumeContext(UMB_PROPERTY_CONTEXT, (context) => {
-				this.#propertyContext = context;
+				this._propertyContext = context;
 			}).asPromise({ preventTimeout: true }),
 
 			this.consumeContext(UMB_CLIPBOARD_PROPERTY_CONTEXT, (context) => {
@@ -30,12 +30,24 @@ export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<M
 		return true;
 	}
 
+	/**
+	 * Adjusts the translated value before it is written to the property. Property editors whose value
+	 * needs context that the clipboard entry cannot carry — such as the active variant — override this.
+	 * @param {*} value The translated property value.
+	 * @returns {Promise<*>} The value to write to the property.
+	 * @protected
+	 * @memberof UmbPasteFromClipboardPropertyAction
+	 */
+	protected async _prepareValue(value: any): Promise<any> {
+		return value;
+	}
+
 	override async execute() {
 		await this.#init;
 		if (!this.#clipboardContext) throw new Error('Clipboard context not found');
-		if (!this.#propertyContext) throw new Error('Property context not found');
+		if (!this._propertyContext) throw new Error('Property context not found');
 
-		const propertyEditorManifest = this.#propertyContext.getEditorManifest();
+		const propertyEditorManifest = this._propertyContext.getEditorManifest();
 
 		if (!propertyEditorManifest) {
 			throw new Error('Property editor manifest not found');
@@ -58,7 +70,7 @@ export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<M
 			throw new Error('No property value found');
 		}
 
-		const hasCurrentPropertyValue = this.#propertyContext.getValue();
+		const hasCurrentPropertyValue = this._propertyContext.getValue();
 
 		if (hasCurrentPropertyValue) {
 			const clipboardEntryItemRepository = new UmbClipboardEntryItemRepository(this);
@@ -79,7 +91,7 @@ export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<M
 			});
 		}
 
-		this.#propertyContext?.setValue(propertyValue);
+		this._propertyContext?.setValue(await this._prepareValue(propertyValue));
 	}
 }
 export { UmbPasteFromClipboardPropertyAction as api };


### PR DESCRIPTION
### Description

Pasting blocks from the clipboard left them uncreated: every pasted block showed a "Create" button and had to be clicked through by hand before it could be published.

A clipboard entry has no `expose` data — and shouldn't, since whether a block is *created* is a property of the variant you paste it into, not of the block you copied. The four paste translators therefore wrote `expose: []`, and nothing filled it in afterwards.

#### Why not fix it in the translators

That is where the empty array is, but the translators cannot resolve it: they are pure value translators with no property context, so they cannot know which variant is being edited. `UmbBlockExposeModel` needs `{ contentKey, culture, segment }`.

The paste property action does have that context (`UMB_PROPERTY_CONTEXT.getVariantId()`), and it already awaits it before doing anything, so it is deterministic rather than a race.

#### Change

- `UmbPasteFromClipboardPropertyAction` gets a `_prepareValue` hook, a no-op by default, applied to the translated value just before it is written to the property. `#propertyContext` becomes `protected _propertyContext` so subclasses can reach it.
- New `UmbBlockPasteFromClipboardPropertyAction` in the Block package overrides it and exposes each pasted block for the active variant.
- Block List and Block Single point their existing `pasteFromClipboard` manifests at it; Block Grid's action now extends it, keeping its own `_pickerFilter`.

#### On variance

Only the variant being edited is exposed, which mirrors what pressing "Create" on the block does. Exposing every variant found in `contentData` would silently create the block in languages the editor isn't working in — a surprising side effect, and the harder one to undo. Happy to revisit if the intent of `expose` differs from my reading.

### Testing

New unit tests for the shared action cover the variant case, the invariant case, and a value with no content data. Full `block` (66) and `clipboard` (49) suites pass, `tsc` is clean and there are no new circular dependencies.

Worth a manual check that a pasted block is immediately publishable without pressing "Create", in both an invariant and a culture-varying property.

Fixes #20327
Fixes #21855