### PR TITLE
Navigation Cache: Prevent concurrent alias map corruption (closes #23518)

### DIFF
--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -26,7 +26,9 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     private readonly ICoreScopeProvider _coreScopeProvider;
     private readonly INavigationRepository _navigationRepository;
     private readonly TContentTypeService _typeService;
-    private readonly Lazy<Dictionary<string, Guid>> _contentTypeAliasToKeyMap;
+    // concurrent because TryGetContentTypeKey lazily adds aliases resolved after the initial load,
+    // on live request threads; a non-concurrent map corrupts under parallel misses.
+    private readonly Lazy<ConcurrentDictionary<string, Guid>> _contentTypeAliasToKeyMap;
 
     /// <summary>
     ///     Bundles a navigation structure dictionary and its root keys into a single reference so that
@@ -109,7 +111,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         _coreScopeProvider = coreScopeProvider;
         _navigationRepository = navigationRepository;
         _typeService = typeService;
-        _contentTypeAliasToKeyMap = new Lazy<Dictionary<string, Guid>>(LoadContentTypes);
+        _contentTypeAliasToKeyMap = new Lazy<ConcurrentDictionary<string, Guid>>(LoadContentTypes);
     }
 
     /// <summary>
@@ -1037,7 +1039,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
 
     private bool TryGetContentTypeKey(string contentTypeAlias, out Guid? contentTypeKey)
     {
-        Dictionary<string, Guid> aliasToKeyMap = _contentTypeAliasToKeyMap.Value;
+        ConcurrentDictionary<string, Guid> aliasToKeyMap = _contentTypeAliasToKeyMap.Value;
 
         if (aliasToKeyMap.TryGetValue(contentTypeAlias, out Guid key))
         {
@@ -1090,6 +1092,6 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         }
     }
 
-    private Dictionary<string, Guid> LoadContentTypes()
-        => _typeService.GetAll().ToDictionary(ct => ct.Alias, ct => ct.Key);
+    private ConcurrentDictionary<string, Guid> LoadContentTypes()
+        => new(_typeService.GetAll().Select(ct => new KeyValuePair<string, Guid>(ct.Alias, ct.Key)));
 }

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -26,16 +26,19 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     private readonly ICoreScopeProvider _coreScopeProvider;
     private readonly INavigationRepository _navigationRepository;
     private readonly TContentTypeService _typeService;
-    // concurrent because TryGetContentTypeKey lazily adds aliases resolved after the initial load,
-    // on live request threads; a non-concurrent map corrupts under parallel misses.
+
+    // Concurrent because TryGetContentTypeKey lazily adds aliases resolved after the initial load,
+    // on live request threads; a non-concurrent map corrupts under parallel misses. See #23518.
     private readonly Lazy<ConcurrentDictionary<string, Guid>> _contentTypeAliasToKeyMap;
 
+#pragma warning disable CS0419 // Ambiguous reference in cref attribute
     /// <summary>
     ///     Bundles a navigation structure dictionary and its root keys into a single reference so that
     ///     <see cref="HandleRebuildAsync"/> can swap both atomically with one <see cref="Interlocked.Exchange{T}"/>
     ///     call and readers always observe a consistent pair. Also carries the per-snapshot
     ///     descendants cache populated by <see cref="TryGetDescendantsKeysFromStructure"/>.
     /// </summary>
+#pragma warning restore CS0419 // Ambiguous reference in cref attribute
     private sealed record NavigationSnapshot(
         ConcurrentDictionary<Guid, NavigationNode> Structure,
         HashSet<Guid> Roots)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
@@ -1991,6 +1992,79 @@ public class ContentNavigationServiceBaseTests
         var descendantsCountAfterRestore = restoredDescendantsKeys.Count();
 
         Assert.AreEqual(initialDescendantsCount, descendantsCountAfterRestore);
+    }
+
+    [Test]
+    public async Task Concurrent_Queries_By_Unmapped_Aliases_Do_Not_Corrupt_The_Alias_Map()
+    {
+        // Arrange
+        // the alias-to-key map is seeded from GetAll(); returning nothing here sends the first
+        // lookup per alias through the miss path, which resolves the type individually and writes
+        // it back to the map (later lookups of the same alias read the cached entry). Concurrent
+        // writes to a non-thread-safe map corrupt its internal state, after which every navigation
+        // query by alias throws (or livelocks) until the process is restarted.
+        var contentTypeKeys = new ConcurrentDictionary<string, Guid>();
+        var contentTypeServiceMock = new Mock<IContentTypeService>();
+        contentTypeServiceMock.Setup(x => x.GetAll()).Returns([]);
+        contentTypeServiceMock
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns((string alias) =>
+            {
+                Guid key = contentTypeKeys.GetOrAdd(alias, _ => Guid.NewGuid());
+                var contentTypeMock = new Mock<IContentType>();
+                contentTypeMock.SetupGet(x => x.Alias).Returns(alias);
+                contentTypeMock.SetupGet(x => x.Key).Returns(key);
+                return contentTypeMock.Object;
+            });
+
+        var navigationService = new TestContentNavigationService(
+            Mock.Of<ICoreScopeProvider>(),
+            Mock.Of<INavigationRepository>(),
+            contentTypeServiceMock.Object);
+
+        const int AliasCount = 512;
+        const int ThreadCount = 8;
+        var exceptions = new ConcurrentQueue<Exception>();
+
+        // all workers start their lookups together to maximise concurrent misses on the map
+        using var startGate = new Barrier(ThreadCount);
+
+        // Act
+        Task workers = Task.WhenAll(Enumerable.Range(0, ThreadCount).Select(thread => Task.Run(() =>
+        {
+            startGate.SignalAndWait();
+            for (var i = 0; i < AliasCount; i++)
+            {
+                try
+                {
+                    navigationService.TryGetRootKeysOfType($"alias{i}", out _);
+                }
+                catch (Exception exception)
+                {
+                    exceptions.Enqueue(exception);
+                }
+            }
+        })));
+
+        // a corrupted dictionary can also livelock readers in an infinite bucket cycle, so a hang
+        // here is a failure mode of its own, not just slowness.
+        Task completed = await Task.WhenAny(workers, Task.Delay(TimeSpan.FromSeconds(30)));
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(workers, completed, "Concurrent alias lookups did not finish; the alias map has likely livelocked.");
+            Assert.IsEmpty(exceptions, $"Concurrent alias lookups threw: {exceptions.FirstOrDefault()}");
+        });
+
+        // observe any worker fault raised outside the per-lookup try (e.g. from the start gate)
+        await workers;
+
+        // the map must still resolve every alias correctly after the concurrent misses
+        for (var i = 0; i < AliasCount; i++)
+        {
+            Assert.IsTrue(navigationService.TryGetRootKeysOfType($"alias{i}", out _));
+        }
     }
 
     private void CreateTestData()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
@@ -1998,23 +1998,33 @@ public class ContentNavigationServiceBaseTests
     public async Task Concurrent_Queries_By_Unmapped_Aliases_Do_Not_Corrupt_The_Alias_Map()
     {
         // Arrange
-        // the alias-to-key map is seeded from GetAll(); returning nothing here sends the first
+        // The alias-to-key map is seeded from GetAll(); returning nothing here sends the first
         // lookup per alias through the miss path, which resolves the type individually and writes
         // it back to the map (later lookups of the same alias read the cached entry). Concurrent
         // writes to a non-thread-safe map corrupt its internal state, after which every navigation
         // query by alias throws (or livelocks) until the process is restarted.
-        var contentTypeKeys = new ConcurrentDictionary<string, Guid>();
+        const int AliasCount = 512;
+        const int ThreadCount = 8;
+
+        // Built up front so the worker threads run nothing but the lookup under test: anything else
+        // running there can fail for its own reasons and read as a corrupted map.
+        var contentTypes = Enumerable.Range(0, AliasCount).ToDictionary(
+            i => $"alias{i}",
+            _ =>
+            {
+                var key = Guid.NewGuid();
+                return Mock.Of<IContentType>(x => x.Key == key);
+            });
+
+        var resolvedAliases = new ConcurrentDictionary<string, int>();
         var contentTypeServiceMock = new Mock<IContentTypeService>();
         contentTypeServiceMock.Setup(x => x.GetAll()).Returns([]);
         contentTypeServiceMock
             .Setup(x => x.Get(It.IsAny<string>()))
             .Returns((string alias) =>
             {
-                Guid key = contentTypeKeys.GetOrAdd(alias, _ => Guid.NewGuid());
-                var contentTypeMock = new Mock<IContentType>();
-                contentTypeMock.SetupGet(x => x.Alias).Returns(alias);
-                contentTypeMock.SetupGet(x => x.Key).Returns(key);
-                return contentTypeMock.Object;
+                resolvedAliases.AddOrUpdate(alias, 1, (_, count) => count + 1);
+                return contentTypes[alias];
             });
 
         var navigationService = new TestContentNavigationService(
@@ -2022,49 +2032,64 @@ public class ContentNavigationServiceBaseTests
             Mock.Of<INavigationRepository>(),
             contentTypeServiceMock.Object);
 
-        const int AliasCount = 512;
-        const int ThreadCount = 8;
         var exceptions = new ConcurrentQueue<Exception>();
 
-        // all workers start their lookups together to maximise concurrent misses on the map
-        using var startGate = new Barrier(ThreadCount);
+        // All workers start their lookups together to maximise concurrent misses on the map, on
+        // dedicated threads so releasing the gate never waits on thread pool growth.
+        var startGate = new Barrier(ThreadCount);
 
         // Act
-        Task workers = Task.WhenAll(Enumerable.Range(0, ThreadCount).Select(thread => Task.Run(() =>
-        {
-            startGate.SignalAndWait();
-            for (var i = 0; i < AliasCount; i++)
+        Task workers = Task.WhenAll(Enumerable.Range(0, ThreadCount).Select(thread => Task.Factory.StartNew(
+            () =>
             {
-                try
+                startGate.SignalAndWait();
+                for (var i = 0; i < AliasCount; i++)
                 {
-                    navigationService.TryGetRootKeysOfType($"alias{i}", out _);
+                    try
+                    {
+                        navigationService.TryGetRootKeysOfType($"alias{i}", out _);
+                    }
+                    catch (Exception exception)
+                    {
+                        exceptions.Enqueue(exception);
+                    }
                 }
-                catch (Exception exception)
-                {
-                    exceptions.Enqueue(exception);
-                }
-            }
-        })));
+            },
+            TaskCreationOptions.LongRunning)));
 
-        // a corrupted dictionary can also livelock readers in an infinite bucket cycle, so a hang
+        // A corrupted dictionary can also livelock readers in an infinite bucket cycle, so a hang
         // here is a failure mode of its own, not just slowness.
         Task completed = await Task.WhenAny(workers, Task.Delay(TimeSpan.FromSeconds(30)));
 
         // Assert
+        // The gate is disposed only once the workers are done, never with `using`: on the livelock
+        // path they are still blocked on it.
         Assert.Multiple(() =>
         {
-            Assert.AreEqual(workers, completed, "Concurrent alias lookups did not finish; the alias map has likely livelocked.");
+            Assert.AreSame(workers, completed, "Concurrent alias lookups did not finish; the alias map has likely livelocked.");
             Assert.IsEmpty(exceptions, $"Concurrent alias lookups threw: {exceptions.FirstOrDefault()}");
         });
 
-        // observe any worker fault raised outside the per-lookup try (e.g. from the start gate)
+        // Observe any worker fault raised outside the per-lookup try (e.g. from the start gate).
         await workers;
+        startGate.Dispose();
 
-        // the map must still resolve every alias correctly after the concurrent misses
+        Assert.AreEqual(AliasCount, resolvedAliases.Count, "Not every alias was resolved through the miss path, so the concurrent map writes under test never ran.");
+
+        // Every alias must now be served from the map, and resolve to its own key: one root node per
+        // content type makes a crossed entry visible as the wrong node rather than just a true result.
+        resolvedAliases.Clear();
         for (var i = 0; i < AliasCount; i++)
         {
-            Assert.IsTrue(navigationService.TryGetRootKeysOfType($"alias{i}", out _));
+            var alias = $"alias{i}";
+            var rootKey = Guid.NewGuid();
+            navigationService.Add(rootKey, contentTypes[alias].Key);
+
+            Assert.IsTrue(navigationService.TryGetRootKeysOfType(alias, out IEnumerable<Guid> rootKeys));
+            CollectionAssert.AreEqual(new[] { rootKey }, rootKeys, $"Alias '{alias}' did not resolve to its own content type key.");
         }
+
+        Assert.IsEmpty(resolvedAliases, "Aliases were resolved through the content type service again, so not every concurrent write reached the alias map.");
     }
 
     private void CreateTestData()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #23518

### Description

`ContentNavigationServiceBase` lazily seeds a shared alias-to-key map. If an alias is absent, `TryGetContentTypeKey` resolves it through `_typeService.Get(alias)` and adds it to the map. The current `Dictionary` is therefore mutated by concurrent request threads, which can corrupt it and make subsequent alias lookups fail until the process restarts.

This changes the map to `ConcurrentDictionary`. The existing `TryGetValue`/`TryAdd` flow, default case-sensitive comparer, and duplicate-alias constructor behaviour are preserved.

The cache remains process-lifetime and grow-only. Content type rename and delete invalidation is outside this change.

### How to test

1. Run:
   `dotnet test tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj -p:UmbracoBuild=Cli --filter "FullyQualifiedName~Concurrent_Queries_By_Unmapped_Aliases_Do_Not_Corrupt_The_Alias_Map"`
2. Run:
   `dotnet test tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj -p:UmbracoBuild=Cli --filter "FullyQualifiedName~Navigation"`

The focused regression test forces concurrent miss-path writes from 8 workers across 512 aliases, verifies no lookup throws or hangs, then verifies every alias remains resolvable.
