### PR TITLE
Imaging: Enforce max width/height when HMAC is configured

### DIFF
--- a/src/Umbraco.Cms.Imaging.ImageSharp/CLAUDE.md
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/CLAUDE.md
@@ -128,13 +128,13 @@ if (_options.HMACSecretKey.Length != 0 && _requestAuthorizationUtilities is not 
 }
 ```
 
-### Security: Size Limits Without HMAC
+### Security: Max Dimension Limits
 
-When HMAC is not configured, `ConfigureImageSharpMiddlewareOptions.cs:46-83` enforces max dimensions:
+`ConfigureImageSharpMiddlewareOptions.cs` enforces max dimensions on every request, **regardless of whether HMAC is configured**:
 - Width/height requests exceeding `MaxWidth`/`MaxHeight` are **stripped** from the query
 - This prevents DoS via excessive image generation
 
-When HMAC **is** configured, size validation is skipped (trusted requests).
+HMAC and the size limits do two separate jobs: HMAC controls *who* may request processing, while `MaxWidth`/`MaxHeight` control *how large* the output may be. The dimension ceiling therefore still applies to validly-signed requests — for legitimate (server-generated) URLs it is a no-op, and it remains a useful backstop if the HMAC secret key ever leaks.
 
 ### Cache Busting
 

--- a/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
@@ -53,7 +53,6 @@ public sealed class ConfigureImageSharpMiddlewareOptions : IConfigureOptions<Ima
             // Enforce the configured maximum dimensions regardless of HMAC. HMAC authorizes *who*
             // may request processing; MaxWidth/MaxHeight bound *how large* the output may be, and
             // that ceiling stays useful for signed requests too (e.g. if the secret key leaks).
-
             if (context.Commands.Contains(ResizeWebProcessor.Width))
             {
                 if (!int.TryParse(

--- a/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ConfigureImageSharpMiddlewareOptions.cs
@@ -45,11 +45,14 @@ public sealed class ConfigureImageSharpMiddlewareOptions : IConfigureOptions<Ima
         // Use configurable maximum width and height
         options.OnParseCommandsAsync = context =>
         {
-            if (context.Commands.Count == 0 || _imagingSettings.HMACSecretKey.Length > 0)
+            if (context.Commands.Count == 0)
             {
-                // Nothing to parse or using HMAC authentication
                 return Task.CompletedTask;
             }
+
+            // Enforce the configured maximum dimensions regardless of HMAC. HMAC authorizes *who*
+            // may request processing; MaxWidth/MaxHeight bound *how large* the output may be, and
+            // that ceiling stays useful for signed requests too (e.g. if the secret key leaks).
 
             if (context.Commands.Contains(ResizeWebProcessor.Width))
             {

--- a/src/Umbraco.Core/Configuration/Models/ImagingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingSettings.cs
@@ -16,6 +16,7 @@ public class ImagingSettings
     /// </summary>
     /// <remarks>
     /// Setting or updating this value will cause all existing generated URLs to become invalid and return a 400 Bad Request response code.
+    /// The <see cref="ImagingResizeSettings.MaxWidth" />/<see cref="ImagingResizeSettings.MaxHeight" /> limits are still enforced even when this key is set.
     /// </remarks>
     public byte[] HMACSecretKey { get; set; } = Array.Empty<byte>();
 

--- a/src/Umbraco.Core/Configuration/Models/ImagingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingSettings.cs
@@ -16,7 +16,6 @@ public class ImagingSettings
     /// </summary>
     /// <remarks>
     /// Setting or updating this value will cause all existing generated URLs to become invalid and return a 400 Bad Request response code.
-    /// When set, the maximum resize settings are not used/validated anymore, because you can only request URLs with a valid HMAC token anyway.
     /// </remarks>
     public byte[] HMACSecretKey { get; set; } = Array.Empty<byte>();
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Media/ConfigureImageSharpMiddlewareOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Media/ConfigureImageSharpMiddlewareOptionsTests.cs
@@ -57,6 +57,16 @@ public class ConfigureImageSharpMiddlewareOptionsTests
     }
 
     [Test]
+    public async Task Cannot_Request_Negative_Height_When_Hmac_Configured()
+    {
+        ImageCommandContext context = BuildContext((ResizeWebProcessor.Height, "-100"));
+
+        await ConfigureAndParse(withHmac: true, context);
+
+        Assert.IsFalse(context.Commands.Contains(ResizeWebProcessor.Height));
+    }
+
+    [Test]
     public async Task Can_Request_Dimensions_Within_Maximum_When_Hmac_Configured()
     {
         ImageCommandContext context = BuildContext(

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Media/ConfigureImageSharpMiddlewareOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Media/ConfigureImageSharpMiddlewareOptionsTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using SixLabors.ImageSharp.Web.Commands;
+using SixLabors.ImageSharp.Web.Commands.Converters;
+using SixLabors.ImageSharp.Web.Middleware;
+using SixLabors.ImageSharp.Web.Processors;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Imaging.ImageSharp;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Media;
+
+[TestFixture]
+public class ConfigureImageSharpMiddlewareOptionsTests
+{
+    private const int MaxWidth = ImagingResizeSettings.StaticMaxWidth;
+    private const int MaxHeight = ImagingResizeSettings.StaticMaxHeight;
+
+    private static readonly byte[] _hmacKey =
+    {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+    };
+
+    [Test]
+    public async Task Cannot_Request_Width_Above_Maximum_When_Hmac_Configured()
+    {
+        ImageCommandContext context = BuildContext((ResizeWebProcessor.Width, (MaxWidth + 1000).ToString(CultureInfo.InvariantCulture)));
+
+        await ConfigureAndParse(withHmac: true, context);
+
+        Assert.IsFalse(context.Commands.Contains(ResizeWebProcessor.Width));
+    }
+
+    [Test]
+    public async Task Cannot_Request_Height_Above_Maximum_When_Hmac_Configured()
+    {
+        ImageCommandContext context = BuildContext((ResizeWebProcessor.Height, (MaxHeight + 1000).ToString(CultureInfo.InvariantCulture)));
+
+        await ConfigureAndParse(withHmac: true, context);
+
+        Assert.IsFalse(context.Commands.Contains(ResizeWebProcessor.Height));
+    }
+
+    [Test]
+    public async Task Cannot_Request_Negative_Width_When_Hmac_Configured()
+    {
+        ImageCommandContext context = BuildContext((ResizeWebProcessor.Width, "-100"));
+
+        await ConfigureAndParse(withHmac: true, context);
+
+        Assert.IsFalse(context.Commands.Contains(ResizeWebProcessor.Width));
+    }
+
+    [Test]
+    public async Task Can_Request_Dimensions_Within_Maximum_When_Hmac_Configured()
+    {
+        ImageCommandContext context = BuildContext(
+            (ResizeWebProcessor.Width, "800"),
+            (ResizeWebProcessor.Height, "600"));
+
+        await ConfigureAndParse(withHmac: true, context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(context.Commands.Contains(ResizeWebProcessor.Width));
+            Assert.AreEqual("800", context.Commands[ResizeWebProcessor.Width]);
+            Assert.IsTrue(context.Commands.Contains(ResizeWebProcessor.Height));
+            Assert.AreEqual("600", context.Commands[ResizeWebProcessor.Height]);
+        });
+    }
+
+    [Test]
+    public async Task Cannot_Request_Width_Above_Maximum_When_Hmac_Not_Configured()
+    {
+        ImageCommandContext context = BuildContext((ResizeWebProcessor.Width, (MaxWidth + 1000).ToString(CultureInfo.InvariantCulture)));
+
+        await ConfigureAndParse(withHmac: false, context);
+
+        Assert.IsFalse(context.Commands.Contains(ResizeWebProcessor.Width));
+    }
+
+    private static async Task ConfigureAndParse(bool withHmac, ImageCommandContext context)
+    {
+        var settings = new ImagingSettings
+        {
+            HMACSecretKey = withHmac ? _hmacKey : Array.Empty<byte>(),
+        };
+
+        var sut = new ConfigureImageSharpMiddlewareOptions(
+            SixLabors.ImageSharp.Configuration.Default.Clone(),
+            Options.Create(settings));
+
+        var options = new ImageSharpMiddlewareOptions();
+        sut.Configure(options);
+
+        await options.OnParseCommandsAsync(context);
+    }
+
+    private static ImageCommandContext BuildContext(params (string Key, string Value)[] commands)
+    {
+        var collection = new CommandCollection();
+        foreach ((var key, var value) in commands)
+        {
+            collection.Add(key, value);
+        }
+
+        return new ImageCommandContext(
+            new DefaultHttpContext(),
+            collection,
+            new CommandParser(Enumerable.Empty<ICommandConverter>()),
+            CultureInfo.InvariantCulture);
+    }
+}


### PR DESCRIPTION
## Description

We have a fallback check in place when processing images such that, even when [an HMAC setting](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/configuration/imagingsettings#hash-based-message-authentication-code-hmac-secret-key) is not in place, there's still some protection against a malicious request for a very large image. This is provided by the [max width/height settings](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/configuration/imagingsettings#max-width-max-height): a resize request for dimensions above the configured maximum has the offending `width`/`height` stripped from the request before it reaches the image pipeline.

We currently don't apply that check when an HMAC secret key is in place, as HMAC is considered sufficient (and much more comprehensive) protection — only URLs signed by the site itself are honoured, so an outside caller can't request an arbitrary size anyway.

That behaviour isn't documented though, and leaves two rough edges:

- **Inconsistency** — the max width/height settings are silently ignored when HMAC is configured, which is surprising.
- **No backstop if the secret key leaks** — if the HMAC key is ever exposed, there's nothing capping the requested dimensions.

So, as a consistency fix and a small security hardening, this PR applies the max width/height check on every request, regardless of whether HMAC is configured. As before, an over-sized dimension is stripped rather than the whole request being rejected. For legitimate, site-generated URLs (which are always within the limits) this is a no-op, so there's no change to normal behaviour.

Note that the `Umbraco.Cms.Imaging.ImageSharp2` package already applied this check unconditionally (it has no HMAC support), so this also brings the two imaging packages into line.

## Testing

### Automated

`ConfigureImageSharpMiddlewareOptionsTests` has been introduced to verify this fix and provide coverage around the existing behaviour of the class.

### Manual

Verified on a local site with an HMAC secret key configured (`MaxWidth`/`MaxHeight` left at their `5000` defaults), using a media item and `GetCropUrl`. The source image is 850×567.

| Request | Result |
|---------|--------|
| Signed, within limits (`width=400&height=300`) | `200` — rendered at 400×300 (behaviour unchanged) |
| Signed, above the maximum (`width=5500&height=5500`) | `200` — over-sized dimensions stripped; image returned at its native 850×567, **not** the requested size |
| Tampered signed URL (`width` bumped to 5500, signature unchanged) | `400 Bad Request` — rejected by the HMAC check before any decoding |

As a control, a signed request within the limit but larger than the source (`width=2000`) upscaled to 2000×2000 as expected — confirming the stripped result above is the max-dimension check taking effect, not ImageSharp declining to upscale.

Note that a legitimately-signed over-sized request is served at native size rather than rejected: the HMAC is validated against the originally-signed command set first, then the over-sized dimensions are stripped, leaving no resize to apply. Legitimate site-generated URLs are always within the limits, so this is a no-op for them.

The following can be dropped into a template to reproduce (replace the media key with one from your own site):

```cshtml
@using Umbraco.Cms.Core.Configuration.Models
@using Microsoft.Extensions.Options
@inject IOptions<ImagingSettings> ImagingOptions
@{
    var imgKey = new Guid("17d0df50-111c-4469-95fe-319e1ed7c154");
    var imgMedia = Umbraco.Media(imgKey);

    var hmacConfigured = ImagingOptions.Value.HMACSecretKey.Length > 0;
    var maxWidth = ImagingOptions.Value.Resize.MaxWidth;
    var maxHeight = ImagingOptions.Value.Resize.MaxHeight;
    var oversized = maxWidth + 500;

    // Legitimate, within limits: signed by Umbraco's URL generator.
    var legitUrl = imgMedia?.GetCropUrl(width: 400, height: 300);

    // Legitimate, oversized: still signed by Umbraco, but requesting above the configured MaxWidth.
    // This is the case the fix changes - the oversized dimensions are stripped during command parsing.
    var legitOversizedUrl = imgMedia?.GetCropUrl(width: oversized, height: maxHeight + 500);

    // Illegitimate: take the legit (within-limit) signed URL and tamper the requested width.
    // The HMAC token was computed for width=400, so changing it invalidates the signature.
    var tamperedUrl = legitUrl?.Replace("width=400", "width=" + oversized);
}
@if (imgMedia is null)
{
    <p style="color:red">No media found for key @imgKey.</p>
}
else
{
    <table border="1" cellpadding="6">
        <tr><td>HMAC configured</td><td>@hmacConfigured</td></tr>
        <tr><td>Configured MaxWidth / MaxHeight</td><td>@maxWidth / @maxHeight</td></tr>
    </table>

    <h4>1. Legitimate signed crop (400×300, within limits) — expected: renders normally</h4>
    <p><code>@legitUrl</code></p>
    <img src="@legitUrl" alt="legit within-limit crop" />

    <h4>2. Legitimate signed crop, oversized (@oversized wide) — expected: requested size NOT honoured</h4>
    <p><code>@legitOversizedUrl</code></p>
    <p><a href="@legitOversizedUrl" target="_blank">Open oversized signed URL directly</a></p>
    <img src="@legitOversizedUrl" alt="legit oversized crop" />

    <h4>3. Illegitimate / tampered crop (width bumped to @oversized on a signed URL) — expected: 400 Bad Request</h4>
    <p><code>@tamperedUrl</code></p>
    <p><a href="@tamperedUrl" target="_blank">Open tampered URL directly</a></p>
}
```
