### PR TITLE
Block editors: Pair inner block values by block key when merging variant data (closes #23525)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/property-value-resolver/block-value-resolver.api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/property-value-resolver/block-value-resolver.api.ts
@@ -2,28 +2,35 @@ import type { UmbBlockDataValueModel, UmbBlockExposeModel, UmbBlockValueDataProp
 import type { UmbElementValueModel } from '@umbraco-cms/backoffice/content';
 import type { UmbPropertyValueResolver } from '@umbraco-cms/backoffice/property';
 
+export type UmbBlockValuesCallback = (
+	values: Array<UmbBlockDataValueModel>,
+	groupIdentifier?: string,
+) => Promise<Array<UmbBlockDataValueModel> | undefined>;
+
 export abstract class UmbBlockValueResolver<ValueType>
 	implements UmbPropertyValueResolver<UmbElementValueModel<ValueType>, UmbBlockDataValueModel, UmbBlockExposeModel>
 {
 	abstract processValues(
 		property: UmbElementValueModel<ValueType>,
-		valuesCallback: (values: Array<UmbBlockDataValueModel>) => Promise<Array<UmbBlockDataValueModel> | undefined>,
+		valuesCallback: UmbBlockValuesCallback,
 	): Promise<UmbElementValueModel<ValueType>>;
 
 	protected async _processValueBlockData<ValueType extends UmbBlockValueDataPropertiesBaseType>(
 		value: ValueType,
-		valuesCallback: (values: Array<UmbBlockDataValueModel>) => Promise<Array<UmbBlockDataValueModel> | undefined>,
+		valuesCallback: UmbBlockValuesCallback,
 	) {
+		// The group identifier ties each call back to its specific block, so consumers can pair
+		// two block values up by block instead of by the order the callback happens to fire in.
 		const contentData = await Promise.all(
 			(value.contentData ?? []).map(async (entry) => ({
 				...entry,
-				values: (await valuesCallback(entry.values)) ?? [],
+				values: (await valuesCallback(entry.values, `contentData:${entry.key}`)) ?? [],
 			})),
 		);
 		const settingsData = await Promise.all(
 			(value.settingsData ?? []).map(async (entry) => ({
 				...entry,
-				values: (await valuesCallback(entry.values)) ?? [],
+				values: (await valuesCallback(entry.values, `settingsData:${entry.key}`)) ?? [],
 			})),
 		);
 		return { ...value, contentData, settingsData };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/property-value-resolver/standard-block-value-resolver.api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/property-value-resolver/standard-block-value-resolver.api.ts
@@ -1,12 +1,9 @@
-import type { UmbBlockDataValueModel, UmbBlockExposeModel, UmbBlockValueType } from '../types.js';
-import { UmbBlockValueResolver } from './block-value-resolver.api.js';
+import type { UmbBlockExposeModel, UmbBlockValueType } from '../types.js';
+import { UmbBlockValueResolver, type UmbBlockValuesCallback } from './block-value-resolver.api.js';
 import type { UmbElementValueModel } from '@umbraco-cms/backoffice/content';
 
 export class UmbStandardBlockValueResolver extends UmbBlockValueResolver<UmbBlockValueType> {
-	async processValues(
-		property: UmbElementValueModel<UmbBlockValueType>,
-		valuesCallback: (values: Array<UmbBlockDataValueModel>) => Promise<Array<UmbBlockDataValueModel> | undefined>,
-	) {
+	async processValues(property: UmbElementValueModel<UmbBlockValueType>, valuesCallback: UmbBlockValuesCallback) {
 		if (property.value) {
 			return {
 				...property,

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/controller/merge-content-variant-data.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/controller/merge-content-variant-data.controller.test.ts
@@ -102,21 +102,26 @@ const block = (key: string, valuesByCulture: Record<string, string>) => ({
 	values: Object.entries(valuesByCulture).map(([culture, value]) => innerValue(culture, value)),
 });
 
+/** Registers a property value resolver for the duration of each test in the current describe. */
+const useResolver = (alias: string, api: ManifestPropertyValueResolver['api'], forEditorAlias: string) => {
+	beforeEach(async () => {
+		umbExtensionsRegistry.register({
+			type: 'propertyValueResolver',
+			name: alias,
+			alias,
+			api,
+			forEditorAlias,
+		} as ManifestPropertyValueResolver);
+	});
+
+	afterEach(async () => {
+		umbExtensionsRegistry.unregister(alias);
+	});
+};
+
 describe('UmbMergeContentVariantDataController', () => {
 	describe('Block-shaped resolver', () => {
-		beforeEach(async () => {
-			umbExtensionsRegistry.register({
-				type: 'propertyValueResolver',
-				name: 'test-block-resolver',
-				alias: 'Umb.Test.Resolver.Block',
-				api: TestBlockValueResolver,
-				forEditorAlias: 'test-block-editor',
-			} as ManifestPropertyValueResolver);
-		});
-
-		afterEach(async () => {
-			umbExtensionsRegistry.unregister('Umb.Test.Resolver.Block');
-		});
+		useResolver('Umb.Test.Resolver.Block', TestBlockValueResolver, 'test-block-editor');
 
 		it('pairs inner values by block key, not by array position', async () => {
 			const ctrlHost = new UmbTestControllerHostElement();
@@ -167,21 +172,7 @@ describe('UmbMergeContentVariantDataController', () => {
 	});
 
 	describe('Simple resolver', () => {
-		beforeEach(async () => {
-			const manifest: ManifestPropertyValueResolver = {
-				type: 'propertyValueResolver',
-				name: 'test-resolver-1',
-				alias: 'Umb.Test.Resolver.1',
-				api: TestPropertyValueResolver,
-				forEditorAlias: 'test-editor',
-			};
-
-			umbExtensionsRegistry.register(manifest);
-		});
-
-		afterEach(async () => {
-			umbExtensionsRegistry.unregister('Umb.Test.Resolver.1');
-		});
+		useResolver('Umb.Test.Resolver.1', TestPropertyValueResolver, 'test-editor');
 
 		it('transfers inner values of select variants', async () => {
 			const ctrlHost = new UmbTestControllerHostElement();

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/controller/merge-content-variant-data.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/controller/merge-content-variant-data.controller.test.ts
@@ -96,6 +96,12 @@ const innerValue = (culture: string | null, value: string): UmbPropertyValueData
 	value,
 });
 
+/** A block holding one `text` value per culture, keyed by culture. */
+const block = (key: string, valuesByCulture: Record<string, string>) => ({
+	key,
+	values: Object.entries(valuesByCulture).map(([culture, value]) => innerValue(culture, value)),
+});
+
 describe('UmbMergeContentVariantDataController', () => {
 	describe('Block-shaped resolver', () => {
 		beforeEach(async () => {
@@ -120,9 +126,9 @@ describe('UmbMergeContentVariantDataController', () => {
 			const persistedData: UmbContentLikeDetailModel = {
 				values: [
 					blockValue([
-						{ key: 'block-a', values: [innerValue('da', 'a-da'), innerValue('de', 'a-de')] },
-						{ key: 'block-b', values: [innerValue('da', 'b-da'), innerValue('de', 'b-de')] },
-						{ key: 'block-c', values: [innerValue('da', 'c-da'), innerValue('de', 'c-de')] },
+						block('block-a', { da: 'a-da', de: 'a-de' }),
+						block('block-b', { da: 'b-da', de: 'b-de' }),
+						block('block-c', { da: 'c-da', de: 'c-de' }),
 					]),
 				],
 			};
@@ -132,8 +138,8 @@ describe('UmbMergeContentVariantDataController', () => {
 			const runtimeData: UmbContentLikeDetailModel = {
 				values: [
 					blockValue([
-						{ key: 'block-b', values: [innerValue('da', 'b-da'), innerValue('de', 'b-de-edited')] },
-						{ key: 'block-c', values: [innerValue('da', 'c-da'), innerValue('de', 'c-de-edited')] },
+						block('block-b', { da: 'b-da', de: 'b-de-edited' }),
+						block('block-c', { da: 'c-da', de: 'c-de-edited' }),
 					]),
 				],
 			};

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/controller/merge-content-variant-data.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/controller/merge-content-variant-data.controller.test.ts
@@ -45,7 +45,121 @@ export class TestPropertyValueResolver
 	destroy(): void {}
 }
 
+type TestBlockValueType = {
+	contentData: Array<{ key: string; values: Array<UmbPropertyValueData> }>;
+};
+
+/**
+ * Mirrors UmbBlockValueResolver._processValueBlockData: the values callback is invoked
+ * once per contentData entry, in array order.
+ */
+export class TestBlockValueResolver
+	implements
+		UmbPropertyValueResolver<UmbPropertyValueData<TestBlockValueType>, UmbPropertyValueData, UmbVariantDataModel>
+{
+	async processValues(
+		property: UmbPropertyValueData<TestBlockValueType>,
+		valuesCallback: (
+			values: Array<UmbPropertyValueData>,
+			groupIdentifier?: string,
+		) => Promise<Array<UmbPropertyValueData> | undefined>,
+	) {
+		if (property.value) {
+			const contentData = await Promise.all(
+				property.value.contentData.map(async (entry) => ({
+					...entry,
+					values: (await valuesCallback(entry.values, `contentData:${entry.key}`)) ?? [],
+				})),
+			);
+			return { ...property, value: { ...property.value, contentData } };
+		}
+		return property;
+	}
+
+	destroy(): void {}
+}
+
+const blockValue = (contentData: TestBlockValueType['contentData']) => ({
+	editorAlias: 'test-block-editor',
+	alias: 'blocks',
+	culture: null,
+	segment: null,
+	entityType: '',
+	value: { contentData },
+});
+
+const innerValue = (culture: string | null, value: string): UmbPropertyValueData => ({
+	editorAlias: 'some-editor',
+	alias: 'text',
+	culture,
+	segment: null,
+	value,
+});
+
 describe('UmbMergeContentVariantDataController', () => {
+	describe('Block-shaped resolver', () => {
+		beforeEach(async () => {
+			umbExtensionsRegistry.register({
+				type: 'propertyValueResolver',
+				name: 'test-block-resolver',
+				alias: 'Umb.Test.Resolver.Block',
+				api: TestBlockValueResolver,
+				forEditorAlias: 'test-block-editor',
+			} as ManifestPropertyValueResolver);
+		});
+
+		afterEach(async () => {
+			umbExtensionsRegistry.unregister('Umb.Test.Resolver.Block');
+		});
+
+		it('pairs inner values by block key, not by array position', async () => {
+			const ctrlHost = new UmbTestControllerHostElement();
+			const ctrl = new UmbMergeContentVariantDataController(ctrlHost);
+
+			// Persisted: three blocks, each with a Danish and a German value.
+			const persistedData: UmbContentLikeDetailModel = {
+				values: [
+					blockValue([
+						{ key: 'block-a', values: [innerValue('da', 'a-da'), innerValue('de', 'a-de')] },
+						{ key: 'block-b', values: [innerValue('da', 'b-da'), innerValue('de', 'b-de')] },
+						{ key: 'block-c', values: [innerValue('da', 'c-da'), innerValue('de', 'c-de')] },
+					]),
+				],
+			};
+
+			// Draft: the first block has been deleted, so every remaining block now sits one
+			// position earlier than it does in the persisted data.
+			const runtimeData: UmbContentLikeDetailModel = {
+				values: [
+					blockValue([
+						{ key: 'block-b', values: [innerValue('da', 'b-da'), innerValue('de', 'b-de-edited')] },
+						{ key: 'block-c', values: [innerValue('da', 'c-da'), innerValue('de', 'c-de-edited')] },
+					]),
+				],
+			};
+
+			// Saving German only: Danish values must be carried over from the persisted data.
+			const variants = [new UmbVariantId('de')];
+			const result = await ctrl.process(persistedData, runtimeData, variants, [
+				...variants,
+				UmbVariantId.CreateInvariant(),
+			]);
+
+			const blocks = (result.values[0].value as TestBlockValueType).contentData;
+			const textOf = (key: string, culture: string) =>
+				blocks.find((b) => b.key === key)?.values.find((v) => v.culture === culture)?.value;
+
+			// The German edits must land on their own blocks.
+			expect(textOf('block-b', 'de'), 'block-b German').to.equal('b-de-edited');
+			expect(textOf('block-c', 'de'), 'block-c German').to.equal('c-de-edited');
+
+			// The Danish values must be carried over onto their own blocks, not shifted onto
+			// the block that took the deleted one's position.
+			expect(textOf('block-b', 'da'), 'block-b Danish').to.equal('b-da');
+			expect(textOf('block-c', 'da'), 'block-c Danish').to.equal('c-da');
+		});
+	});
+
 	describe('Simple resolver', () => {
 		beforeEach(async () => {
 			const manifest: ManifestPropertyValueResolver = {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/controller/merge-content-variant-data.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/controller/merge-content-variant-data.controller.ts
@@ -140,22 +140,30 @@ export class UmbMergeContentVariantDataController extends UmbControllerBase {
 		let newValue = draftValue;
 
 		if (api.processValues) {
-			// The a property values resolver resolves one value, we need to gather the persisted inner values first, and store them here:
-			const persistedValuesHolder: Array<Array<UmbPotentialContentValueModel>> = [];
+			// A property value resolver may resolve more than one group of inner values (a block editor
+			// emits one group per block). Gather the persisted groups keyed by the identifier the resolver
+			// supplies, so a draft group is paired with the persisted group belonging to the *same* block.
+			// Pairing on call order breaks as soon as the two arrays stop lining up, which shifts inner
+			// values onto neighbouring blocks and drops those falling off the end (#23525).
+			const persistedValuesHolder = new Map<string, Array<UmbPotentialContentValueModel>>();
+			let persistedIndex = 0;
 
 			if (persistedValue) {
-				await api.processValues(persistedValue, async (values) => {
-					persistedValuesHolder.push(values as unknown as Array<UmbPotentialContentValueModel>);
+				await api.processValues(persistedValue, async (values, groupIdentifier) => {
+					persistedValuesHolder.set(
+						groupIdentifier ?? `index:${persistedIndex++}`,
+						values as unknown as Array<UmbPotentialContentValueModel>,
+					);
 					return undefined;
 				});
 			}
 
 			let valuesIndex = 0;
 			newValue =
-				(await api.processValues(newValue, async (values) => {
-					// got some values (content and/or settings):
-					// but how to get the persisted and the draft of this.....
-					const persistedValues = persistedValuesHolder[valuesIndex++];
+				(await api.processValues(newValue, async (values, groupIdentifier) => {
+					// Resolvers that do not supply an identifier only ever emit a single group, so falling
+					// back to call order keeps them working unchanged.
+					const persistedValues = persistedValuesHolder.get(groupIdentifier ?? `index:${valuesIndex++}`);
 
 					return await this.#processValues(persistedValues, values, variantsToStore);
 				})) ?? newValue;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-resolver/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-resolver/types.ts
@@ -22,7 +22,10 @@ export type UmbPropertyValueResolverValuesProcessor<
 	InnerPropertyValueType extends UmbPropertyValueData = PropertyValueType,
 > = (
 	value: PropertyValueType,
-	valuesProcessor: (values: Array<InnerPropertyValueType>) => Promise<Array<InnerPropertyValueType> | undefined>,
+	valuesProcessor: (
+		values: Array<InnerPropertyValueType>,
+		groupIdentifier?: string,
+	) => Promise<Array<InnerPropertyValueType> | undefined>,
 ) => PromiseLike<PropertyValueType | undefined>;
 
 export type UmbPropertyValueResolverVariantsProcessor<

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/property-value-resolver/rte-block-value-resolver.api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/property-value-resolver/rte-block-value-resolver.api.ts
@@ -1,15 +1,15 @@
 import type { UmbPropertyEditorRteValueType } from '../types.js';
 import {
 	UmbBlockValueResolver,
-	type UmbBlockDataValueModel,
 	type UmbBlockExposeModel,
+	type UmbBlockValuesCallback,
 } from '@umbraco-cms/backoffice/block';
 import type { UmbElementValueModel } from '@umbraco-cms/backoffice/content';
 
 export class UmbRteBlockValueResolver extends UmbBlockValueResolver<UmbPropertyEditorRteValueType> {
 	async processValues(
 		property: UmbElementValueModel<UmbPropertyEditorRteValueType>,
-		valuesCallback: (values: Array<UmbBlockDataValueModel>) => Promise<Array<UmbBlockDataValueModel> | undefined>,
+		valuesCallback: UmbBlockValuesCallback,
 	) {
 		if (property.value) {
 			return {

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
@@ -1468,6 +1468,11 @@ export class ContentUiHelper extends UiBaseLocators {
     await this.hoverAndClick(this.blockListEntry, this.deleteBlockEntryBtn);
   }
 
+  async clickDeleteBlockListBlockButtonAtIndex(index: number) {
+    const blockEntry = this.blockListEntry.nth(index);
+    await this.hoverAndClick(blockEntry, blockEntry.locator('[label="Delete"]'));
+  }
+
   async clickCopyBlockListBlockButton(groupName: string, propertyName: string, blockName: string, index: number = 0) {
     const blockListBlock = this.workspaceEditTab.filter({hasText: groupName}).locator(this.workspaceEditProperties).filter({hasText: propertyName}).locator(this.blockListEntry).nth(index).filter({hasText: blockName});
     await this.hoverAndClick(blockListBlock, blockListBlock.locator(this.copyBlockEntryBtn), {force: true});

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentApiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentApiHelper.ts
@@ -1834,4 +1834,68 @@ export class DocumentApiHelper {
     const variantEntry = documentData.variants.find(v => v.culture === culture);
     expect(variantEntry?.name).toBe(expectedName);
   }
+
+  /**
+   * Creates a culture-variant document whose invariant Block List property already holds blocks with
+   * a value per culture, plus a matching expose entry per block and culture.
+   * @param documentName - name given to every variant
+   * @param documentTypeId - the document type, expected to vary by culture
+   * @param blockListPropertyAlias - alias of the (invariant) block list property
+   * @param elementTypeId - content element type of every block, expected to vary by culture
+   * @param blockPropertyAlias - alias of the variant property inside the element type
+   * @param blockPropertyEditorAlias - property editor alias of that property
+   * @param cultures - the cultures to create variants for
+   * @param blockValuesPerCulture - one entry per block, mapping culture to that block's value
+   */
+  async createDocumentWithBlockListBlocksInCultures(
+    documentName: string,
+    documentTypeId: string,
+    blockListPropertyAlias: string,
+    elementTypeId: string,
+    blockPropertyAlias: string,
+    blockPropertyEditorAlias: string,
+    cultures: Array<string>,
+    blockValuesPerCulture: Array<Record<string, string>>) {
+    await this.ensureNameNotExists(documentName);
+
+    const crypto = require('crypto');
+    const blockKeys = blockValuesPerCulture.map(() => crypto.randomUUID());
+
+    const documentBuilder = new DocumentBuilder().withDocumentTypeId(documentTypeId);
+
+    for (const culture of cultures) {
+      documentBuilder.addVariant().withName(documentName).withCulture(culture).done();
+    }
+
+    const blockListBuilder = documentBuilder.addValue().withAlias(blockListPropertyAlias).addBlockListValue();
+
+    blockValuesPerCulture.forEach((valuesByCulture, index) => {
+      const contentDataBuilder = blockListBuilder
+        .addContentData()
+        .withContentTypeKey(elementTypeId)
+        .withKey(blockKeys[index]);
+
+      for (const [culture, value] of Object.entries(valuesByCulture)) {
+        contentDataBuilder
+          .addContentDataValue()
+          .withAlias(blockPropertyAlias)
+          .withEditorAlias(blockPropertyEditorAlias)
+          .withCulture(culture)
+          .withValue(value)
+          .done();
+      }
+
+      contentDataBuilder.done();
+
+      for (const culture of Object.keys(valuesByCulture)) {
+        blockListBuilder.addExpose().withContentKey(blockKeys[index]).withCulture(culture).done();
+      }
+
+      blockListBuilder.addLayout().withContentKey(blockKeys[index]).done();
+    });
+
+    const document = blockListBuilder.done().done().build();
+
+    return await this.create(document);
+  }
 }

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/BlockList/InvariantBlockListWithVariantBlocksValueShift.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/BlockList/InvariantBlockListWithVariantBlocksValueShift.spec.ts
@@ -1,0 +1,104 @@
+import {AliasHelper, ConstantHelper, test} from '@umbraco/acceptance-test-helpers';
+
+/**
+ * Document Type (varies by culture)
+ * └── Block List Property (invariant - blocks are shared across languages)
+ *     └── Block Element (varies by culture)
+ *         └── Property (varies by culture)
+ *
+ * Deleting a block and then saving only one language must not move the other language's
+ * inner block values onto the block that took the deleted block's position.
+ */
+
+const documentTypeName = 'TestDocType';
+const documentTypeGroupName = 'TestGroup';
+const blockListName = 'InvariantBlockList';
+const blockName = 'BlockElement';
+const blockGroupName = 'BlockGroup';
+const textStringName = 'Textstring';
+const contentName = 'TestContent';
+const englishCulture = 'en-US';
+const danishCulture = 'da';
+
+const firstEnglishText = 'first-english';
+const secondEnglishText = 'second-english';
+const firstDanishText = 'first-danish';
+const secondDanishText = 'second-danish';
+const secondEnglishTextEdited = 'second-english-edited';
+
+let textStringDataTypeId = '';
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.language.createDanishLanguage();
+  const textStringDataType = await umbracoApi.dataType.getByName(textStringName);
+  textStringDataTypeId = textStringDataType.id;
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(contentName);
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.documentType.ensureNameNotExists(blockName);
+  await umbracoApi.dataType.ensureNameNotExists(blockListName);
+  await umbracoApi.language.ensureIsoCodeNotExists('da');
+});
+
+test('does not move inner block values onto another block when deleting a block and saving one language', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const elementTypeId = await umbracoApi.documentType.createDefaultElementTypeWithVaryByCulture(
+    blockName, blockGroupName, textStringName, textStringDataTypeId, true, true
+  );
+  const blockListId = await umbracoApi.dataType.createBlockListDataTypeWithABlock(blockListName, elementTypeId);
+  // The document type varies by culture, the block list property does not - the combination under test.
+  const documentTypeId = await umbracoApi.documentType.createDocumentTypeWithPropertyEditor(
+    documentTypeName, blockListName, blockListId, documentTypeGroupName, true, false
+  );
+  await umbracoApi.document.createDocumentWithBlockListBlocksInCultures(
+    contentName,
+    documentTypeId,
+    AliasHelper.toAlias(blockListName),
+    elementTypeId,
+    AliasHelper.toAlias(textStringName),
+    'Umbraco.TextBox',
+    [englishCulture, danishCulture],
+    [
+      {[englishCulture]: firstEnglishText, [danishCulture]: firstDanishText},
+      {[englishCulture]: secondEnglishText, [danishCulture]: secondDanishText},
+    ]
+  );
+
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.doesBlockListPropertyHaveBlockAmount(documentTypeGroupName, blockListName, 2);
+
+  // Act
+  // Everything below happens in the default language, which is the only one that may edit an
+  // invariant property under the default AllowEditInvariantFromNonDefault=false. The save
+  // therefore covers en-US only, and the Danish values have to be carried over from the
+  // persisted data - which is where the pairing goes wrong.
+
+  // Delete the first block. This shrinks the contentData array ahead of the second block, and
+  // has to happen in the same session as the save below - a reload resyncs the two arrays.
+  await umbracoUi.content.clickDeleteBlockListBlockButtonAtIndex(0);
+  await umbracoUi.content.clickConfirmToDeleteButton();
+  await umbracoUi.content.doesBlockListPropertyHaveBlockAmount(documentTypeGroupName, blockListName, 1);
+
+  await umbracoUi.content.goToBlockListBlockWithName(documentTypeGroupName, blockListName, blockName, 0);
+  await umbracoUi.content.enterTextstring(secondEnglishTextEdited);
+  await umbracoUi.content.clickUpdateButton();
+  // "Save..." opens the variant picker, which defaults to the active language only.
+  await umbracoUi.content.clickSaveButtonForContent();
+  await umbracoUi.content.clickContainerSaveButtonAndWaitForContentToBeUpdated();
+  await umbracoUi.reloadPage();
+
+  // Assert
+  // The document reopens in the default language, so check the English edit landed first.
+  await umbracoUi.content.goToBlockListBlockWithName(documentTypeGroupName, blockListName, blockName, 0);
+  await umbracoUi.content.doesPropertyContainValue(textStringName, secondEnglishTextEdited);
+  await umbracoUi.content.clickCloseButton();
+
+  // The surviving block must still hold its own Danish value, not the deleted block's.
+  await umbracoUi.content.switchLanguage(danishCulture);
+  await umbracoUi.content.goToBlockListBlockWithName(documentTypeGroupName, blockListName, blockName, 0);
+  await umbracoUi.content.doesPropertyContainValue(textStringName, secondDanishText);
+});


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23525

### Description

On a culture-variant document with a **culture-invariant** Block List / Block Grid property containing
**culture-variant** blocks, saving a subset of the languages could move inner block values onto the wrong
block, and drop values that fell off the end of the run. Silent — no error, no validation message — and it
only damages the draft, so the published site keeps rendering the old values and nothing looks wrong on
the front end.

#### Cause

`UmbMergeContentVariantDataController` recurses into a block editor's inner values through the
`propertyValueResolver` extension, and paired the persisted inner values with the draft inner values **by
the order the resolver's callback happened to fire in**:

```js
const persistedValuesHolder: Array<Array<UmbPotentialContentValueModel>> = [];
...
let valuesIndex = 0;
newValue = (await api.processValues(newValue, async (values) => {
    const persistedValues = persistedValuesHolder[valuesIndex++];   // positional
    return await this.#processValues(persistedValues, values, variantsToStore);
})) ?? newValue;
```

`UmbBlockValueResolver._processValueBlockData` invokes that callback once per `contentData` entry and then
once per `settingsData` entry, in array order, with no identity attached — and both arrays share the one
counter, so a change in `contentData` length shifts the `settingsData` pairing too.

Deleting a block that is not the last one shrinks `contentData` in the middle, so from that point on every
draft block is paired with its predecessor's persisted values. For a value whose culture is not among the
variants being saved, `#processValues` takes the persisted value — i.e. the wrong block's — and where the
mispaired group has no matching alias at all it yields `undefined` and the value is filtered away.

#### How this is actually hit: "Save and preview"

The third precondition — that the save covers only a subset of the variants — sounds like something you would
have to go looking for. It isn't. **"Save and preview" always saves exactly one variant**, with no variant
picker, because it has to know which culture to open the preview for:

```js
// UmbDocumentWorkspaceContext.#handleSaveAndPreview
const { selected } = await this._determineVariantOptions();
if (selected.length > 0) {
    firstVariantId = UmbVariantId.FromString(selected[0]);   // a single variant
    const variantIds = [firstVariantId];
    const saveData = await this._data.constructData(variantIds);
    ...
}
```

The ordinary "Save…" button opens the variant picker, and leaving every language ticked never reaches the
faulty branch. So an editor restructuring blocks and pressing **Save and preview** to check their work hits
this on every save, silently, with nothing on screen to suggest a subset save happened.

Inserting a block does *not* trigger it (`insertBlockData` appends to `contentData` regardless of layout
position), and reloading the editor resyncs the two arrays, which is why the bug looked intermittent.

#### Fix

Resolvers can now pass a stable group identifier alongside the values, and the controller keys the
persisted groups on it instead of on call order:

- optional `groupIdentifier` second argument on the values-processor callback in
  `UmbPropertyValueResolverValuesProcessor`
- `UmbBlockValueResolver._processValueBlockData` passes `contentData:<block key>` /
  `settingsData:<block key>`
- `persistedValuesHolder` becomes a `Map` keyed on that identifier

Resolvers that emit a single group and do not supply an identifier fall back to call order, so this is
additive — no behaviour change for them, and no breaking change for third-party resolvers.

### How to test

Automated, both of which fail without the change to `merge-content-variant-data.controller.ts`:

```
cd src/Umbraco.Web.UI.Client
npm test -- --files "src/packages/content/content/controller/merge-content-variant-data.controller.test.ts"
```

```
cd tests/Umbraco.Tests.AcceptanceTest
npx playwright test --grep "does not move inner block values"
```

Manually, with two languages (`en-US` default and `da`):

1. Element type that **varies by culture** with one variant text property.
2. Document type that **varies by culture** with a Block List property that does **not** vary by culture,
   allowing that element type.
3. Create a document with two blocks, each holding a value in **both** languages. Save.
4. With the **default** language active, **delete the first block**. Do not reload.
5. Still in the default language, edit the surviving block's text and press **Save and preview** (or Save
   with only `en-US` ticked in the variant picker) — either way this saves `en-US` only.
6. Reload, switch to `da`, open the surviving block.

Before: it holds the deleted block's Danish value. After: it holds its own.

Note that under the default `AllowEditInvariantFromNonDefault=false` the invariant block list is read-only
outside the default language, so the structural edit has to happen in the default language — and it is then
the other languages' values that get shifted.

### Notes for the reviewer

- `processVariants` / `persistedVariantsHolder` in the same method still pairs positionally. It is safe
  today because every shipped resolver invokes that callback exactly once per property value, so I left it
  alone rather than widen the diff — but it is the same latent hazard and may be worth the same treatment.
- Two additive helpers in the acceptance-test `lib/` were needed and no existing signature was changed:
  `ContentUiHelper.clickDeleteBlockListBlockButtonAtIndex` (the existing delete helper hovers a locator
  that matches every block entry, so it breaks strict mode with more than one block) and
  `DocumentApiHelper.createDocumentWithBlockListBlocksInCultures` (seeds per-culture inner block values and
  matching expose entries, so the spec does not have to drive a dozen UI steps).
- #23526 covers a separate, still-open problem in the same area — a document with an invariant block
  property can stay permanently on "pending changes" because the draft and published values differ only in
  the order of the `values` array. That one is backend and touches no file in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
