### PR TITLE
Content Notifications: Raise `ContentSavedNotification` on save-and-publish (closes #23523)

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1512,7 +1512,7 @@ public class ContentService : RepositoryService, IContentService
             content.PublishCulture(impact, DateTime.UtcNow, _propertyEditorCollection);
         }
 
-        PublishResult result = CommitDocumentChangesInternal(scope, content, evtMsgs, allLangs, savingNotification.State, userId);
+        PublishResult result = CommitDocumentChangesInternal(scope, content, evtMsgs, allLangs, savingNotification.State, userId, raiseSavedNotification: true);
         scope.Complete();
         return result;
     }
@@ -1566,7 +1566,7 @@ public class ContentService : RepositoryService, IContentService
         // we don't care about the response here, this response will be rechecked below but we need to set the culture info values now.
         content.PublishCulture(impact, DateTime.UtcNow, _propertyEditorCollection);
 
-        PublishResult result = CommitDocumentChangesInternal(scope, content, evtMsgs, allLangs, savingNotification.State, userId);
+        PublishResult result = CommitDocumentChangesInternal(scope, content, evtMsgs, allLangs, savingNotification.State, userId, raiseSavedNotification: true);
         scope.Complete();
         return result;
     }
@@ -1740,7 +1740,8 @@ public class ContentService : RepositoryService, IContentService
         IDictionary<string, object?>? notificationState,
         int userId,
         bool branchOne = false,
-        bool branchRoot = false)
+        bool branchRoot = false,
+        bool raiseSavedNotification = false)
     {
         if (scope == null)
         {
@@ -1920,6 +1921,19 @@ public class ContentService : RepositoryService, IContentService
 
         // Persist the document
         SaveDocument(content);
+
+        // A save-and-publish is also a save, so raise the paired Saved notification (https://github.com/umbraco/Umbraco-CMS/issues/23523).
+        // Positioned here, after the document is actually persisted, so it does not fire on the cancelled-publishing or
+        // concurrency-violation paths above, which return before reaching this point.
+        if (raiseSavedNotification)
+        {
+            scope.Notifications.Publish(
+                new ContentSavedNotification(
+                    content,
+                    eventMessages,
+                    BuildCultureMap(content, variesByCulture ? culturesChanging : ["*"]))
+                .WithState(notificationState));
+        }
 
         // we have tried to unpublish - won't happen in a branch
         if (unpublishing)

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1792,9 +1792,14 @@ public class ContentService : RepositoryService, IContentService
         IReadOnlyCollection<string>? savedCultures = null;
         if (raiseSavedNotification)
         {
-            savedCultures = variesByCulture
-                ? culturesChanging
-                : content.IsDirty() ? ["*"] : [];
+            if (variesByCulture)
+            {
+                savedCultures = culturesChanging;
+            }
+            else
+            {
+                savedCultures = content.IsDirty() ? ["*"] : [];
+            }
         }
 
         var isNew = !content.HasIdentity;

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1722,6 +1722,10 @@ public class ContentService : RepositoryService, IContentService
     /// <param name="userId"></param>
     /// <param name="branchOne"></param>
     /// <param name="branchRoot"></param>
+    /// <param name="raiseSavedNotification">
+    ///     Whether to raise a <see cref="ContentSavedNotification" /> once the document is persisted. Enabled by the
+    ///     save-and-publish entry points, which combine a save and a publish, so the paired Saved notification still fires.
+    /// </param>
     /// <param name="eventMessages"></param>
     /// <returns></returns>
     /// <remarks>
@@ -1781,6 +1785,17 @@ public class ContentService : RepositoryService, IContentService
         IReadOnlyList<string>? culturesChanging = variesByCulture
             ? content.CultureInfos?.Values.Where(x => x.IsDirty()).Select(x => x.Culture).ToList()
             : null;
+
+        // For a save-and-publish, capture the saved cultures the same way (and at the same point) as the standalone
+        // Save path - before persistence resets change tracking - so the Saved notification honours the same
+        // SavedCultures contract: the changed cultures for variant content, or the "*" marker for changed invariant content.
+        IReadOnlyCollection<string>? savedCultures = null;
+        if (raiseSavedNotification)
+        {
+            savedCultures = variesByCulture
+                ? culturesChanging
+                : content.IsDirty() ? ["*"] : [];
+        }
 
         var isNew = !content.HasIdentity;
         TreeChangeTypes changeType = isNew ? TreeChangeTypes.RefreshNode : TreeChangeTypes.RefreshBranch;
@@ -1931,7 +1946,7 @@ public class ContentService : RepositoryService, IContentService
                 new ContentSavedNotification(
                     content,
                     eventMessages,
-                    BuildCultureMap(content, variesByCulture ? culturesChanging : ["*"]))
+                    BuildCultureMap(content, savedCultures))
                 .WithState(notificationState));
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceNotificationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceNotificationTests.cs
@@ -491,6 +491,68 @@ internal sealed class ContentServiceNotificationTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public async Task Can_Read_All_Changed_Cultures_As_Saved_When_Publishing_A_Subset()
+    {
+        // The saved cultures must reflect what was *changed*, not what was *published*: both cultures are edited here
+        // but only one is published, so the Saved notification reports both while the Published notification reports one.
+        await LanguageService.CreateAsync(new Language("fr-FR", "French (France)"), Constants.Security.SuperUserKey);
+
+        _contentType.Variations = ContentVariation.Culture;
+        foreach (IPropertyType propertyType in _contentType.PropertyTypes)
+        {
+            propertyType.Variations = ContentVariation.Culture;
+        }
+
+        await ContentTypeService.UpdateAsync(_contentType, Constants.Security.SuperUserKey);
+
+        Content document = new Content("content", -1, _contentType);
+        document.SetCultureName("hello", "en-US");
+        document.SetCultureName("bonjour", "fr-FR");
+
+        var savedWasCalled = false;
+        var publishedWasCalled = false;
+
+        ContentNotificationHandler.SavedContent = notification =>
+        {
+            IContent saved = notification.SavedEntities.First();
+
+            Assert.IsNotNull(notification.SavedCultures);
+            Assert.IsTrue(notification.SavedCultures.ContainsKey(saved.Key));
+
+            // both cultures were changed, so both are reported as saved - even though only en-US is being published
+            CollectionAssert.AreEquivalent(new[] { "en-US", "fr-FR" }, notification.SavedCultures[saved.Key]);
+
+            savedWasCalled = true;
+        };
+
+        ContentNotificationHandler.PublishedContent = notification =>
+        {
+            IContent published = notification.PublishedEntities.First();
+
+            Assert.IsNotNull(notification.PublishedCultures);
+            Assert.IsTrue(notification.PublishedCultures.ContainsKey(published.Key));
+
+            // only en-US was published
+            CollectionAssert.AreEquivalent(new[] { "en-US" }, notification.PublishedCultures[published.Key]);
+
+            publishedWasCalled = true;
+        };
+
+        try
+        {
+            var result = ContentService.SaveAndPublish(document, ["en-US"]);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(savedWasCalled, "ContentSavedNotification should fire when saving and publishing.");
+            Assert.IsTrue(publishedWasCalled, "ContentPublishedNotification should fire when saving and publishing.");
+        }
+        finally
+        {
+            ContentNotificationHandler.SavedContent = null;
+            ContentNotificationHandler.PublishedContent = null;
+        }
+    }
+
+    [Test]
     public async Task Can_Set_Mandatory_Value_When_Publishing()
     {
         var titleProperty = _contentType.PropertyTypes.First(x => x.Alias == "title");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceNotificationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceNotificationTests.cs
@@ -407,7 +407,7 @@ internal sealed class ContentServiceNotificationTests : UmbracoIntegrationTest
     {
         // A combined save-and-publish must still raise the paired Saved notification, just like a plain Save does
         // (https://github.com/umbraco/Umbraco-CMS/issues/23523).
-        IContent document = new Content("content", -1, _contentType);
+        Content document = new Content("content", -1, _contentType);
 
         var savingWasCalled = false;
         var savedWasCalled = false;
@@ -459,7 +459,7 @@ internal sealed class ContentServiceNotificationTests : UmbracoIntegrationTest
 
         await ContentTypeService.UpdateAsync(_contentType, Constants.Security.SuperUserKey);
 
-        IContent document = new Content("content", -1, _contentType);
+        Content document = new Content("content", -1, _contentType);
         document.SetCultureName("hello", "en-US");
         document.SetCultureName("bonjour", "fr-FR");
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceNotificationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceNotificationTests.cs
@@ -403,6 +403,94 @@ internal sealed class ContentServiceNotificationTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public void Can_Read_Saved_Notification_When_Save_And_Publishing_Invariant()
+    {
+        // A combined save-and-publish must still raise the paired Saved notification, just like a plain Save does
+        // (https://github.com/umbraco/Umbraco-CMS/issues/23523).
+        IContent document = new Content("content", -1, _contentType);
+
+        var savingWasCalled = false;
+        var savedWasCalled = false;
+        var publishingWasCalled = false;
+        var publishedWasCalled = false;
+
+        ContentNotificationHandler.SavingContent = _ => savingWasCalled = true;
+        ContentNotificationHandler.SavedContent = notification =>
+        {
+            IContent saved = notification.SavedEntities.First();
+
+            Assert.IsNotNull(notification.SavedCultures);
+            Assert.IsTrue(notification.SavedCultures.ContainsKey(saved.Key));
+            CollectionAssert.AreEquivalent(new[] { "*" }, notification.SavedCultures[saved.Key]);
+
+            savedWasCalled = true;
+        };
+        ContentNotificationHandler.PublishingContent = _ => publishingWasCalled = true;
+        ContentNotificationHandler.PublishedContent = _ => publishedWasCalled = true;
+
+        try
+        {
+            var result = ContentService.SaveAndPublish(document, []);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(savingWasCalled);
+            Assert.IsTrue(savedWasCalled, "ContentSavedNotification should fire when saving and publishing.");
+            Assert.IsTrue(publishingWasCalled);
+            Assert.IsTrue(publishedWasCalled);
+        }
+        finally
+        {
+            ContentNotificationHandler.SavingContent = null;
+            ContentNotificationHandler.SavedContent = null;
+            ContentNotificationHandler.PublishingContent = null;
+            ContentNotificationHandler.PublishedContent = null;
+        }
+    }
+
+    [Test]
+    public async Task Can_Read_Saved_Notification_When_Save_And_Publishing_Variant()
+    {
+        await LanguageService.CreateAsync(new Language("fr-FR", "French (France)"), Constants.Security.SuperUserKey);
+
+        _contentType.Variations = ContentVariation.Culture;
+        foreach (IPropertyType propertyType in _contentType.PropertyTypes)
+        {
+            propertyType.Variations = ContentVariation.Culture;
+        }
+
+        await ContentTypeService.UpdateAsync(_contentType, Constants.Security.SuperUserKey);
+
+        IContent document = new Content("content", -1, _contentType);
+        document.SetCultureName("hello", "en-US");
+        document.SetCultureName("bonjour", "fr-FR");
+
+        var savedWasCalled = false;
+
+        ContentNotificationHandler.SavedContent = notification =>
+        {
+            IContent saved = notification.SavedEntities.First();
+
+            Assert.IsNotNull(notification.SavedCultures);
+            Assert.IsTrue(notification.SavedCultures.ContainsKey(saved.Key));
+
+            // both cultures were changed as part of the save-and-publish, so both are reported as saved
+            CollectionAssert.AreEquivalent(new[] { "en-US", "fr-FR" }, notification.SavedCultures[saved.Key]);
+
+            savedWasCalled = true;
+        };
+
+        try
+        {
+            var result = ContentService.SaveAndPublish(document, ["en-US", "fr-FR"]);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(savedWasCalled, "ContentSavedNotification should fire when saving and publishing.");
+        }
+        finally
+        {
+            ContentNotificationHandler.SavedContent = null;
+        }
+    }
+
+    [Test]
     public async Task Can_Set_Mandatory_Value_When_Publishing()
     {
         var titleProperty = _contentType.PropertyTypes.First(x => x.Alias == "title");


### PR DESCRIPTION
## Description

Fixes a regression in 17.6.0-rc where `ContentSavedNotification` no longer fires when content is saved and published in a single operation (the backoffice "Save and publish" action).

Fixes #23523.

When [#22812](https://github.com/umbraco/Umbraco-CMS/pull/22812) reintroduced save-and-publish as a single operation, the combined path (`ContentService.SaveAndPublish` → `CommitDocumentChangesInternal`) published `Saving`, `Publishing` and `Published` but never the paired `Saved` notification. The standalone `Save` path still raised it, so a plain "Save" behaved correctly while "Save and publish" silently skipped `ContentSavedNotification`.

### Fix

`ContentSavedNotification` is now raised inside `CommitDocumentChangesInternal`, immediately after the document is persisted. It is gated behind a new opt-in `raiseSavedNotification` parameter that only the two `SaveAndPublish` overloads pass as `true`, so the unpublish, branch-publish and scheduled-publish callers of the shared method are unaffected. Positioning the notification after persistence means it does not fire on the cancelled-publishing or concurrency-violation paths, which return before the document is saved. The per-document culture map mirrors the standalone `Save` behaviour (changed cultures for variant content, the `*` marker for invariant).

### Notification order

`Saving` → `Publishing` → `Saved` → `Published`. The combined operation raises `Publishing` (cancelable) before persistence by design, so `Saved` sits between `Publishing` and `Published`, reflecting the point at which the document is actually persisted.

## Testing

### Automated

Added invariant and variant regression tests to `ContentServiceNotificationTests` asserting `ContentSavedNotification` fires (with the correct `SavedCultures`) on `SaveAndPublish`; both fail before the fix and pass after. Solution should build and CI checks pass.

### Manual

Register a notification handler that logs each of the four content notifications, then create a document and click **Save and publish** in the backoffice.

```csharp
using Microsoft.Extensions.Logging;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;

public class ContentNotificationLoggingHandler :
    INotificationHandler<ContentSavingNotification>,
    INotificationHandler<ContentSavedNotification>,
    INotificationHandler<ContentPublishingNotification>,
    INotificationHandler<ContentPublishedNotification>
{
    private readonly ILogger<ContentNotificationLoggingHandler> _logger;

    public ContentNotificationLoggingHandler(ILogger<ContentNotificationLoggingHandler> logger) => _logger = logger;

    public void Handle(ContentSavingNotification notification) => Log("Saving", notification.SavedEntities);

    public void Handle(ContentSavedNotification notification) => Log("Saved", notification.SavedEntities);

    public void Handle(ContentPublishingNotification notification) => Log("Publishing", notification.PublishedEntities);

    public void Handle(ContentPublishedNotification notification) => Log("Published", notification.PublishedEntities);

    private void Log(string stage, IEnumerable<IContent> entities)
        => _logger.LogWarning("[Issue23523] {Stage} fired for {Names}", stage, string.Join(", ", entities.Select(e => e.Name)));
}

public class ContentNotificationLoggingComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ContentSavingNotification, ContentNotificationLoggingHandler>();
        builder.AddNotificationHandler<ContentSavedNotification, ContentNotificationLoggingHandler>();
        builder.AddNotificationHandler<ContentPublishingNotification, ContentNotificationLoggingHandler>();
        builder.AddNotificationHandler<ContentPublishedNotification, ContentNotificationLoggingHandler>();
    }
}
```

**Before the fix** — the `Saved` line is missing on "Save and publish":

```
[Issue23523] Saving fired for Home
[Issue23523] Publishing fired for Home
Document Home (id=1234) has been published.
[Issue23523] Published fired for Home
```

**After the fix** — `Saved` now fires, between the persistence of the document and the `Published` notification:

```
[Issue23523] Saving fired for Home
[Issue23523] Publishing fired for Home
Document Home (id=1234) has been published.
[Issue23523] Saved fired for Home
[Issue23523] Published fired for Home
```

For comparison, a plain **Save** (or **Save and preview**) logs `Saving` then `Saved` both before and after the fix — that path was never affected.

## Merge and Release

When reviewed and merged, this needs applying to `release/18.1` and implementing for elements.