### PR TITLE
Migrations: Only rebuild the published cache for migration plans that request it (closes #23537)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -147,6 +147,13 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
     {
         plan.Validate();
 
+        // This class is registered as a singleton and a single boot can execute several plans - the Umbraco plan
+        // followed by one plan per package with pending migrations - so the flags are reset here to keep them scoped
+        // to the plan being executed. Without this, one plan asking for a rebuild makes every plan that follows it
+        // rebuild too (https://github.com/umbraco/Umbraco-CMS/discussions/23531).
+        _rebuildCache = false;
+        _invalidateBackofficeUserAccess = false;
+
         ExecutedMigrationPlan result = await RunMigrationPlanAsync(plan, fromState).ConfigureAwait(false);
 
         // If any completed migration requires us to rebuild cache we'll do that.

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/MigrationPlanExecutorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/MigrationPlanExecutorTests.cs
@@ -47,11 +47,9 @@ internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
         Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(0));
     }
 
-    /// <summary>
-    /// The executor is registered as a singleton and executes the Umbraco plan followed by one plan per package with
-    /// pending migrations, so a rebuild requested by one plan must not leak into the plans that follow it
-    /// (https://github.com/umbraco/Umbraco-CMS/discussions/23531).
-    /// </summary>
+    // The executor is registered as a singleton and executes the Umbraco plan followed by one plan per package with
+    // pending migrations, so a rebuild requested by one plan must not leak into the plans that follow it
+    // (https://github.com/umbraco/Umbraco-CMS/discussions/23531).
     [Test]
     public async Task Cannot_Rebuild_Cache_For_Subsequent_Plan_Not_Requiring_A_Rebuild()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/MigrationPlanExecutorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/MigrationPlanExecutorTests.cs
@@ -32,7 +32,7 @@ internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
     {
         MigrationPlanExecutor executor = CreateExecutor();
 
-        await executor.ExecutePlanAsync(CreatePlan<RebuildCacheMigration>("first"), string.Empty);
+        await ExecutePlanAsync<RebuildCacheMigration>(executor, "first");
 
         Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(1));
     }
@@ -42,7 +42,7 @@ internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
     {
         MigrationPlanExecutor executor = CreateExecutor();
 
-        await executor.ExecutePlanAsync(CreatePlan<NoopMigration>("first"), string.Empty);
+        await ExecutePlanAsync<NoopMigration>(executor, "first");
 
         Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(0));
     }
@@ -57,9 +57,9 @@ internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
     {
         MigrationPlanExecutor executor = CreateExecutor();
 
-        await executor.ExecutePlanAsync(CreatePlan<RebuildCacheMigration>("first"), string.Empty);
-        await executor.ExecutePlanAsync(CreatePlan<NoopMigration>("second"), string.Empty);
-        await executor.ExecutePlanAsync(CreatePlan<NoopMigration>("third"), string.Empty);
+        await ExecutePlanAsync<RebuildCacheMigration>(executor, "first");
+        await ExecutePlanAsync<NoopMigration>(executor, "second");
+        await ExecutePlanAsync<NoopMigration>(executor, "third");
 
         Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(1));
     }
@@ -69,17 +69,24 @@ internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
     {
         MigrationPlanExecutor executor = CreateExecutor();
 
-        await executor.ExecutePlanAsync(CreatePlan<RebuildCacheMigration>("first"), string.Empty);
-        await executor.ExecutePlanAsync(CreatePlan<RebuildCacheMigration>("second"), string.Empty);
+        await ExecutePlanAsync<RebuildCacheMigration>(executor, "first");
+        await ExecutePlanAsync<RebuildCacheMigration>(executor, "second");
 
         Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(2));
     }
 
-    private static MigrationPlan CreatePlan<TMigration>(string name)
+    private static async Task ExecutePlanAsync<TMigration>(MigrationPlanExecutor executor, string name)
         where TMigration : AsyncMigrationBase
-        => new MigrationPlan(name)
+    {
+        MigrationPlan plan = new MigrationPlan(name)
             .From(string.Empty)
             .To<TMigration>("done");
+
+        ExecutedMigrationPlan result = await executor.ExecutePlanAsync(plan, string.Empty);
+
+        // Asserted so a plan that errors can't leave the rebuild count coincidentally matching the expectation.
+        Assert.That(result.Successful, Is.True, result.Exception?.ToString());
+    }
 
     private MigrationPlanExecutor CreateExecutor() => new(
         GetRequiredService<ICoreScopeProvider>(),
@@ -89,6 +96,10 @@ internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
         GetRequiredService<IUmbracoDatabaseFactory>(),
         _databaseCacheRebuilder,
         GetRequiredService<DistributedCache>(),
+
+        // Not the real IKeyValueService: this fixture runs against an empty database, so persisting the plan state
+        // in MigrationContext.Complete() would fail on the missing umbracoLock table and every plan would report
+        // itself unsuccessful.
         Mock.Of<IKeyValueService>(),
         GetRequiredService<IServiceScopeFactory>(),
         AppCaches.NoCache,

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/MigrationPlanExecutorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/MigrationPlanExecutorTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewEmptyPerTest)]
+internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
+{
+    private CountingDatabaseCacheRebuilder _databaseCacheRebuilder;
+
+    [SetUp]
+    public void CreateDatabaseCacheRebuilder() => _databaseCacheRebuilder = new CountingDatabaseCacheRebuilder();
+
+    [Test]
+    public async Task Can_Rebuild_Cache_For_Plan_Requiring_A_Rebuild()
+    {
+        MigrationPlanExecutor executor = CreateExecutor();
+
+        await executor.ExecutePlanAsync(CreatePlan<RebuildCacheMigration>("first"), string.Empty);
+
+        Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Cannot_Rebuild_Cache_For_Plan_Not_Requiring_A_Rebuild()
+    {
+        MigrationPlanExecutor executor = CreateExecutor();
+
+        await executor.ExecutePlanAsync(CreatePlan<NoopMigration>("first"), string.Empty);
+
+        Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// The executor is registered as a singleton and executes the Umbraco plan followed by one plan per package with
+    /// pending migrations, so a rebuild requested by one plan must not leak into the plans that follow it
+    /// (https://github.com/umbraco/Umbraco-CMS/discussions/23531).
+    /// </summary>
+    [Test]
+    public async Task Cannot_Rebuild_Cache_For_Subsequent_Plan_Not_Requiring_A_Rebuild()
+    {
+        MigrationPlanExecutor executor = CreateExecutor();
+
+        await executor.ExecutePlanAsync(CreatePlan<RebuildCacheMigration>("first"), string.Empty);
+        await executor.ExecutePlanAsync(CreatePlan<NoopMigration>("second"), string.Empty);
+        await executor.ExecutePlanAsync(CreatePlan<NoopMigration>("third"), string.Empty);
+
+        Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Can_Rebuild_Cache_Once_Per_Plan_Requiring_A_Rebuild()
+    {
+        MigrationPlanExecutor executor = CreateExecutor();
+
+        await executor.ExecutePlanAsync(CreatePlan<RebuildCacheMigration>("first"), string.Empty);
+        await executor.ExecutePlanAsync(CreatePlan<RebuildCacheMigration>("second"), string.Empty);
+
+        Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(2));
+    }
+
+    private static MigrationPlan CreatePlan<TMigration>(string name)
+        where TMigration : AsyncMigrationBase
+        => new MigrationPlan(name)
+            .From(string.Empty)
+            .To<TMigration>("done");
+
+    private MigrationPlanExecutor CreateExecutor() => new(
+        GetRequiredService<ICoreScopeProvider>(),
+        ScopeAccessor,
+        LoggerFactory,
+        GetRequiredService<IMigrationBuilder>(),
+        GetRequiredService<IUmbracoDatabaseFactory>(),
+        _databaseCacheRebuilder,
+        GetRequiredService<DistributedCache>(),
+        Mock.Of<IKeyValueService>(),
+        GetRequiredService<IServiceScopeFactory>(),
+        AppCaches.NoCache,
+        GetRequiredService<IPublishedContentTypeFactory>());
+
+    public class RebuildCacheMigration : AsyncMigrationBase
+    {
+        public RebuildCacheMigration(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        protected override Task MigrateAsync()
+        {
+            RebuildCache = true;
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class NoopMigration : AsyncMigrationBase
+    {
+        public NoopMigration(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        protected override Task MigrateAsync() => Task.CompletedTask;
+    }
+
+    private sealed class CountingDatabaseCacheRebuilder : IDatabaseCacheRebuilder
+    {
+        public int RebuildCount { get; private set; }
+
+        public Task<Attempt<DatabaseCacheRebuildResult>> RebuildAsync(bool useBackgroundThread)
+        {
+            RebuildCount++;
+
+            return Task.FromResult(Attempt.Succeed(DatabaseCacheRebuildResult.Success));
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        public void RebuildDatabaseCacheIfSerializerChanged() => throw new NotSupportedException();
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+}


### PR DESCRIPTION
## Description

Raised from discussion [#23531](https://github.com/umbraco/Umbraco-CMS/discussions/23531), where a v13 to v17 upgrade ran a full cache rebuild after the core migrations *and* again after each of six migrating packages - roughly 7 minutes each, sequentially, adding 40+ minutes to the upgrade.

### Why did this happen?

`MigrationPlanExecutor` collects a `_rebuildCache` flag while running a plan and rebuilds once at the end of `ExecutePlanAsync`, so a plan already batches its rebuild across all of its migrations. The problem is that the flag is never reset, and the executor is registered as a singleton (`UmbracoBuilder.CoreServices`):

- `UnattendedUpgrader` runs the `UmbracoPlan` first, then `PackageMigrationRunner` loops over the pending package plans, calling `ExecutePlanAsync` on that same instance once per plan.
- On a v13 to v17 path the core plan legitimately sets the flag (`MigrateDataTypeConfigurations`, `ConvertLocalLinks`, `FixConvertLocalLinks`).
- The flag then stays `true` for the lifetime of the singleton, so every package plan that runs afterwards rebuilds again at its end - even though its own migrations never asked for a rebuild.

So the number of rebuilds was "one per migration plan executed after the first plan that wanted one", rather than "one per plan that wants one". Because the flag lives as long as the process, this also meant a package installed through the backoffice later in the same app lifetime would trigger an unrequested full rebuild.

`_invalidateBackofficeUserAccess` had the identical problem, re-revoking all backoffice tokens once per subsequent plan. 

### Fix
Both flags are now reset at the start of `ExecutePlanAsync` so they stay scoped to the plan being executed.

This is deliberately the minimal fix: it does not change *when* a rebuild happens for a plan that wants one, only that a plan which does not want one no longer inherits it. Batching further - a single rebuild at the end of the whole upgrade regardless of how many plans requested one - would be more correct, but was not done here.  It would be a larger undertaking and in practice few package migrations request a rebuild at all.

Fixes #23537.

## Testing

### Automated

`MigrationPlanExecutorTests` is new and covers the regression (three plans where only the first requests a rebuild - one rebuild, not three), the single-plan positive and negative cases, and that two plans each requesting a rebuild still get one each. The regression test fails on `v17/dev` without the fix, reporting 3 rebuilds instead of 1.

### Manual

Verified on a local site by making both a core migration and a package migration pending in the same boot, so that the core plan requests a rebuild and the package plan that follows it does not.

#### Setup

1. Add a package migration plan with a handful of steps, none of which set `RebuildCache`. The run below used a `TestPackage` plan whose steps just log (`TestPackageMigrationPlan: log step ran.`).

2. Temporarily make the last core migration request a rebuild, so the core plan sets the flag the way a real v13 to v17 upgrade would:

   ```csharp
   // V_17_6_0/AddContentTypeIdIndexForContent.cs
   RebuildCache = true;
   ```

3. Wind the stored plan state back so both plans have pending steps. `{3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}` is the state immediately before `AddContentTypeIdIndexForContent` in `UmbracoPlan`; removing the package's row leaves its plan at `origin`:

   ```sql
   UPDATE umbracoKeyValue
   SET    [value] = '{3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}'
   WHERE  [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core';

   DELETE FROM umbracoKeyValue
   WHERE  [key] = 'Umbraco.Core.Upgrader.State+TestPackage';
   ```

4. Ensure unattended upgrades are enabled for both core and package migrations (`Umbraco:CMS:Unattended:UpgradeUnattended` and `Umbraco:CMS:Unattended:PackageMigrationsUnattended`), then start the site.

**What to look for:** the number of `Starts rebuilding the cache` lines. One is expected, from the core plan. Any line appearing after a package plan's `Done` is a rebuild no migration asked for.

#### Before (`v17/dev`)

```
[22:24:05 INF] Starting 'Umbraco.Core'...
[22:24:05 INF] At {3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}
[22:24:05 INF] Execute AddContentTypeIdIndexForContent
[22:24:05 INF] At {3A1A8047-74AE-491A-B2C4-0BAE4A1289EC}
[22:24:05 INF] Done
[22:24:05 INF] Starts rebuilding the cache. This can be a long running operation   <-- requested by the core plan
...
[22:24:06 INF] Starting package migration for TestPackage [Timing be1d79b]
[22:24:06 INF] Starting 'TestPackage '...
[22:24:06 INF] At origin
...
[22:24:16 INF] Execute LogStep
[22:24:16 INF] TestPackageMigrationPlan: log step ran.
[22:24:16 INF] At log-step-14
[22:24:16 INF] Done
[22:24:16 INF] Starts rebuilding the cache. This can be a long running operation   <-- nothing in this plan asked for it
```

Two rebuilds. The second is the stale flag: none of the `LogStep` migrations touch `RebuildCache`, but the flag set by the core plan is still `true` on the singleton executor.

#### After (this branch)

```
[22:29:05 INF] Starting 'Umbraco.Core'...
[22:29:05 INF] At {3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}
[22:29:05 INF] Execute AddContentTypeIdIndexForContent
[22:29:05 INF] At {3A1A8047-74AE-491A-B2C4-0BAE4A1289EC}
[22:29:05 INF] Done
[22:29:05 INF] Starts rebuilding the cache. This can be a long running operation   <-- requested by the core plan
...
[22:29:17 INF] TestPackageMigrationPlan: log step ran.
[22:29:17 INF] At log-step-14
[22:29:17 INF] Done
[22:29:17 INF] Package migration completed for TestPackage
```

One rebuild. The package plan now goes straight from `Done` to `Package migration completed`, and the rebuild the core plan genuinely asked for still happens. Cache seeding, document URL caching and `Upgrade completed!` are unchanged from the before run.

Remember to revert the temporary `RebuildCache = true` from step 2 afterwards.