### PR TITLE
Tiptap RTE: Prevent duplicate toolbar items when reordering a newly dragged item (closes #23524)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/property-editor-ui-tiptap-statusbar-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/property-editor-ui-tiptap-statusbar-configuration.element.ts
@@ -7,6 +7,8 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/property-editor';
 
+const UMB_TIPTAP_STATUSBAR_ITEM_DRAG_TYPE = 'text/umb-tiptap-statusbar-item';
+
 @customElement('umb-property-editor-ui-tiptap-statusbar-configuration')
 export class UmbPropertyEditorUiTiptapStatusbarConfigurationElement
 	extends UmbLitElement
@@ -74,29 +76,40 @@ export class UmbPropertyEditorUiTiptapStatusbarConfigurationElement
 		this.#context.insertStatusbarItem(item.alias, [lastArea, lastItem]);
 	}
 
+	#isOwnDragItem(event: DragEvent) {
+		return event.dataTransfer?.types.includes(UMB_TIPTAP_STATUSBAR_ITEM_DRAG_TYPE) === true;
+	}
+
 	#onDragStart(event: DragEvent, alias: string, fromPos?: [number, number]) {
 		event.dataTransfer!.effectAllowed = 'move';
+		event.dataTransfer!.setData(UMB_TIPTAP_STATUSBAR_ITEM_DRAG_TYPE, alias);
 		this.#currentDragItem = { alias, fromPos };
 	}
 
 	#onDragOver(event: DragEvent) {
+		if (!this.#isOwnDragItem(event)) return;
 		event.preventDefault();
 		event.dataTransfer!.dropEffect = 'move';
 	}
 
 	#onDragEnd(event: DragEvent) {
 		event.preventDefault();
-		if (event.dataTransfer?.dropEffect === 'none') {
-			const { fromPos } = this.#currentDragItem ?? {};
-			if (!fromPos) return;
+		const { fromPos } = this.#currentDragItem ?? {};
+		this.#currentDragItem = undefined;
 
+		if (event.dataTransfer?.dropEffect === 'none' && fromPos) {
 			this.#context.removeStatusbarItem(fromPos);
 		}
 	}
 
 	#onDrop(event: DragEvent, toPos?: [number, number]) {
+		// An area can also receive a drag of the toolbar designer, which sits alongside this one. Acting on one of
+		// those would re-insert the item of the preceding drag. (#23524)
+		if (!this.#isOwnDragItem(event)) return;
+
 		event.preventDefault();
 		const { alias, fromPos } = this.#currentDragItem ?? {};
+		this.#currentDragItem = undefined;
 
 		// Remove item if no destination position is provided
 		if (fromPos && !toPos) {
@@ -198,7 +211,7 @@ export class UmbPropertyEditorUiTiptapStatusbarConfigurationElement
 				class="area"
 				dropzone="move"
 				@dragover=${this.#onDragOver}
-				@drop=${(e: DragEvent) => this.#onDrop(e, [areaIndex, area.data.length - 1])}>
+				@drop=${(e: DragEvent) => this.#onDrop(e, [areaIndex, area.data.length])}>
 				<div class="items">
 					${when(
 						area?.data.length === 0,

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/property-editor-ui-tiptap-statusbar-configuration.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/property-editor-ui-tiptap-statusbar-configuration.test.ts
@@ -126,6 +126,17 @@ describe('UmbPropertyEditorUiTiptapStatusbarConfigurationElement', () => {
 		expect(duplicatedAliases()).to.be.empty;
 	});
 
+	it('drops the repeat occurrences of an item already duplicated in the value', async () => {
+		await givenStatusbar([['Test.Statusbar.One', 'Test.Statusbar.Two'], ['Test.Statusbar.One']]);
+
+		await dragAvailableItemToArea('Test.Statusbar.Three', 0);
+
+		expect(element.value).to.deep.equal([
+			['Test.Statusbar.One', 'Test.Statusbar.Two', 'Test.Statusbar.Three'],
+			[],
+		]);
+	});
+
 	it('leaves a drag of another editor to be handled elsewhere', async () => {
 		const event = await dispatchForeignDrop(0);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/property-editor-ui-tiptap-statusbar-configuration.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/property-editor-ui-tiptap-statusbar-configuration.test.ts
@@ -1,0 +1,135 @@
+import { UmbPropertyEditorUiTiptapStatusbarConfigurationElement } from './property-editor-ui-tiptap-statusbar-configuration.element.js';
+import type { UmbTiptapStatusbarValue } from '../../components/types.js';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbPropertyContext, UmbPropertyDatasetContextBase } from '@umbraco-cms/backoffice/property';
+
+const STATUSBAR_EXTENSION_ALIASES = [
+	'Test.Statusbar.One',
+	'Test.Statusbar.Two',
+	'Test.Statusbar.Three',
+	'Test.Statusbar.Four',
+];
+
+const manifests: Array<UmbExtensionManifest> = STATUSBAR_EXTENSION_ALIASES.map((alias) => ({
+	type: 'tiptapStatusbarExtension',
+	alias,
+	name: alias,
+	meta: { alias, icon: 'icon-code', label: alias },
+}));
+
+@customElement('umb-test-tiptap-statusbar-configuration-host')
+class UmbTestTiptapStatusbarConfigurationHostElement extends UmbLitElement {
+	readonly datasetContext = new UmbPropertyDatasetContextBase(this);
+	readonly propertyContext = new UmbPropertyContext(this);
+
+	constructor() {
+		super();
+		this.propertyContext.setAlias('statusbar');
+		this.datasetContext.setValues([{ alias: 'extensions', value: [] }]);
+	}
+
+	override render() {
+		return html`<slot></slot>`;
+	}
+}
+
+describe('UmbPropertyEditorUiTiptapStatusbarConfigurationElement', () => {
+	let element: UmbPropertyEditorUiTiptapStatusbarConfigurationElement;
+
+	/** The `.area` element of the designer, which is what receives a dropped statusbar item. */
+	const areaElement = (areaIndex: number) => element.shadowRoot!.querySelectorAll<HTMLElement>('.area')[areaIndex];
+
+	const dragEvent = (type: string, dataTransfer: DataTransfer) =>
+		new DragEvent(type, { bubbles: true, cancelable: true, composed: true, dataTransfer });
+
+	/** Drags an item from the available items list onto an area, as a user would with the mouse. */
+	const dragAvailableItemToArea = async (alias: string, areaIndex: number) => {
+		const selector = `.available-items [data-mark="tiptap-statusbar-item:${alias}"]`;
+		await waitUntil(() => element.shadowRoot!.querySelector(selector), `available item for ${alias} was rendered`);
+		const availableItem = element.shadowRoot!.querySelector<HTMLElement>(selector)!;
+
+		const dataTransfer = new DataTransfer();
+		availableItem.dispatchEvent(dragEvent('dragstart', dataTransfer));
+		areaElement(areaIndex).dispatchEvent(dragEvent('dragover', dataTransfer));
+		areaElement(areaIndex).dispatchEvent(dragEvent('drop', dataTransfer));
+		availableItem.dispatchEvent(dragEvent('dragend', dataTransfer));
+
+		await element.updateComplete;
+	};
+
+	/**
+	 * Mimics a drop that belongs to another editor, such as the toolbar designer that sits alongside this one on the
+	 * data type workspace. Its data transfer does not carry the type of a statusbar item.
+	 */
+	const dispatchForeignDrop = async (areaIndex: number) => {
+		const dataTransfer = new DataTransfer();
+		dataTransfer.setData('text/umb-tiptap-toolbar-item', 'Test.Toolbar.One');
+		const event = dragEvent('drop', dataTransfer);
+		areaElement(areaIndex).dispatchEvent(event);
+
+		await element.updateComplete;
+		return event;
+	};
+
+	const givenStatusbar = async (value: UmbTiptapStatusbarValue) => {
+		const host = await fixture<UmbTestTiptapStatusbarConfigurationHostElement>(html`
+			<umb-test-tiptap-statusbar-configuration-host>
+				<umb-property-editor-ui-tiptap-statusbar-configuration .value=${value}>
+				</umb-property-editor-ui-tiptap-statusbar-configuration>
+			</umb-test-tiptap-statusbar-configuration-host>
+		`);
+
+		element = host.querySelector('umb-property-editor-ui-tiptap-statusbar-configuration')!;
+		await element.updateComplete;
+		await waitUntil(
+			() => element.shadowRoot!.querySelectorAll('.area').length === value.length,
+			'the areas of the statusbar were rendered',
+		);
+	};
+
+	const aliasesInUse = () => (element.value ?? []).flat();
+
+	const duplicatedAliases = () => {
+		const aliases = aliasesInUse();
+		return [...new Set(aliases.filter((alias, index) => aliases.indexOf(alias) !== index))];
+	};
+
+	beforeEach(async () => {
+		umbExtensionsRegistry.registerMany(manifests);
+		await givenStatusbar([['Test.Statusbar.One', 'Test.Statusbar.Two'], []]);
+	});
+
+	afterEach(() => {
+		umbExtensionsRegistry.unregisterMany(manifests.map((manifest) => manifest.alias));
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbPropertyEditorUiTiptapStatusbarConfigurationElement);
+	});
+
+	it('appends an item dragged from the available items to the end of the area', async () => {
+		await dragAvailableItemToArea('Test.Statusbar.Three', 0);
+
+		expect(element.value).to.deep.equal([
+			['Test.Statusbar.One', 'Test.Statusbar.Two', 'Test.Statusbar.Three'],
+			[],
+		]);
+	});
+
+	it('cannot duplicate an item when a drag of another editor is dropped on an area', async () => {
+		await dragAvailableItemToArea('Test.Statusbar.Three', 0);
+		await dispatchForeignDrop(1);
+
+		expect(duplicatedAliases()).to.be.empty;
+	});
+
+	it('leaves a drag of another editor to be handled elsewhere', async () => {
+		const event = await dispatchForeignDrop(0);
+
+		expect(event.defaultPrevented, 'the drop was claimed by an area').to.be.false;
+		expect(aliasesInUse()).to.not.include('Test.Toolbar.One');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/tiptap-statusbar-configuration.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/tiptap-statusbar-configuration.context.ts
@@ -164,9 +164,17 @@ export class UmbTiptapStatusbarConfigurationContext extends UmbContextBase {
 		}
 
 		this.#extensionsInUse.clear();
-		value.forEach((area) => area.forEach((alias) => this.#extensionsInUse.add(alias)));
 
-		const statusbar = value.map((area) => ({ unique: UmbId.new(), data: area }));
+		// An extension can only be used once, so any repeat occurrence is dropped rather than carried along. (#23524)
+		const statusbar = value.map((area) => {
+			const aliases: Array<string> = [];
+			for (const alias of area) {
+				if (this.#extensionsInUse.has(alias)) continue;
+				this.#extensionsInUse.add(alias);
+				aliases.push(alias);
+			}
+			return { unique: UmbId.new(), data: aliases };
+		});
 
 		this.#statusbar.setValue(statusbar);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/property-editor-ui-tiptap-toolbar-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/property-editor-ui-tiptap-toolbar-configuration.element.ts
@@ -14,6 +14,8 @@ import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/propert
 
 import './tiptap-toolbar-group-configuration.element.js';
 
+const UMB_TIPTAP_TOOLBAR_ITEM_DRAG_TYPE = 'text/umb-tiptap-toolbar-item';
+
 @customElement('umb-property-editor-ui-tiptap-toolbar-configuration')
 export class UmbPropertyEditorUiTiptapToolbarConfigurationElement
 	extends UmbLitElement
@@ -89,29 +91,40 @@ export class UmbPropertyEditorUiTiptapToolbarConfigurationElement
 		this.#context.insertToolbarItem(item.alias, [lastRow, lastGroup, lastItem]);
 	}
 
+	#isOwnDragItem(event: DragEvent) {
+		return event.dataTransfer?.types.includes(UMB_TIPTAP_TOOLBAR_ITEM_DRAG_TYPE) === true;
+	}
+
 	#onDragStart(event: DragEvent, alias: string, fromPos?: [number, number, number]) {
 		event.dataTransfer!.effectAllowed = 'move';
+		event.dataTransfer!.setData(UMB_TIPTAP_TOOLBAR_ITEM_DRAG_TYPE, alias);
 		this.#currentDragItem = { alias, fromPos };
 	}
 
 	#onDragOver(event: DragEvent) {
+		if (!this.#isOwnDragItem(event)) return;
 		event.preventDefault();
 		event.dataTransfer!.dropEffect = 'move';
 	}
 
 	#onDragEnd(event: DragEvent) {
 		event.preventDefault();
-		if (event.dataTransfer?.dropEffect === 'none') {
-			const { fromPos } = this.#currentDragItem ?? {};
-			if (!fromPos) return;
+		const { fromPos } = this.#currentDragItem ?? {};
+		this.#currentDragItem = undefined;
 
+		if (event.dataTransfer?.dropEffect === 'none' && fromPos) {
 			this.#context.removeToolbarItem(fromPos);
 		}
 	}
 
 	#onDrop(event: DragEvent, toPos?: [number, number, number]) {
+		// A group also receives the drops of the sorter that reorders the items within it, as those bubble out of the
+		// group element. Acting on one of those would re-insert the item of the preceding drag. (#23524)
+		if (!this.#isOwnDragItem(event)) return;
+
 		event.preventDefault();
 		const { alias, fromPos } = this.#currentDragItem ?? {};
+		this.#currentDragItem = undefined;
 
 		// Remove item if no destination position is provided
 		if (fromPos && !toPos) {
@@ -261,7 +274,7 @@ export class UmbPropertyEditorUiTiptapToolbarConfigurationElement
 				class="group"
 				dropzone="move"
 				@dragover=${this.#onDragOver}
-				@drop=${(e: DragEvent) => this.#onDrop(e, [rowIndex, groupIndex, group.data.length - 1])}>
+				@drop=${(e: DragEvent) => this.#onDrop(e, [rowIndex, groupIndex, group.data.length])}>
 				<umb-tiptap-toolbar-group-configuration
 					.items=${items}
 					.rowIndex=${rowIndex}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/property-editor-ui-tiptap-toolbar-configuration.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/property-editor-ui-tiptap-toolbar-configuration.test.ts
@@ -1,0 +1,147 @@
+import { UmbPropertyEditorUiTiptapToolbarConfigurationElement } from './property-editor-ui-tiptap-toolbar-configuration.element.js';
+import type { UmbTiptapToolbarValue } from '../../components/types.js';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbPropertyContext, UmbPropertyDatasetContextBase } from '@umbraco-cms/backoffice/property';
+
+const TOOLBAR_EXTENSION_ALIASES = ['Test.Toolbar.One', 'Test.Toolbar.Two', 'Test.Toolbar.Three', 'Test.Toolbar.Four'];
+
+const manifests: Array<UmbExtensionManifest> = TOOLBAR_EXTENSION_ALIASES.map((alias) => ({
+	type: 'tiptapToolbarExtension',
+	kind: 'button',
+	alias,
+	name: alias,
+	meta: { alias, icon: 'icon-code', label: alias },
+}));
+
+@customElement('umb-test-tiptap-toolbar-configuration-host')
+class UmbTestTiptapToolbarConfigurationHostElement extends UmbLitElement {
+	readonly datasetContext = new UmbPropertyDatasetContextBase(this);
+	readonly propertyContext = new UmbPropertyContext(this);
+
+	constructor() {
+		super();
+		this.propertyContext.setAlias('toolbar');
+		this.datasetContext.setValues([{ alias: 'extensions', value: [] }]);
+	}
+
+	override render() {
+		return html`<slot></slot>`;
+	}
+}
+
+describe('UmbPropertyEditorUiTiptapToolbarConfigurationElement', () => {
+	let element: UmbPropertyEditorUiTiptapToolbarConfigurationElement;
+
+	/** The `.group` element of the designer, which is what receives a dropped toolbar item. */
+	const groupElement = (groupIndex: number) =>
+		element.shadowRoot!.querySelectorAll<HTMLElement>('.group')[groupIndex];
+
+	/** The sorter's container, within the group element, which is where a reorder is dropped. */
+	const groupSorterContainer = (groupIndex: number) =>
+		element
+			.shadowRoot!.querySelectorAll('umb-tiptap-toolbar-group-configuration')
+			[groupIndex].shadowRoot!.querySelector<HTMLElement>('.items')!;
+
+	const dragEvent = (type: string, dataTransfer: DataTransfer) =>
+		new DragEvent(type, { bubbles: true, cancelable: true, composed: true, dataTransfer });
+
+	/** Drags an item from the available items list onto a group, as a user would with the mouse. */
+	const dragAvailableItemToGroup = async (alias: string, groupIndex: number) => {
+		const selector = `.available-items [data-mark="tiptap-toolbar-item:${alias}"]`;
+		await waitUntil(() => element.shadowRoot!.querySelector(selector), `available item for ${alias} was rendered`);
+		const availableItem = element.shadowRoot!.querySelector<HTMLElement>(selector)!;
+
+		const dataTransfer = new DataTransfer();
+		availableItem.dispatchEvent(dragEvent('dragstart', dataTransfer));
+		groupElement(groupIndex).dispatchEvent(dragEvent('dragover', dataTransfer));
+		groupElement(groupIndex).dispatchEvent(dragEvent('drop', dataTransfer));
+		availableItem.dispatchEvent(dragEvent('dragend', dataTransfer));
+
+		await element.updateComplete;
+	};
+
+	/**
+	 * Mimics the drop of the sorter that reorders the items of a group. The sorter carries its own identifier on the
+	 * data transfer, and does not stop the drop from bubbling out to the group element.
+	 */
+	const dispatchSorterDrop = async (groupIndex: number) => {
+		const dataTransfer = new DataTransfer();
+		dataTransfer.setData('text/umb-sorter-identifier#umb-tiptap-toolbar-sorter', 'true');
+		groupSorterContainer(groupIndex).dispatchEvent(dragEvent('drop', dataTransfer));
+
+		await element.updateComplete;
+	};
+
+	const aliasesInUse = () => (element.value ?? []).flat(2);
+
+	const occurrencesOf = (alias: string) => aliasesInUse().filter((x) => x === alias).length;
+
+	const duplicatedAliases = () => {
+		const aliases = aliasesInUse();
+		return [...new Set(aliases.filter((alias, index) => aliases.indexOf(alias) !== index))];
+	};
+
+	const givenToolbar = async (value: UmbTiptapToolbarValue) => {
+		const host = await fixture<UmbTestTiptapToolbarConfigurationHostElement>(html`
+			<umb-test-tiptap-toolbar-configuration-host>
+				<umb-property-editor-ui-tiptap-toolbar-configuration .value=${value}>
+				</umb-property-editor-ui-tiptap-toolbar-configuration>
+			</umb-test-tiptap-toolbar-configuration-host>
+		`);
+
+		element = host.querySelector('umb-property-editor-ui-tiptap-toolbar-configuration')!;
+		await element.updateComplete;
+		await waitUntil(
+			() => element.shadowRoot!.querySelectorAll('.group').length === value.flat().length,
+			'the groups of the toolbar were rendered',
+		);
+	};
+
+	beforeEach(async () => {
+		umbExtensionsRegistry.registerMany(manifests);
+		await givenToolbar([[['Test.Toolbar.One', 'Test.Toolbar.Two']]]);
+	});
+
+	afterEach(() => {
+		umbExtensionsRegistry.unregisterMany(manifests.map((manifest) => manifest.alias));
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbPropertyEditorUiTiptapToolbarConfigurationElement);
+	});
+
+	it('appends an item dragged from the available items to the end of the group', async () => {
+		await dragAvailableItemToGroup('Test.Toolbar.Three', 0);
+
+		expect(element.value).to.deep.equal([[['Test.Toolbar.One', 'Test.Toolbar.Two', 'Test.Toolbar.Three']]]);
+	});
+
+	it('cannot duplicate an item when its group is sorted after it was dragged in', async () => {
+		await dragAvailableItemToGroup('Test.Toolbar.Three', 0);
+		await dispatchSorterDrop(0);
+
+		expect(occurrencesOf('Test.Toolbar.Three')).to.equal(1);
+		expect(duplicatedAliases()).to.be.empty;
+	});
+
+	it('cannot duplicate an item into another group when that group is sorted after it was dragged in', async () => {
+		await givenToolbar([[['Test.Toolbar.One'], ['Test.Toolbar.Two']]]);
+
+		await dragAvailableItemToGroup('Test.Toolbar.Three', 0);
+		await dispatchSorterDrop(1);
+
+		expect(occurrencesOf('Test.Toolbar.Three')).to.equal(1);
+		expect(duplicatedAliases()).to.be.empty;
+	});
+
+	it('drops the repeat occurrences of an item already duplicated in the value', async () => {
+		await givenToolbar([[['Test.Toolbar.One', 'Test.Toolbar.Two', 'Test.Toolbar.One'], ['Test.Toolbar.Two']]]);
+
+		await dragAvailableItemToGroup('Test.Toolbar.Three', 0);
+
+		expect(element.value).to.deep.equal([[['Test.Toolbar.One', 'Test.Toolbar.Two', 'Test.Toolbar.Three'], []]]);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/tiptap-toolbar-configuration.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/tiptap-toolbar-configuration.context.ts
@@ -230,11 +230,19 @@ export class UmbTiptapToolbarConfigurationContext extends UmbContextBase {
 		}
 
 		this.#extensionsInUse.clear();
-		value.forEach((row) => row.forEach((group) => group.forEach((alias) => this.#extensionsInUse.add(alias))));
 
+		// An extension can only be used once, so any repeat occurrence is dropped rather than carried along. (#23524)
 		const toolbar = value.map((row) => ({
 			unique: UmbId.new(),
-			data: row.map((group) => ({ unique: UmbId.new(), data: group })),
+			data: row.map((group) => {
+				const aliases: Array<string> = [];
+				for (const alias of group) {
+					if (this.#extensionsInUse.has(alias)) continue;
+					this.#extensionsInUse.add(alias);
+					aliases.push(alias);
+				}
+				return { unique: UmbId.new(), data: aliases };
+			}),
 		}));
 
 		this.#toolbar.setValue(toolbar);


### PR DESCRIPTION
## Description

This PR fixes an issue reported for Umbraco Deploy, where the serialised `.uda` files for data types would show duplicate items for the toolbar configuration of the Tiptap rich text editor.  Really though this only made visible an underlying issue with the code responsible for handling adding and sorting of the toolbar (and status line) items.

Fixes #23524.

### Why it happens

The Tiptap toolbar designer has **two independent drag systems acting on the same drop**:

1. **Native HTML5 drag and drop**, handled by `property-editor-ui-tiptap-toolbar-configuration.element.ts`, for dragging an item out of *Available items* into a group. It tracks the dragged alias in `#currentDragItem`.
2. **`UmbSorterController`**, owned by the child `umb-tiptap-toolbar-group-configuration` element, for reordering items within and between groups.

Two facts combined to duplicate an item:

- **`#currentDragItem` was never cleared.** `#onDragStart` set it, `#onDragEnd` only read it when the drop had been cancelled, and `#onDrop` left it in place. So after dragging an item in from the available list, its alias stayed parked on the element.
- **The sorter's `drop` handler does not stop propagation.** `UmbSorterController` deliberately calls `stopPropagation()` on `dragover` and `dragstart`, but `#itemDropped` does not. Since `drop` is a composed event, it escapes the group element's shadow root and reaches the `.group` div's own `@drop` handler in the parent.

So on a reorder, the sorter correctly rewrote the group, and then the very same drop bubbled up to the parent, which — seeing a stale `#currentDragItem` and no `fromPos` — took its "insert" branch and added the previously dragged alias a second time.

It was also broader than the report suggests: after dragging an item in, reordering *any* item in *any* group injected a copy of that alias into whichever group received the drop, not just the item or group that was touched.

### Why it isn't visible until Deploy surfaces it

`tiptap-toolbar-group-configuration.element.ts` de-duplicates by alias when it renders — the `items` setter filters repeats, and `repeat()` is keyed by alias. The designer therefore draws a single button while the value handed to the property (and saved to the database) contains the alias twice.

Nothing in the backoffice shows the raw configuration, so the duplicate stays hidden until something serialises it. A Deploy `.uda` file does exactly that, which is why the issue reads as a Deploy problem. It isn't — Deploy only transfer the configuration "as is", and the duplicate is already in the stored configuration before Deploy sees it.

### What changed

**Duplicate toolbar items (the reported issue)** — `property-editor-ui-tiptap-toolbar-configuration.element.ts`

- `#onDragStart` now marks the drag by setting `UMB_TIPTAP_TOOLBAR_ITEM_DRAG_TYPE` (`text/umb-tiptap-toolbar-item`) on the data transfer.
- `#onDragOver` and `#onDrop` ignore any drag that does not carry that type, via `#isOwnDragItem`. This is what stops a group acting on the sorter's bubbled drop.
- `#currentDragItem` is cleared in both `#onDrop` and `#onDragEnd`, so no stale alias can outlive a drag.

**Existing broken configurations self-heal** — `tiptap-toolbar-configuration.context.ts`

`setToolbar` now drops repeat occurrences while it populates `#extensionsInUse`. A toolbar item can only be used once — the available-items list already hides anything in use — so a repeat is always wrong. Without this, configurations that already contain duplicates would keep them until the affected group happened to be reordered again.

**Drags leaking between the toolbar and statusbar designers** — `property-editor-ui-tiptap-statusbar-configuration.element.ts`

The statusbar designer had the same uncleared `#currentDragItem`. It has no sorter, so it cannot hit the reordering bug, but both designers sit on the same data type workspace: dragging an item out of the *toolbar* designer and dropping it on a *statusbar* area re-inserted whatever the statusbar had last dragged, duplicating it.

The statusbar now gets the same treatment, with its **own** drag type (`text/umb-tiptap-statusbar-item`) rather than sharing the toolbar's. Distinct types mean neither designer will accept the other's items at all.

**Off-by-one on the drop position** — both designers

The drop index was `group.data.length - 1` / `area.data.length - 1`, so an item dropped onto a populated group or area landed *second from last* instead of at the end. Both are now `.length`. This means an item dragged to the end of a group will be added there, rather than one in from the end.

## Testing

### Automated tests

Two new test files, both driving real `DragEvent`s against the elements:

`property-editor-ui-tiptap-toolbar-configuration.test.ts` (5 tests)

- an item dragged in from the available list is appended to the end of the group
- reordering the group it was dragged into does not duplicate it
- reordering a *different* group does not duplicate it into that group
- repeat occurrences already present in the value are dropped
- the element is defined with its own instance

`property-editor-ui-tiptap-statusbar-configuration.test.ts` (4 tests)

- an item dragged in from the available list is appended to the end of the area
- a drag belonging to another editor, dropped on an area, does not duplicate anything
- an area leaves another editor's drag to be handled elsewhere (asserts the drop is not `preventDefault`ed)
- the element is defined with its own instance

Each element is mounted under a small test host that provides `UmbPropertyContext` and `UmbPropertyDatasetContextBase`, with throwaway toolbar/statusbar extension manifests registered for the duration. The reordering case is exercised by dispatching the drop on the sorter's own `.items` container carrying the sorter's identifier, which is what the browser does during a real reorder.

Every new test was confirmed to fail before the corresponding change and pass after. The two duplication tests assert "this alias appears exactly once" rather than comparing the whole array, so they fail only for duplication and not for a change in ordering.

### Manual

The duplicate is invisible in the designer, so to see it you need to look at the value that will be saved. I did this by temporarily adding some throw away code to make the stored configuration visible.

To repeat, add the following to `property-editor-ui-tiptap-toolbar-configuration.element.ts` — it renders a live panel below the designer showing the value per row/group and turning red when an alias is repeated.

<details>
<summary>Temporary visibility code</summary>

In `render()`, and a new method beside it:

```ts
override render() {
    return html`${this.#renderDesigner()} ${this.#renderAvailableItems()} ${this.#renderTempDebug()}`;
}

#renderTempDebug() {
    const value = this._toolbar.map((row) => row.data.map((group) => [...group.data]));
    const aliases = value.flat(2);
    const duplicates = [...new Set(aliases.filter((alias, index) => aliases.indexOf(alias) !== index))];
    return html`
        <div id="tempDebug" class=${duplicates.length ? 'has-duplicates' : ''}>
            <strong>
                ${duplicates.length
                    ? `⚠ ${duplicates.length} duplicated alias(es): ${duplicates.join(', ')}`
                    : '✓ no duplicates'}
            </strong>
            <pre>
${value.map((row, r) => row.map((group, g) => `[${r}][${g}]  ${group.map((a) => a.split('.').pop()).join(', ')}`).join('\n')).join('\n')}</pre
            >
        </div>
    `;
}
```

And at the top of `static override readonly styles`:

```css
#tempDebug {
    border: 2px solid var(--uui-color-positive);
    border-radius: var(--uui-border-radius);
    padding: var(--uui-size-space-3);
    font-size: 12px;

    &.has-duplicates {
        border-color: var(--uui-color-danger);
        color: var(--uui-color-danger-emphasis);
    }

    pre {
        margin: var(--uui-size-space-2) 0 0;
        white-space: pre-wrap;
    }
}
```

</details>

Then, on **Settings → Data Types → Richtext editor**:

1. **The reported duplicate.** Drag an item from *Available items* into a toolbar group, then drag it to a new position. Before the fix the panel turns red and names the alias, while the designer above still shows a single button. After the fix it stays green.
2. **The wider case.** Drag an item in, then reorder an *unrelated* item in a *different* group. Before the fix the dragged alias is duplicated into that other group.
3. **Drag between the two designers.** Drag an item from the statusbar's *Available statuses* into an area, then drag an item out of the toolbar designer and drop it on a statusbar area. Before the fix the statusbar item is duplicated.
4. **The drop position.** Drag an item onto a group or area that already has items. Before the fix it lands second from last; after, at the end. Use a populated group — dropping into an empty one looked correct either way.

To check the actual configuration saved into the database use:

```sql
select n.Text, dt.config
from umbracoDataType dt 
inner join umbracoNode n on n.id = dt.nodeId
where propertyEditorUiAlias = 'Umb.PropertyEditorUi.Tiptap'
```