### PR TITLE
Basic Authentication: Allow preview requests from an authenticated back-office user (closes #23475)

### DIFF
--- a/src/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddleware.cs
+++ b/src/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddleware.cs
@@ -1,10 +1,12 @@
 using System.Net;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.Security;
@@ -20,6 +22,7 @@ public class BasicAuthenticationMiddleware : IMiddleware
 {
     private readonly IBasicAuthService _basicAuthService;
     private readonly IRuntimeState _runtimeState;
+    private readonly IPreviewService _previewService;
     private readonly string _backOfficePath;
 
     /// <summary>
@@ -28,14 +31,36 @@ public class BasicAuthenticationMiddleware : IMiddleware
     /// <param name="runtimeState">The runtime state used to determine if the application is running.</param>
     /// <param name="basicAuthService">The service providing basic authentication configuration and validation.</param>
     /// <param name="hostingEnvironment">The hosting environment used to resolve the backoffice path.</param>
+    /// <param name="previewService">The service used to resolve the back-office user previewing the front-end.</param>
+    public BasicAuthenticationMiddleware(
+        IRuntimeState runtimeState,
+        IBasicAuthService basicAuthService,
+        IHostingEnvironment hostingEnvironment,
+        IPreviewService previewService)
+    {
+        _runtimeState = runtimeState;
+        _basicAuthService = basicAuthService;
+        _previewService = previewService;
+        _backOfficePath = hostingEnvironment.GetBackOfficePath();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BasicAuthenticationMiddleware"/> class.
+    /// </summary>
+    /// <param name="runtimeState">The runtime state used to determine if the application is running.</param>
+    /// <param name="basicAuthService">The service providing basic authentication configuration and validation.</param>
+    /// <param name="hostingEnvironment">The hosting environment used to resolve the backoffice path.</param>
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
     public BasicAuthenticationMiddleware(
         IRuntimeState runtimeState,
         IBasicAuthService basicAuthService,
         IHostingEnvironment hostingEnvironment)
+        : this(
+            runtimeState,
+            basicAuthService,
+            hostingEnvironment,
+            StaticServiceProvider.Instance.GetRequiredService<IPreviewService>())
     {
-        _runtimeState = runtimeState;
-        _basicAuthService = basicAuthService;
-        _backOfficePath = hostingEnvironment.GetBackOfficePath();
     }
 
     /// <inheritdoc />
@@ -59,7 +84,7 @@ public class BasicAuthenticationMiddleware : IMiddleware
             return;
         }
 
-        if (await IsAuthenticatedBackOfficeRequestAsync(context))
+        if (await IsAuthenticatedBackOfficeRequestAsync(context) || await IsAuthenticatedPreviewRequestAsync())
         {
             await next(context);
             return;
@@ -124,6 +149,18 @@ public class BasicAuthenticationMiddleware : IMiddleware
 
         AuthenticateResult authenticateResult = await context.AuthenticateBackOfficeAsync();
         return authenticateResult.Succeeded;
+    }
+
+    /// <summary>
+    /// Checks if the request carries a valid preview token, identifying a back-office user previewing the
+    /// front-end. The back-office cookie alone is not enough: it expires a fixed period after sign-in and is
+    /// not renewed by the token-authenticated back-office client, so preview would otherwise start
+    /// challenging mid-session (https://github.com/umbraco/Umbraco-CMS/issues/23475).
+    /// </summary>
+    private async Task<bool> IsAuthenticatedPreviewRequestAsync()
+    {
+        Attempt<ClaimsIdentity> previewIdentityAttempt = await _previewService.TryGetPreviewClaimsIdentityAsync();
+        return previewIdentityAttempt.Success;
     }
 
     private void HandleUnauthorized(HttpContext context)

--- a/src/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddleware.cs
+++ b/src/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddleware.cs
@@ -158,9 +158,9 @@ public class BasicAuthenticationMiddleware : IMiddleware
     /// challenging mid-session (https://github.com/umbraco/Umbraco-CMS/issues/23475).
     /// </summary>
     /// <remarks>
-    /// A successful attempt can still carry a null identity, when the token verified but no back-office
-    /// principal could be built for the user. That must not authenticate the request, so the identity itself
-    /// is what is checked here rather than the attempt's success.
+    /// The attempt succeeds whenever the preview token verifies, even when no back-office identity could be
+    /// resolved from it — <see cref="IPreviewService"/> reports success carrying a null identity in that case.
+    /// Checking the identity rather than the attempt keeps an unresolvable token from authenticating the request.
     /// </remarks>
     private async Task<bool> IsAuthenticatedPreviewRequestAsync()
     {

--- a/src/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddleware.cs
+++ b/src/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddleware.cs
@@ -157,10 +157,15 @@ public class BasicAuthenticationMiddleware : IMiddleware
     /// not renewed by the token-authenticated back-office client, so preview would otherwise start
     /// challenging mid-session (https://github.com/umbraco/Umbraco-CMS/issues/23475).
     /// </summary>
+    /// <remarks>
+    /// A successful attempt can still carry a null identity, when the token verified but no back-office
+    /// principal could be built for the user. That must not authenticate the request, so the identity itself
+    /// is what is checked here rather than the attempt's success.
+    /// </remarks>
     private async Task<bool> IsAuthenticatedPreviewRequestAsync()
     {
         Attempt<ClaimsIdentity> previewIdentityAttempt = await _previewService.TryGetPreviewClaimsIdentityAsync();
-        return previewIdentityAttempt.Success;
+        return previewIdentityAttempt.Success && previewIdentityAttempt.Result.IsBackOfficeAuthenticationType();
     }
 
     private void HandleUnauthorized(HttpContext context)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddlewareTests.cs
@@ -329,7 +329,8 @@ public class BasicAuthenticationMiddlewareTests
     {
         _previewServiceMock
             .Setup(x => x.TryGetPreviewClaimsIdentityAsync())
-            .ReturnsAsync(Attempt<ClaimsIdentity>.Succeed(new ClaimsIdentity()));
+            .ReturnsAsync(Attempt<ClaimsIdentity>.Succeed(
+                new ClaimsIdentity(Constants.Security.BackOfficeAuthenticationType)));
 
         HttpContext context = CreateHttpContext("/previewed-page");
 
@@ -349,6 +350,45 @@ public class BasicAuthenticationMiddlewareTests
         _previewServiceMock
             .Setup(x => x.TryGetPreviewClaimsIdentityAsync())
             .ReturnsAsync(Attempt<ClaimsIdentity>.Fail());
+
+        HttpContext context = CreateHttpContext("/previewed-page");
+
+        await _middleware.InvokeAsync(context, NextDelegate());
+
+        Assert.IsFalse(_nextCalled);
+        Assert.That(context.Response.StatusCode, Is.EqualTo(401));
+    }
+
+    /// <summary>
+    /// Verifies that a successful preview attempt carrying no identity does not authenticate the request.
+    /// The preview token can verify without a back-office principal being built for the user.
+    /// </summary>
+    [Test]
+    public async Task InvokeAsync_PreviewAttemptWithNullIdentity_HandleUnauthorized()
+    {
+        _basicAuthServiceMock.Setup(x => x.IsRedirectToLoginPageEnabled()).Returns(false);
+        _previewServiceMock
+            .Setup(x => x.TryGetPreviewClaimsIdentityAsync())
+            .ReturnsAsync(Attempt<ClaimsIdentity>.Succeed(null!));
+
+        HttpContext context = CreateHttpContext("/previewed-page");
+
+        await _middleware.InvokeAsync(context, NextDelegate());
+
+        Assert.IsFalse(_nextCalled);
+        Assert.That(context.Response.StatusCode, Is.EqualTo(401));
+    }
+
+    /// <summary>
+    /// Verifies that a preview identity that is not a back-office identity does not authenticate the request.
+    /// </summary>
+    [Test]
+    public async Task InvokeAsync_PreviewIdentityNotBackOfficeAuthenticationType_HandleUnauthorized()
+    {
+        _basicAuthServiceMock.Setup(x => x.IsRedirectToLoginPageEnabled()).Returns(false);
+        _previewServiceMock
+            .Setup(x => x.TryGetPreviewClaimsIdentityAsync())
+            .ReturnsAsync(Attempt<ClaimsIdentity>.Succeed(new ClaimsIdentity("SomeOtherScheme")));
 
         HttpContext context = CreateHttpContext("/previewed-page");
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddlewareTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Security.Claims;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,7 @@ public class BasicAuthenticationMiddlewareTests
     private Mock<IRuntimeState> _runtimeStateMock = null!;
     private Mock<IBasicAuthService> _basicAuthServiceMock = null!;
     private Mock<IBackOfficeSignInManager> _signInManagerMock = null!;
+    private Mock<IPreviewService> _previewServiceMock = null!;
     private BasicAuthenticationMiddleware _middleware = null!;
     private bool _nextCalled;
 
@@ -36,12 +38,19 @@ public class BasicAuthenticationMiddlewareTests
         hostingEnvironmentMock.Setup(x => x.ToAbsolute(It.IsAny<string>())).Returns<string>(path => path.TrimStart('~'));
 
         _signInManagerMock = new Mock<IBackOfficeSignInManager>();
+
+        _previewServiceMock = new Mock<IPreviewService>();
+        _previewServiceMock
+            .Setup(x => x.TryGetPreviewClaimsIdentityAsync())
+            .ReturnsAsync(Attempt<ClaimsIdentity>.Fail());
+
         _nextCalled = false;
 
         _middleware = new BasicAuthenticationMiddleware(
             _runtimeStateMock.Object,
             _basicAuthServiceMock.Object,
-            hostingEnvironmentMock.Object);
+            hostingEnvironmentMock.Object,
+            _previewServiceMock.Object);
     }
 
     /// <summary>
@@ -309,6 +318,44 @@ public class BasicAuthenticationMiddlewareTests
 
         Assert.IsFalse(_nextCalled);
         Assert.That(httpContext.Response.StatusCode, Is.EqualTo(401));
+    }
+
+    /// <summary>
+    /// Verifies that a request carrying a valid preview token is let through without a Basic challenge,
+    /// even though the back-office cookie has expired.
+    /// </summary>
+    [Test]
+    public async Task InvokeAsync_ValidPreviewToken_NoBackOfficeCookie_PassesThrough()
+    {
+        _previewServiceMock
+            .Setup(x => x.TryGetPreviewClaimsIdentityAsync())
+            .ReturnsAsync(Attempt<ClaimsIdentity>.Succeed(new ClaimsIdentity()));
+
+        HttpContext context = CreateHttpContext("/previewed-page");
+
+        await _middleware.InvokeAsync(context, NextDelegate());
+
+        Assert.IsTrue(_nextCalled);
+        Assert.That(context.Response.StatusCode, Is.EqualTo(200));
+    }
+
+    /// <summary>
+    /// Verifies that an unverifiable preview token does not bypass the Basic challenge.
+    /// </summary>
+    [Test]
+    public async Task InvokeAsync_InvalidPreviewToken_HandleUnauthorized()
+    {
+        _basicAuthServiceMock.Setup(x => x.IsRedirectToLoginPageEnabled()).Returns(false);
+        _previewServiceMock
+            .Setup(x => x.TryGetPreviewClaimsIdentityAsync())
+            .ReturnsAsync(Attempt<ClaimsIdentity>.Fail());
+
+        HttpContext context = CreateHttpContext("/previewed-page");
+
+        await _middleware.InvokeAsync(context, NextDelegate());
+
+        Assert.IsFalse(_nextCalled);
+        Assert.That(context.Response.StatusCode, Is.EqualTo(401));
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

With `Umbraco:CMS:BasicAuth:Enabled` set, **Save & Preview** starts showing the browser's Basic authentication dialog once the editor has been signed in for longer than `Global:TimeOut` (20 minutes by default).

`BasicAuthenticationMiddleware` decides "this is an already signed-in backoffice user, let them through" by authenticating the back-office login cookie (`UMB_UCONTEXT`) via `context.AuthenticateBackOfficeAsync()`.

That cookie is configured with `SlidingExpiration = false` and `ExpireTimeSpan = Global:TimeOut` (`ConfigureBackOfficeCookieOptions`), and is only ever renewed inside `OnValidatePrincipal` — which runs solely on requests that the *cookie scheme itself* authenticates. The backoffice client's traffic is all OpenIddict-token-authenticated Management API calls, so the cookie quietly expires a fixed period after sign-in while the token session keeps sliding along happily.

The preview window loads the **front-end** URL in an IFRAME, so it reaches the middleware, fails the cookie check, and gets a `401` with `WWW-Authenticate: Basic`.

## The fix

Also accept a valid **preview token** as evidence of an authenticated backoffice user, via `IPreviewService.TryGetPreviewClaimsIdentityAsync()` — the same call `PreviewAuthenticationMiddleware` already makes earlier in the same request.

This suits the job well:

- It is re-issued on **every** Save & Preview (`DocumentUrlFactory.GetPreviewUrlAsync` calls `TryEnterPreviewAsync`), so unlike the login cookie it cannot go stale mid-session.
- It is Data-Protection-encrypted and user-bound, and `VerifyAsync` re-checks that the user is approved and not locked out.
- Sign-out clears the preview cookie from the browser (`OnSigningOut`).

A token can only come into existence because an authenticated back-office user asked to preview something: it is minted solely by `TryEnterPreviewAsync`, whose only callers sit behind back-office authorization (`DocumentControllerBase` carries `[Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]`), and it cannot be forged without the Data Protection key ring.

Fixes #23475

## Scope

Limited to preview. An editor browsing the **published** front-end site after `Global:TimeOut` is still challenged — that is the same underlying cookie-lifetime behaviour, and is better addressed alongside #22752.

## Testing

### Automated

Two tests added to `BasicAuthenticationMiddlewareTests`, covering that a valid preview token is let through without a challenge, and that an unverifiable one still gets a `401`. Verified fail-before by temporarily removing the new clause. 

### Manual

I've carried this out on my local development site.

1. In `appsettings.Local.json`, set `Umbraco:CMS:Global:TimeOut` to `00:02:00` and `Umbraco:CMS:BasicAuth:Enabled` to `true`, leaving `RedirectToLoginPage` at its default `false` so the browser Basic dialog is used. `AllowedIPs` left empty.
2. Run over HTTPS, and create a document type with a template plus a page to preview.
3. Sign in to the backoffice, then keep clicking around it for over two minutes to stay active.
4. Confirm in dev tools that the `UMB_UCONTEXT` cookie has expired while the backoffice is still working.
5. Click **Save & Preview**.

Before: the preview tab presents the Basic authentication dialog, and the front-end request returns `401` with `WWW-Authenticate: Basic realm="Umbraco login"`.
After: the preview loads as expected, with no challenge.

Use a fresh incognito window per attempt, as browsers cache Basic credentials per origin and will silently re-send them.