### PR TITLE
Confirm Modal: Escaped special characters in item names

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/eslint/rules/no-unsafe-localize.cjs
+++ b/src/Umbraco.Web.UI.Client/devops/eslint/rules/no-unsafe-localize.cjs
@@ -8,15 +8,137 @@
  *    `<x>.localize.htmlString(text, ...args)` instead, which escapes args via escapeHTML and
  *    returns a Lit unsafeHTML directive ready to inline in templates.
  *
- * 2. `umbConfirmModal(_, { content: ... })` (and other modals sharing the same `content` sink)
- *    given a `string` built from a template literal with interpolation, or an unescaped
+ * 2. `umbConfirmModal(_, { content: ... })` / `umbInfoModal(_, { content: ... })` given a `string`
+ *    built from a template literal with interpolation, or an unescaped
  *    `<x>.localize.string|term(key, ...args)` call — the modal renders string `content` via
  *    `unsafeHTML` internally, so any interpolated arg reaches the DOM unescaped. Use
- *    `content: html\`${this.localize.htmlString(key, ...args)}\`` (or a plain `html` template,
- *    for keys with no HTML markup) instead.
+ *    `content: this.localize.term(key, escapeHTML(value))` (preferred — a plain string), or
+ *    `content: html\`${this.localize.htmlString(key, ...args)}\`` for keys containing markup.
  *
  * See `docs/security.md` (XSS Prevention → Localized HTML) for the full pattern.
  */
+
+const MODAL_CALLEES = new Set(['umbConfirmModal', 'umbInfoModal']);
+
+/**
+ * Returns true if the given AST node represents a `<...>.localize` member access,
+ * e.g. `this.localize`, `this.#localize`, `host.localize`, `this._localize`.
+ */
+function isLocalizeMemberAccess(node) {
+	if (node?.type !== 'MemberExpression') return false;
+	const prop = node.property;
+	if (!prop) return false;
+	// Match `localize` (regular) or any private/aliased identifier ending in `localize` (e.g. `#localize`, `_localize`).
+	if (prop.type === 'Identifier' && /localize$/i.test(prop.name)) return true;
+	if (prop.type === 'PrivateIdentifier' && /localize$/i.test(prop.name)) return true;
+	return false;
+}
+
+/**
+ * Returns true if an arg to `<localizeExpr>.string|term(key, ...args)` is provably harmless
+ * regardless of its runtime value: a literal, a non-computed `<ref>.length` access (always a
+ * number for the array/string cases this matches), an `escapeHTML(...)` call (already sanitized),
+ * or an array of only such values.
+ */
+function isKnownSafeArg(argNode) {
+	if (!argNode) return false;
+
+	if (argNode.type === 'Literal') return true;
+
+	if (
+		argNode.type === 'MemberExpression' &&
+		!argNode.computed &&
+		argNode.property?.type === 'Identifier' &&
+		argNode.property.name === 'length' &&
+		(argNode.object?.type === 'Identifier' ||
+			argNode.object?.type === 'MemberExpression' ||
+			argNode.object?.type === 'ThisExpression')
+	) {
+		return true;
+	}
+
+	if (argNode.type === 'CallExpression' && argNode.callee?.type === 'Identifier' && argNode.callee.name === 'escapeHTML') {
+		return true;
+	}
+
+	if (argNode.type === 'ArrayExpression') {
+		return argNode.elements.every((el) => isKnownSafeArg(el));
+	}
+
+	return false;
+}
+
+/**
+ * Returns true if the given `content:` value is provably unsafe: a template literal with at
+ * least one interpolated expression, or an `<localizeExpr>.string|term(key, ...args)` call
+ * where at least one arg beyond the key isn't provably harmless. `html`...`` (a
+ * TaggedTemplateExpression), static strings, arg-less localize calls, calls where every extra
+ * arg is known-safe (see `isKnownSafeArg`), and opaque variables are left alone.
+ */
+function isUnsafeContentValue(valueNode) {
+	if (!valueNode) return false;
+
+	if (valueNode.type === 'TemplateLiteral') {
+		return valueNode.expressions.length > 0;
+	}
+
+	if (valueNode.type === 'CallExpression') {
+		const callee = valueNode.callee;
+		if (callee?.type !== 'MemberExpression') return false;
+		if (callee.property?.type !== 'Identifier') return false;
+
+		const method = callee.property.name;
+		if (method !== 'string' && method !== 'term') return false;
+		if (!isLocalizeMemberAccess(callee.object)) return false;
+
+		const extraArgs = valueNode.arguments.slice(1);
+		if (extraArgs.length === 0) return false;
+
+		return extraArgs.some((arg) => !isKnownSafeArg(arg));
+	}
+
+	return false;
+}
+
+/** Looking for: unsafeHTML(<localizeExpr>.string|term(...)) */
+function reportUnsafeLocalizeWrap(context, node) {
+	if (node.arguments.length === 0) return;
+
+	const arg = node.arguments[0];
+	if (arg?.type !== 'CallExpression') return;
+
+	// <arg> must itself be a member-call: <localizeExpr>.string(...) or .term(...)
+	const innerCallee = arg.callee;
+	if (innerCallee?.type !== 'MemberExpression') return;
+	if (innerCallee.property?.type !== 'Identifier') return;
+
+	const method = innerCallee.property.name;
+	if (method !== 'string' && method !== 'term') return;
+
+	if (!isLocalizeMemberAccess(innerCallee.object)) return;
+
+	context.report({
+		node,
+		messageId: 'unsafeLocalize',
+		data: { method },
+	});
+}
+
+/** Looking for: umbConfirmModal(<host>, { content: <unsafe> }) or umbInfoModal(<host>, { content: <unsafe> }) */
+function reportUnsafeModalContent(context, node) {
+	const dataArg = node.arguments[1];
+	if (dataArg?.type !== 'ObjectExpression') return;
+
+	const contentProp = dataArg.properties.find((p) => p.type === 'Property' && p.key?.type === 'Identifier' && p.key.name === 'content');
+	if (!contentProp) return;
+
+	if (isUnsafeContentValue(contentProp.value)) {
+		context.report({
+			node: contentProp,
+			messageId: 'unsafeModalContent',
+		});
+	}
+}
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -33,126 +155,18 @@ module.exports = {
 			unsafeLocalize:
 				'Avoid `unsafeHTML(...localize.{{method}}(...))` — interpolated args are not escaped (XSS hazard). Use `localize.htmlString(...)` instead.',
 			unsafeModalContent:
-				'Avoid interpolating values directly into modal `content` — it is rendered via `unsafeHTML` (XSS hazard). Wrap the value in an `html` template (or use `localize.htmlString(key, ...args)` for keys containing markup).',
+				'Avoid interpolating values directly into modal `content` — it is rendered via `unsafeHTML` (XSS hazard). Pass pre-escaped args instead: `localize.term(key, escapeHTML(value))`.',
 		},
 	},
 	create(context) {
-		/**
-		 * Returns true if the given AST node represents a `<...>.localize` member access,
-		 * e.g. `this.localize`, `this.#localize`, `host.localize`, `this._localize`.
-		 */
-		function isLocalizeMemberAccess(node) {
-			if (!node || node.type !== 'MemberExpression') return false;
-			const prop = node.property;
-			if (!prop) return false;
-			// Match `localize` (regular) or any private/aliased identifier ending in `localize` (e.g. `#localize`, `_localize`).
-			if (prop.type === 'Identifier' && /localize$/i.test(prop.name)) return true;
-			if (prop.type === 'PrivateIdentifier' && /localize$/i.test(prop.name)) return true;
-			return false;
-		}
-
-		/**
-		 * Returns true if an arg to `<localizeExpr>.string|term(key, ...args)` is provably harmless
-		 * regardless of its runtime value: a literal, a `<expr>.length` access (always a number), an
-		 * `escapeHTML(...)` call (already sanitized), or an array of only such values.
-		 */
-		function isKnownSafeArg(argNode) {
-			if (!argNode) return false;
-
-			if (argNode.type === 'Literal') return true;
-
-			if (argNode.type === 'MemberExpression' && argNode.property?.type === 'Identifier' && argNode.property.name === 'length') {
-				return true;
-			}
-
-			if (argNode.type === 'CallExpression' && argNode.callee?.type === 'Identifier' && argNode.callee.name === 'escapeHTML') {
-				return true;
-			}
-
-			if (argNode.type === 'ArrayExpression') {
-				return argNode.elements.every((el) => isKnownSafeArg(el));
-			}
-
-			return false;
-		}
-
-		/**
-		 * Returns true if the given `content:` value is provably unsafe: a template literal with at
-		 * least one interpolated expression, or an `<localizeExpr>.string|term(key, ...args)` call
-		 * where at least one arg beyond the key isn't provably harmless. `html`...`` (a
-		 * TaggedTemplateExpression), static strings, arg-less localize calls, calls where every extra
-		 * arg is known-safe (see `isKnownSafeArg`), and opaque variables are left alone.
-		 */
-		function isUnsafeContentValue(valueNode) {
-			if (!valueNode) return false;
-
-			if (valueNode.type === 'TemplateLiteral') {
-				return valueNode.expressions.length > 0;
-			}
-
-			if (valueNode.type === 'CallExpression') {
-				const callee = valueNode.callee;
-				if (!callee || callee.type !== 'MemberExpression') return false;
-				if (callee.property?.type !== 'Identifier') return false;
-
-				const method = callee.property.name;
-				if (method !== 'string' && method !== 'term') return false;
-				if (!isLocalizeMemberAccess(callee.object)) return false;
-
-				const extraArgs = valueNode.arguments.slice(1);
-				if (extraArgs.length === 0) return false;
-
-				return extraArgs.some((arg) => !isKnownSafeArg(arg));
-			}
-
-			return false;
-		}
-
 		return {
 			CallExpression(node) {
-				if (!node.callee || node.callee.type !== 'Identifier') return;
+				if (node.callee?.type !== 'Identifier') return;
 
-				// Looking for: unsafeHTML(<inner>)
 				if (node.callee.name === 'unsafeHTML') {
-					if (node.arguments.length === 0) return;
-
-					const arg = node.arguments[0];
-					if (!arg || arg.type !== 'CallExpression') return;
-
-					// <inner> must itself be a member-call: <localizeExpr>.string(...) or .term(...)
-					const innerCallee = arg.callee;
-					if (!innerCallee || innerCallee.type !== 'MemberExpression') return;
-					if (innerCallee.property?.type !== 'Identifier') return;
-
-					const method = innerCallee.property.name;
-					if (method !== 'string' && method !== 'term') return;
-
-					if (!isLocalizeMemberAccess(innerCallee.object)) return;
-
-					context.report({
-						node,
-						messageId: 'unsafeLocalize',
-						data: { method },
-					});
-					return;
-				}
-
-				// Looking for: umbConfirmModal(<host>, { content: <unsafe> }) or umbInfoModal(<host>, { content: <unsafe> })
-				if (node.callee.name === 'umbConfirmModal' || node.callee.name === 'umbInfoModal') {
-					const dataArg = node.arguments[1];
-					if (!dataArg || dataArg.type !== 'ObjectExpression') return;
-
-					const contentProp = dataArg.properties.find(
-						(p) => p.type === 'Property' && p.key?.type === 'Identifier' && p.key.name === 'content',
-					);
-					if (!contentProp) return;
-
-					if (isUnsafeContentValue(contentProp.value)) {
-						context.report({
-							node: contentProp,
-							messageId: 'unsafeModalContent',
-						});
-					}
+					reportUnsafeLocalizeWrap(context, node);
+				} else if (MODAL_CALLEES.has(node.callee.name)) {
+					reportUnsafeModalContent(context, node);
 				}
 			},
 		};

--- a/src/Umbraco.Web.UI.Client/devops/eslint/rules/no-unsafe-localize.cjs
+++ b/src/Umbraco.Web.UI.Client/devops/eslint/rules/no-unsafe-localize.cjs
@@ -1,11 +1,19 @@
 'use strict';
 
 /**
- * Flags `unsafeHTML(<x>.localize.string(...))` and `unsafeHTML(<x>.localize.term(...))`.
+ * Flags two XSS-prone shapes:
  *
- * Wrapping a localized string in `unsafeHTML` leaves any interpolated args un-escaped — an XSS hazard
- * when the args are user-controlled. Use `<x>.localize.htmlString(text, ...args)` instead, which
- * escapes args via escapeHTML and returns a Lit unsafeHTML directive ready to inline in templates.
+ * 1. `unsafeHTML(<x>.localize.string(...))` / `unsafeHTML(<x>.localize.term(...))` — wrapping a
+ *    localized string in `unsafeHTML` leaves any interpolated args un-escaped. Use
+ *    `<x>.localize.htmlString(text, ...args)` instead, which escapes args via escapeHTML and
+ *    returns a Lit unsafeHTML directive ready to inline in templates.
+ *
+ * 2. `umbConfirmModal(_, { content: ... })` (and other modals sharing the same `content` sink)
+ *    given a `string` built from a template literal with interpolation, or an unescaped
+ *    `<x>.localize.string|term(key, ...args)` call — the modal renders string `content` via
+ *    `unsafeHTML` internally, so any interpolated arg reaches the DOM unescaped. Use
+ *    `content: html\`${this.localize.htmlString(key, ...args)}\`` (or a plain `html` template,
+ *    for keys with no HTML markup) instead.
  *
  * See `docs/security.md` (XSS Prevention → Localized HTML) for the full pattern.
  */
@@ -15,7 +23,8 @@ module.exports = {
 	meta: {
 		type: 'problem',
 		docs: {
-			description: 'Disallow `unsafeHTML(<x>.localize.string|term(...))`. Use `<x>.localize.htmlString(...)` instead.',
+			description:
+				'Disallow `unsafeHTML(<x>.localize.string|term(...))` and unescaped interpolation in modal `content`.',
 			category: 'Possible Errors',
 			recommended: true,
 		},
@@ -23,6 +32,8 @@ module.exports = {
 		messages: {
 			unsafeLocalize:
 				'Avoid `unsafeHTML(...localize.{{method}}(...))` — interpolated args are not escaped (XSS hazard). Use `localize.htmlString(...)` instead.',
+			unsafeModalContent:
+				'Avoid interpolating values directly into modal `content` — it is rendered via `unsafeHTML` (XSS hazard). Wrap the value in an `html` template (or use `localize.htmlString(key, ...args)` for keys containing markup).',
 		},
 	},
 	create(context) {
@@ -40,30 +51,109 @@ module.exports = {
 			return false;
 		}
 
+		/**
+		 * Returns true if an arg to `<localizeExpr>.string|term(key, ...args)` is provably harmless
+		 * regardless of its runtime value: a literal, a `<expr>.length` access (always a number), an
+		 * `escapeHTML(...)` call (already sanitized), or an array of only such values.
+		 */
+		function isKnownSafeArg(argNode) {
+			if (!argNode) return false;
+
+			if (argNode.type === 'Literal') return true;
+
+			if (argNode.type === 'MemberExpression' && argNode.property?.type === 'Identifier' && argNode.property.name === 'length') {
+				return true;
+			}
+
+			if (argNode.type === 'CallExpression' && argNode.callee?.type === 'Identifier' && argNode.callee.name === 'escapeHTML') {
+				return true;
+			}
+
+			if (argNode.type === 'ArrayExpression') {
+				return argNode.elements.every((el) => isKnownSafeArg(el));
+			}
+
+			return false;
+		}
+
+		/**
+		 * Returns true if the given `content:` value is provably unsafe: a template literal with at
+		 * least one interpolated expression, or an `<localizeExpr>.string|term(key, ...args)` call
+		 * where at least one arg beyond the key isn't provably harmless. `html`...`` (a
+		 * TaggedTemplateExpression), static strings, arg-less localize calls, calls where every extra
+		 * arg is known-safe (see `isKnownSafeArg`), and opaque variables are left alone.
+		 */
+		function isUnsafeContentValue(valueNode) {
+			if (!valueNode) return false;
+
+			if (valueNode.type === 'TemplateLiteral') {
+				return valueNode.expressions.length > 0;
+			}
+
+			if (valueNode.type === 'CallExpression') {
+				const callee = valueNode.callee;
+				if (!callee || callee.type !== 'MemberExpression') return false;
+				if (callee.property?.type !== 'Identifier') return false;
+
+				const method = callee.property.name;
+				if (method !== 'string' && method !== 'term') return false;
+				if (!isLocalizeMemberAccess(callee.object)) return false;
+
+				const extraArgs = valueNode.arguments.slice(1);
+				if (extraArgs.length === 0) return false;
+
+				return extraArgs.some((arg) => !isKnownSafeArg(arg));
+			}
+
+			return false;
+		}
+
 		return {
 			CallExpression(node) {
+				if (!node.callee || node.callee.type !== 'Identifier') return;
+
 				// Looking for: unsafeHTML(<inner>)
-				if (!node.callee || node.callee.type !== 'Identifier' || node.callee.name !== 'unsafeHTML') return;
-				if (node.arguments.length === 0) return;
+				if (node.callee.name === 'unsafeHTML') {
+					if (node.arguments.length === 0) return;
 
-				const arg = node.arguments[0];
-				if (!arg || arg.type !== 'CallExpression') return;
+					const arg = node.arguments[0];
+					if (!arg || arg.type !== 'CallExpression') return;
 
-				// <inner> must itself be a member-call: <localizeExpr>.string(...) or .term(...)
-				const innerCallee = arg.callee;
-				if (!innerCallee || innerCallee.type !== 'MemberExpression') return;
-				if (innerCallee.property?.type !== 'Identifier') return;
+					// <inner> must itself be a member-call: <localizeExpr>.string(...) or .term(...)
+					const innerCallee = arg.callee;
+					if (!innerCallee || innerCallee.type !== 'MemberExpression') return;
+					if (innerCallee.property?.type !== 'Identifier') return;
 
-				const method = innerCallee.property.name;
-				if (method !== 'string' && method !== 'term') return;
+					const method = innerCallee.property.name;
+					if (method !== 'string' && method !== 'term') return;
 
-				if (!isLocalizeMemberAccess(innerCallee.object)) return;
+					if (!isLocalizeMemberAccess(innerCallee.object)) return;
 
-				context.report({
-					node,
-					messageId: 'unsafeLocalize',
-					data: { method },
-				});
+					context.report({
+						node,
+						messageId: 'unsafeLocalize',
+						data: { method },
+					});
+					return;
+				}
+
+				// Looking for: umbConfirmModal(<host>, { content: <unsafe> }) or umbInfoModal(<host>, { content: <unsafe> })
+				if (node.callee.name === 'umbConfirmModal' || node.callee.name === 'umbInfoModal') {
+					const dataArg = node.arguments[1];
+					if (!dataArg || dataArg.type !== 'ObjectExpression') return;
+
+					const contentProp = dataArg.properties.find(
+						(p) => p.type === 'Property' && p.key?.type === 'Identifier' && p.key.name === 'content',
+					);
+					if (!contentProp) return;
+
+					if (isUnsafeContentValue(contentProp.value)) {
+						context.report({
+							node: contentProp,
+							messageId: 'unsafeModalContent',
+						});
+					}
+				}
 			},
 		};
 	},

--- a/src/Umbraco.Web.UI.Client/docs/security.md
+++ b/src/Umbraco.Web.UI.Client/docs/security.md
@@ -164,10 +164,16 @@ html`<p>${this.localize.htmlString('#defaultdialogs_confirmdelete', userControll
 html`<p>${unsafeHTML(this.localize.string('#defaultdialogs_confirmdelete', userControlledName))}</p>`;
 ```
 
-**Modal `content` field** (e.g. `umbConfirmModal`) renders strings via `unsafeHTML` internally. When passing a localized string with user-controlled args, wrap it in a template:
+**Modal `content` field** (e.g. `umbConfirmModal`) renders strings via `unsafeHTML` internally. When passing a localized string with user-controlled args, either pre-escape the args (preferred, `content` stays a plain string) or wrap an `htmlString()` call in a template for keys containing markup. Note `term()`/`string()` take a **bare** key — only `string()`/`htmlString()` resolve a leading `#`, so `term()` never uses one:
 
 ```typescript
-// ✅ Safe — htmlString escapes args, html`...` wraps the directive in a TemplateResult
+// ✅ Preferred — term() returns a plain string; escape user-controlled args at the call site
+umbConfirmModal(this, {
+	headline: '#actions_delete',
+	content: this.localize.term('defaultdialogs_confirmdelete', escapeHTML(item.name ?? '')),
+});
+
+// ✅ Also safe — htmlString escapes args, html`...` wraps the directive in a TemplateResult
 umbConfirmModal(this, {
 	headline: '#actions_delete',
 	content: html`${this.#localize.htmlString('#defaultdialogs_confirmdelete', item.name)}`,

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -562,6 +562,7 @@ export default {
 		confirmdeleteNumberOfItems: 'Are you sure you want to delete <strong>%0%</strong> of <strong>%1%</strong> items',
 		confirmdisable: 'Are you sure you want to disable',
 		confirmremove: 'Are you sure you want to remove',
+		confirmRemoveItem: (name: string) => `Are you sure you want to remove${name ? ` <strong>${name}</strong>` : ''}?`,
 		confirmremoveusageof: 'Are you sure you want to remove the usage of <strong>%0%</strong>',
 		confirmlogout: 'Are you sure?',
 		confirmSure: 'Are you sure?',
@@ -2636,6 +2637,9 @@ export default {
 		confirmDeleteHeadline: 'Delete from clipboard',
 		confirmDeleteDescription: 'Are you sure you want to delete <strong>{0}</strong> from the clipboard?',
 		confirmClearDescription: 'Are you sure you want to clear the clipboard?',
+		confirmPasteHeadline: 'Paste from clipboard',
+		confirmPasteOverwriteMessage:
+			'The property already contains a value. Paste from the property action will overwrite the current value. Do you want to replace the current value with %0%?',
 		copySuccessHeadline: 'Copied to clipboard',
 	},
 	propertyActions: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1436,7 +1436,7 @@ export default {
 	propertyEditorPicker: {
 		title: 'Select a property editor',
 		openPropertyEditorPicker: 'Select a property editor UI',
-		selectAction: "Select Property Editor",
+		selectAction: 'Select Property Editor',
 	},
 	propertyEditorUIGroups: {
 		advanced: 'Advanced',
@@ -2638,8 +2638,8 @@ export default {
 		confirmDeleteDescription: 'Are you sure you want to delete <strong>{0}</strong> from the clipboard?',
 		confirmClearDescription: 'Are you sure you want to clear the clipboard?',
 		confirmPasteHeadline: 'Paste from clipboard',
-		confirmPasteOverwriteMessage:
-			'The property already contains a value. Paste from the property action will overwrite the current value. Do you want to replace the current value with %0%?',
+		confirmPasteOverwriteMessage: (name: string) =>
+			`The property already contains a value. Paste from the property action will overwrite the current value. Do you want to replace the current value with <strong>${name}</strong>?`,
 		copySuccessHeadline: 'Copied to clipboard',
 	},
 	propertyActions: {

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -369,8 +369,9 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 	htmlString(text: string | undefined, ...args: unknown[]) {
 		// `escapeHTML` short-circuits on non-strings, so we stringify first to also escape values
 		// like `{ toString: () => '<script>...' }`. `undefined` is preserved so `string()` can
-		// keep the original placeholder unmatched (existing semantics).
-		const escapedArgs = args.map((a) => (typeof a === 'undefined' ? a : escapeHTML(String(a))));
+		// keep the original placeholder unmatched (existing semantics). A plain object with no
+		// custom `toString` safely degrades to the literal "[object Object]" here.
+		const escapedArgs = args.map((a) => (a === undefined ? a : escapeHTML(String(a))));
 		return unsafeHTML(this.string(text, ...escapedArgs));
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/property-editor-ui-block-grid-type-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/property-editor-ui-block-grid-type-configuration.element.ts
@@ -182,7 +182,7 @@ export class UmbPropertyEditorUIBlockGridTypeConfigurationElement
 		const groupName = this.#blockGroups?.find((group) => group.key === groupKey)?.name ?? '';
 		await umbConfirmModal(this, {
 			headline: '#blockEditor_confirmDeleteBlockGroupTitle',
-			content: this.localize.term('blockEditor_confirmDeleteBlockGroupMessage', [groupName]),
+			content: html`${this.localize.htmlString('#blockEditor_confirmDeleteBlockGroupMessage', groupName)}`,
 			color: 'danger',
 			confirmLabel: '#general_delete',
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/property-editor-ui-block-grid-type-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/property-editor-ui-block-grid-type-configuration.element.ts
@@ -177,7 +177,6 @@ export class UmbPropertyEditorUIBlockGridTypeConfigurationElement
 		}
 	}
 
-	// TODO: Implement confirm dialog [NL]
 	async #deleteGroup(groupKey: string) {
 		const groupName = this.#blockGroups?.find((group) => group.key === groupKey)?.name ?? '';
 		await umbConfirmModal(this, {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/property-editor-ui-block-grid-type-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/property-editor-ui-block-grid-type-configuration.element.ts
@@ -16,6 +16,7 @@ import {
 	css,
 	ifDefined,
 } from '@umbraco-cms/backoffice/external/lit';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
@@ -181,7 +182,7 @@ export class UmbPropertyEditorUIBlockGridTypeConfigurationElement
 		const groupName = this.#blockGroups?.find((group) => group.key === groupKey)?.name ?? '';
 		await umbConfirmModal(this, {
 			headline: '#blockEditor_confirmDeleteBlockGroupTitle',
-			content: html`${this.localize.htmlString('#blockEditor_confirmDeleteBlockGroupMessage', groupName)}`,
+			content: this.localize.term('blockEditor_confirmDeleteBlockGroupMessage', escapeHTML(groupName)),
 			color: 'danger',
 			confirmLabel: '#general_delete',
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
@@ -3,6 +3,7 @@ import type { UmbBlockTypeCardElement } from '../block-type-card/index.js';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { css, html, customElement, property, state, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbPropertyDatasetContext } from '@umbraco-cms/backoffice/property';
 import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
@@ -151,7 +152,7 @@ export class UmbInputBlockTypeElement<
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: '#blockEditor_confirmDeleteBlockTypeTitle',
-			content: html`${this.localize.htmlString('#blockEditor_confirmDeleteBlockTypeMessage', contentType[0]?.name ?? '')}`,
+			content: this.localize.term('blockEditor_confirmDeleteBlockTypeMessage', escapeHTML(contentType[0]?.name ?? '')),
 			confirmLabel: '#general_remove',
 		});
 		this.deleteItem(item.contentElementTypeKey);

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
@@ -151,7 +151,7 @@ export class UmbInputBlockTypeElement<
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: '#blockEditor_confirmDeleteBlockTypeTitle',
-			content: this.localize.term('blockEditor_confirmDeleteBlockTypeMessage', [contentType[0]?.name]),
+			content: html`${this.localize.htmlString('#blockEditor_confirmDeleteBlockTypeMessage', contentType[0]?.name ?? '')}`,
 			confirmLabel: '#general_remove',
 		});
 		this.deleteItem(item.contentElementTypeKey);

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -8,7 +8,6 @@ import type {
 } from '../types.js';
 import type { UmbBlockEntriesContext } from './block-entries.context.js';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
-import { html } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbBooleanState,
 	UmbClassState,
@@ -18,7 +17,12 @@ import {
 	mergeObservables,
 	observeMultiple,
 } from '@umbraco-cms/backoffice/observable-api';
-import { encodeFilePath, UmbDeprecation, UmbReadOnlyVariantGuardManager } from '@umbraco-cms/backoffice/utils';
+import {
+	encodeFilePath,
+	escapeHTML,
+	UmbDeprecation,
+	UmbReadOnlyVariantGuardManager,
+} from '@umbraco-cms/backoffice/utils';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 import { UmbRoutePathAddendumContext } from '@umbraco-cms/backoffice/router';
@@ -788,7 +792,7 @@ export abstract class UmbBlockEntryContext<
 		const blockName = this.getName();
 		await umbConfirmModal(this, {
 			headline: this.localize.term('blockEditor_confirmDeleteBlockTitle', blockName),
-			content: html`${this.localize.htmlString('#blockEditor_confirmDeleteBlockMessage', blockName)}`,
+			content: this.localize.term('blockEditor_confirmDeleteBlockMessage', escapeHTML(blockName)),
 			confirmLabel: '#general_delete',
 			color: 'danger',
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -8,6 +8,7 @@ import type {
 } from '../types.js';
 import type { UmbBlockEntriesContext } from './block-entries.context.js';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+import { html } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbBooleanState,
 	UmbClassState,
@@ -787,7 +788,7 @@ export abstract class UmbBlockEntryContext<
 		const blockName = this.getName();
 		await umbConfirmModal(this, {
 			headline: this.localize.term('blockEditor_confirmDeleteBlockTitle', blockName),
-			content: this.localize.term('blockEditor_confirmDeleteBlockMessage', blockName),
+			content: html`${this.localize.htmlString('#blockEditor_confirmDeleteBlockMessage', blockName)}`,
 			confirmLabel: '#general_delete',
 			color: 'danger',
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/paste/paste-from-clipboard.property-action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/paste/paste-from-clipboard.property-action.ts
@@ -2,15 +2,17 @@ import { UmbClipboardEntryItemRepository } from '../../../clipboard-entry/index.
 import { UMB_CLIPBOARD_PROPERTY_CONTEXT } from '../../context/clipboard.property-context-token.js';
 import type { MetaPropertyActionPasteFromClipboardKind } from './types.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UmbPropertyActionBase, type UmbPropertyActionArgs } from '@umbraco-cms/backoffice/property-action';
-import { html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<MetaPropertyActionPasteFromClipboardKind> {
 	#init: Promise<unknown>;
 	#propertyContext?: typeof UMB_PROPERTY_CONTEXT.TYPE;
 	#clipboardContext?: typeof UMB_CLIPBOARD_PROPERTY_CONTEXT.TYPE;
+	readonly #localize = new UmbLocalizationController(this);
 
 	constructor(host: UmbControllerHost, args: UmbPropertyActionArgs<MetaPropertyActionPasteFromClipboardKind>) {
 		super(host, args);
@@ -71,12 +73,10 @@ export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<M
 
 			const item = data[0];
 
-			// Todo: localize
 			await umbConfirmModal(this, {
-				headline: 'Paste from clipboard',
-				content: html`The property already contains a value. Paste from the property action will overwrite the current value.
-				Do you want to replace the current value with ${item.name}?`,
-				confirmLabel: 'Paste',
+				headline: '#clipboard_confirmPasteHeadline',
+				content: this.#localize.term('clipboard_confirmPasteOverwriteMessage', escapeHTML(item.name ?? '')),
+				confirmLabel: '#defaultdialogs_paste',
 			});
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/paste/paste-from-clipboard.property-action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/paste/paste-from-clipboard.property-action.ts
@@ -5,6 +5,7 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UmbPropertyActionBase, type UmbPropertyActionArgs } from '@umbraco-cms/backoffice/property-action';
+import { html } from '@umbraco-cms/backoffice/external/lit';
 
 export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<MetaPropertyActionPasteFromClipboardKind> {
 	#init: Promise<unknown>;
@@ -73,7 +74,7 @@ export class UmbPasteFromClipboardPropertyAction extends UmbPropertyActionBase<M
 			// Todo: localize
 			await umbConfirmModal(this, {
 				headline: 'Paste from clipboard',
-				content: `The property already contains a value. Paste from the property action will overwrite the current value.
+				content: html`The property already contains a value. Paste from the property action will overwrite the current value.
 				Do you want to replace the current value with ${item.name}?`,
 				confirmLabel: 'Paste',
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker-input/picker-input.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker-input/picker-input.context.ts
@@ -1,4 +1,5 @@
 import { UMB_PICKER_INPUT_CONTEXT } from './picker-input.context-token.js';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbInteractionMemoryManager } from '@umbraco-cms/backoffice/interaction-memory';
@@ -16,7 +17,6 @@ import type { UmbItemModel } from '@umbraco-cms/backoffice/entity-item';
 import { UmbModalRouteRegistrationController, type UmbModalRouteSetupReturn } from '@umbraco-cms/backoffice/router';
 import { UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
-import { html } from '@umbraco-cms/backoffice/external/lit';
 
 export class UmbPickerInputContext<
 	PickedItemType extends UmbItemModel = UmbItemModel,
@@ -183,7 +183,7 @@ export class UmbPickerInputContext<
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: html`${this.localize.term('defaultdialogs_confirmremove')} ${this.localize.string(name)}?`,
+			content: this.localize.term('defaultdialogs_confirmRemoveItem', escapeHTML(name)),
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker-input/picker-input.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker-input/picker-input.context.ts
@@ -15,6 +15,8 @@ import {
 import type { UmbItemModel } from '@umbraco-cms/backoffice/entity-item';
 import { UmbModalRouteRegistrationController, type UmbModalRouteSetupReturn } from '@umbraco-cms/backoffice/router';
 import { UmbStringState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
+import { html } from '@umbraco-cms/backoffice/external/lit';
 
 export class UmbPickerInputContext<
 	PickedItemType extends UmbItemModel = UmbItemModel,
@@ -22,6 +24,8 @@ export class UmbPickerInputContext<
 	PickerModalConfigType extends UmbPickerModalData<PickerItemType> = UmbPickerModalData<PickerItemType>,
 	PickerModalValueType extends UmbPickerModalValue = UmbPickerModalValue,
 > extends UmbContextBase {
+	protected readonly localize = new UmbLocalizationController(this);
+
 	modalAlias?: string | UmbModalToken<UmbPickerModalData<PickerItemType>, PickerModalValueType>;
 	repository?: UmbItemRepository<PickedItemType>;
 
@@ -179,7 +183,7 @@ export class UmbPickerInputContext<
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: `#defaultdialogs_confirmremove ${name}?`,
+			content: html`${this.localize.term('defaultdialogs_confirmremove')} ${this.localize.string(name)}?`,
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -6,6 +6,7 @@ import type {
 	UmbLinkPickerModalValue,
 } from './link-picker-modal.token.js';
 import { css, customElement, html, nothing, query, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import {
 	umbBindToValidation,
 	UmbObserveValidationStateController,
@@ -394,7 +395,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: html`${this.localize.term('defaultdialogs_confirmremove')} ${name}?`,
+			content: this.localize.term('defaultdialogs_confirmRemoveItem', escapeHTML(name)),
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -394,7 +394,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: `#defaultdialogs_confirmremove ${name}?`,
+			content: html`${this.localize.term('defaultdialogs_confirmremove')} ${name}?`,
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
@@ -1,5 +1,6 @@
 import type { UmbInputCollectionContentTypePropertyElement } from './components/index.js';
 import { css, customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -88,7 +89,7 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: html`${this.localize.term('defaultdialogs_confirmremove')} ${column.header ?? ''}?`,
+			content: this.localize.term('defaultdialogs_confirmRemoveItem', escapeHTML(column.header ?? '')),
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
@@ -88,7 +88,7 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: `#defaultdialogs_confirmremove ${column.header ?? ''}?`,
+			content: html`${this.localize.term('defaultdialogs_confirmremove')} ${column.header ?? ''}?`,
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
@@ -97,7 +97,7 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: `#defaultdialogs_confirmremove ${layout.name ?? ''}?`,
+			content: html`${this.localize.term('defaultdialogs_confirmremove')} ${layout.name ?? ''}?`,
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
@@ -1,4 +1,5 @@
 import { css, customElement, html, ifDefined, property, when } from '@umbraco-cms/backoffice/external/lit';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { extractUmbColorVariable } from '@umbraco-cms/backoffice/resources';
 import { simpleHashCode } from '@umbraco-cms/backoffice/observable-api';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
@@ -97,7 +98,7 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: html`${this.localize.term('defaultdialogs_confirmremove')} ${layout.name ?? ''}?`,
+			content: this.localize.term('defaultdialogs_confirmRemoveItem', escapeHTML(layout.name ?? '')),
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/external-login/modals/external-login-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/external-login/modals/external-login-modal.element.ts
@@ -1,6 +1,7 @@
 import { UmbCurrentUserRepository } from '../../repository/index.js';
 import type { UmbCurrentUserExternalLoginProviderModel } from '../../types.js';
 import { css, customElement, html, nothing, property, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { umbConfirmModal, type UmbModalContext } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -163,7 +164,7 @@ export class UmbCurrentUserExternalLoginModalElement extends UmbLitElement {
 		try {
 			await umbConfirmModal(this, {
 				headline: this.localize.term('defaultdialogs_linkYour', providerDisplayName),
-				content: html`${this.localize.term('defaultdialogs_linkYourConfirm', providerDisplayName)}`,
+				content: this.localize.term('defaultdialogs_linkYourConfirm', escapeHTML(providerDisplayName)),
 				confirmLabel: '#general_continue',
 				color: 'positive',
 			});
@@ -193,7 +194,7 @@ export class UmbCurrentUserExternalLoginModalElement extends UmbLitElement {
 		try {
 			await umbConfirmModal(this, {
 				headline: this.localize.term('defaultdialogs_unLinkYour', providerDisplayName),
-				content: html`${this.localize.term('defaultdialogs_unLinkYourConfirm', providerDisplayName)}`,
+				content: this.localize.term('defaultdialogs_unLinkYourConfirm', escapeHTML(providerDisplayName)),
 				confirmLabel: '#general_continue',
 				color: 'danger',
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/external-login/modals/external-login-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/external-login/modals/external-login-modal.element.ts
@@ -163,7 +163,7 @@ export class UmbCurrentUserExternalLoginModalElement extends UmbLitElement {
 		try {
 			await umbConfirmModal(this, {
 				headline: this.localize.term('defaultdialogs_linkYour', providerDisplayName),
-				content: this.localize.term('defaultdialogs_linkYourConfirm', providerDisplayName),
+				content: html`${this.localize.term('defaultdialogs_linkYourConfirm', providerDisplayName)}`,
 				confirmLabel: '#general_continue',
 				color: 'positive',
 			});
@@ -193,7 +193,7 @@ export class UmbCurrentUserExternalLoginModalElement extends UmbLitElement {
 		try {
 			await umbConfirmModal(this, {
 				headline: this.localize.term('defaultdialogs_unLinkYour', providerDisplayName),
-				content: this.localize.term('defaultdialogs_unLinkYourConfirm', providerDisplayName),
+				content: html`${this.localize.term('defaultdialogs_unLinkYourConfirm', providerDisplayName)}`,
 				confirmLabel: '#general_continue',
 				color: 'danger',
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/modals/user-mfa/user-mfa-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/modals/user-mfa/user-mfa-modal.element.ts
@@ -2,6 +2,7 @@ import { UmbUserRepository } from '../../repository/index.js';
 import type { UmbUserMfaProviderModel } from '../../types.js';
 import type { UmbUserMfaModalConfiguration } from './user-mfa-modal.token.js';
 import { css, customElement, html, nothing, property, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { umbConfirmModal, type UmbModalContext } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -142,7 +143,7 @@ export class UmbUserMfaModalElement extends UmbLitElement {
 	async #onProviderDisable(item: UmbMfaLoginProviderOption) {
 		await umbConfirmModal(this, {
 			headline: '#actions_disable',
-			content: html`${this.localize.term('user_2faDisableForUser', item.displayName)}`,
+			content: this.localize.term('user_2faDisableForUser', escapeHTML(item.displayName)),
 			confirmLabel: '#actions_disable',
 			color: 'danger',
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/modals/user-mfa/user-mfa-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/modals/user-mfa/user-mfa-modal.element.ts
@@ -142,7 +142,7 @@ export class UmbUserMfaModalElement extends UmbLitElement {
 	async #onProviderDisable(item: UmbMfaLoginProviderOption) {
 		await umbConfirmModal(this, {
 			headline: '#actions_disable',
-			content: this.localize.term('user_2faDisableForUser', item.displayName),
+			content: html`${this.localize.term('user_2faDisableForUser', item.displayName)}`,
 			confirmLabel: '#actions_disable',
 			color: 'danger',
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-client-credentials/user-workspace-client-credentials.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-client-credentials/user-workspace-client-credentials.element.ts
@@ -10,6 +10,7 @@ import { html, customElement, state, css, nothing } from '@umbraco-cms/backoffic
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UMB_MODAL_MANAGER_CONTEXT, umbConfirmModal } from '@umbraco-cms/backoffice/modal';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-user-workspace-client-credentials')
 export class UmbUserWorkspaceClientCredentialsElement extends UmbLitElement {
@@ -94,7 +95,7 @@ export class UmbUserWorkspaceClientCredentialsElement extends UmbLitElement {
 
 		await umbConfirmModal(this, {
 			headline: `Delete ${client.unique}`,
-			content: html`Are you sure you want to delete ${client.unique}?`,
+			content: this.localize.term('defaultdialogs_confirmdelete', escapeHTML(client.unique)),
 			confirmLabel: 'Delete',
 			color: 'danger',
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-client-credentials/user-workspace-client-credentials.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-client-credentials/user-workspace-client-credentials.element.ts
@@ -94,7 +94,7 @@ export class UmbUserWorkspaceClientCredentialsElement extends UmbLitElement {
 
 		await umbConfirmModal(this, {
 			headline: `Delete ${client.unique}`,
-			content: `Are you sure you want to delete ${client.unique}?`,
+			content: html`Are you sure you want to delete ${client.unique}?`,
 			confirmLabel: 'Delete',
 			color: 'danger',
 		});


### PR DESCRIPTION
## Description

Noticed that a few of our confirmation dialogs (the ones you get when removing/deleting a block type, a picked item, a layout/column, etc.) could get a bit mangled if the item's name had certain special characters in it — things like `<`, `>`, or quotes could throw off the message or mess with the layout.

Tidied up how those dialogs build their message text so names render cleanly as plain text no matter what characters are in them. Also added a small lint rule to catch this pattern if it creeps back in, and localized a couple of dialogs that were still hardcoded in English along the way.

Nothing user-facing changes for normal names — this only affects names with unusual characters in them.

### How to test?

1. Create a Document Type (used as an Element Type) with a name that includes some special characters, e.g. `Test <b>Name</b> & "quotes"`.
2. Add it as a block type on a Block List or Block Grid data type.
3. Remove the block type from the configuration — the confirmation dialog should show the full name cleanly, no broken layout or missing text.
4. A few other spots worth spot-checking with a similarly "special" name:
   - Removing an item from a generic picker (e.g. media picker).
   - Removing a layout or column in a Collection view's data type config.
   - Pasting from the clipboard onto a property that already has a value.