### PR TITLE
Add entity created event & pass variant ids in the entity events

### DIFF
--- a/src/Umbraco.Web.UI.Client/docs/workspaces.md
+++ b/src/Umbraco.Web.UI.Client/docs/workspaces.md
@@ -263,7 +263,8 @@ Workspace contexts can use kinds for shared patterns:
    - If `isNew` → `_create(data, parent)` → `repository.create(data, parentUnique)`
    - If existing → `_update(data)` → `repository.save(data)`
 6. Updates persisted + current data from response
-7. Dispatches events: `UmbRequestReloadChildrenOfEntityEvent` (create), `UmbRequestReloadStructureForEntityEvent`, `UmbEntityUpdatedEvent` (update)
+7. Dispatches events: `UmbRequestReloadChildrenOfEntityEvent` + `UmbEntityCreatedEvent` (create), `UmbRequestReloadStructureForEntityEvent`, `UmbEntityUpdatedEvent` (update)
+   - For content workspaces (varying by culture/segment), `UmbEntityCreatedEvent`/`UmbEntityUpdatedEvent` carry the affected variants via `getVariantIds()`. Invariant entities report an empty array.
 8. If opened in modal → resolves modal value and closes
 
 ### Built-in action classes

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
@@ -3,6 +3,7 @@ import type { UmbContentTypeCompositionModel, UmbContentTypeDetailModel, UmbCont
 import type { UmbContentTypeWorkspaceContext } from './content-type-workspace-context.interface.js';
 import { UmbEntityDetailWorkspaceContextBase } from '@umbraco-cms/backoffice/workspace';
 import {
+	UmbEntityCreatedEvent,
 	UmbEntityUpdatedEvent,
 	UmbRequestReloadChildrenOfEntityEvent,
 	UmbRequestReloadStructureForEntityEvent,
@@ -186,6 +187,16 @@ export abstract class UmbContentTypeWorkspaceContextBase<
 				unique: parent.unique,
 			});
 			eventContext.dispatchEvent(event);
+
+			const unique = this.getUnique();
+			if (unique) {
+				const createdEvent = new UmbEntityCreatedEvent({
+					unique,
+					entityType: this.getEntityType(),
+					eventUnique: this._workspaceEventUnique,
+				});
+				eventContext.dispatchEvent(createdEvent);
+			}
 
 			this.setIsNew(false);
 		} catch (error) {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -28,6 +28,7 @@ import {
 } from '@umbraco-cms/backoffice/workspace';
 import type { UmbWorkspaceActionExecutionOptions } from '@umbraco-cms/backoffice/workspace';
 import {
+	UmbEntityCreatedEvent,
 	UmbEntityUpdatedEvent,
 	UmbRequestReloadChildrenOfEntityEvent,
 	UmbRequestReloadStructureForEntityEvent,
@@ -1092,10 +1093,24 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 		await this.#applyPersistedData(persisted, variantIds);
 		this.setIsNew(false);
 
-		await this.#dispatchActionEvents(
+		const events: Array<UmbEntityActionEvent> = [
 			new UmbRequestReloadStructureForEntityEvent({ entityType: parent.entityType, unique: parent.unique }),
 			new UmbRequestReloadChildrenOfEntityEvent({ entityType: parent.entityType, unique: parent.unique }),
-		);
+		];
+
+		const unique = this.getUnique();
+		if (unique) {
+			events.push(
+				new UmbEntityCreatedEvent({
+					unique,
+					entityType: this.getEntityType(),
+					eventUnique: this._workspaceEventUnique,
+					variantIds,
+				}),
+			);
+		}
+
+		await this.#dispatchActionEvents(...events);
 	}
 
 	async #update(
@@ -1116,7 +1131,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 		const entityType = this.getEntityType();
 		await this.#dispatchActionEvents(
 			new UmbRequestReloadStructureForEntityEvent({ unique, entityType }),
-			new UmbEntityUpdatedEvent({ unique, entityType, eventUnique: this._workspaceEventUnique }),
+			new UmbEntityUpdatedEvent({ unique, entityType, eventUnique: this._workspaceEventUnique, variantIds }),
 		);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/entity-created.event.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/entity-created.event.ts
@@ -1,0 +1,26 @@
+import type { UmbEntityActionEventArgs } from './entity-action.event.js';
+import { UmbEntityActionEvent } from './entity-action.event.js';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+
+export interface UmbEntityCreatedEventArgs extends UmbEntityActionEventArgs {
+	/**
+	 * The variants that were affected by the creation. Empty for entities that do not vary by culture or segment.
+	 */
+	variantIds?: Array<UmbVariantId>;
+}
+
+export class UmbEntityCreatedEvent extends UmbEntityActionEvent<UmbEntityCreatedEventArgs> {
+	static readonly TYPE = 'entity-created';
+
+	constructor(args: UmbEntityCreatedEventArgs) {
+		super(UmbEntityCreatedEvent.TYPE, args);
+	}
+
+	/**
+	 * Gets the variants that were affected by the creation.
+	 * @returns {Array<UmbVariantId>} The affected variants, or an empty array for invariant entities.
+	 */
+	getVariantIds(): Array<UmbVariantId> {
+		return this._args.variantIds ?? [];
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/entity-updated.event.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/entity-updated.event.ts
@@ -1,10 +1,26 @@
 import type { UmbEntityActionEventArgs } from './entity-action.event.js';
 import { UmbEntityActionEvent } from './entity-action.event.js';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
-export class UmbEntityUpdatedEvent extends UmbEntityActionEvent {
+export interface UmbEntityUpdatedEventArgs extends UmbEntityActionEventArgs {
+	/**
+	 * The variants that were affected by the update. Empty for entities that do not vary by culture or segment.
+	 */
+	variantIds?: Array<UmbVariantId>;
+}
+
+export class UmbEntityUpdatedEvent extends UmbEntityActionEvent<UmbEntityUpdatedEventArgs> {
 	static readonly TYPE = 'entity-updated';
 
-	constructor(args: UmbEntityActionEventArgs) {
+	constructor(args: UmbEntityUpdatedEventArgs) {
 		super(UmbEntityUpdatedEvent.TYPE, args);
+	}
+
+	/**
+	 * Gets the variants that were affected by the update.
+	 * @returns {Array<UmbVariantId>} The affected variants, or an empty array for invariant entities.
+	 */
+	getVariantIds(): Array<UmbVariantId> {
+		return this._args.variantIds ?? [];
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/index.ts
@@ -6,6 +6,7 @@ export * from './entity-action-base.js';
 export * from './entity-action-list.element.js';
 export * from './entity-action.event.js';
 export * from './has-children/index.js';
+export * from './entity-created.event.js';
 export * from './entity-updated.event.js';
 export * from './entity-deleted.event.js';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
@@ -9,6 +9,7 @@ import { UmbEntityContext, type UmbEntityModel, type UmbEntityUnique } from '@um
 import { UMB_DISCARD_CHANGES_MODAL, umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import {
+	UmbEntityCreatedEvent,
 	UmbEntityUpdatedEvent,
 	UmbRequestReloadChildrenOfEntityEvent,
 	UmbRequestReloadStructureForEntityEvent,
@@ -379,6 +380,14 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 		});
 
 		eventContext.dispatchEvent(reloadChildren);
+
+		const createdEvent = new UmbEntityCreatedEvent({
+			unique: data.unique,
+			entityType: this.getEntityType(),
+			eventUnique: this._workspaceEventUnique,
+		});
+
+		eventContext.dispatchEvent(createdEvent);
 	}
 
 	protected async _update(currentData: DetailModelType) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/context/document-workspace-crud.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/context/document-workspace-crud.context.test.ts
@@ -4,6 +4,8 @@ import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { useMockSet } from '@umbraco-cms/internal/mock-manager';
 import { UmbDocumentWorkspaceContext } from './document-workspace.context.js';
 import { TEST_MANIFESTS, UmbTestDocumentWorkspaceHostElement } from './document-workspace-context.test-utils.js';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbEntityCreatedEvent, UmbEntityUpdatedEvent } from '@umbraco-cms/backoffice/entity-action';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
 
 const INVARIANT_DOCUMENT_ID = 'variant-documents-invariant-document-id';
@@ -103,6 +105,43 @@ describe('UmbDocumentWorkspaceContext (CRUD)', () => {
 		});
 	});
 
+	describe('create dispatches entity-created event', () => {
+		it('dispatches an entity-created event for the new document on save', async () => {
+			await context.create(PARENT_ENTITY, INVARIANT_DOCUMENT_TYPE_ID);
+			context.setName('New Test Document');
+			const unique = context.getUnique();
+
+			const eventContext = await context.getContext(UMB_ACTION_EVENT_CONTEXT);
+			let createdEvent: UmbEntityCreatedEvent | undefined;
+			eventContext!.addEventListener(UmbEntityCreatedEvent.TYPE, ((event: UmbEntityCreatedEvent) => {
+				createdEvent = event;
+			}) as EventListener);
+
+			await context.requestSave();
+
+			expect(createdEvent, 'entity-created event was not dispatched').to.exist;
+			expect(createdEvent!.getUnique()).to.equal(unique);
+			expect(createdEvent!.getEntityType()).to.equal('document');
+			// Invariant document: the single invariant variant is reported.
+			expect(createdEvent!.getVariantIds().map((v) => v.culture)).to.deep.equal([null]);
+		});
+
+		it('does not dispatch an entity-updated event on create', async () => {
+			await context.create(PARENT_ENTITY, INVARIANT_DOCUMENT_TYPE_ID);
+			context.setName('New Test Document');
+
+			const eventContext = await context.getContext(UMB_ACTION_EVENT_CONTEXT);
+			let updatedDispatched = false;
+			eventContext!.addEventListener(UmbEntityUpdatedEvent.TYPE, (() => {
+				updatedDispatched = true;
+			}) as EventListener);
+
+			await context.requestSave();
+
+			expect(updatedDispatched).to.be.false;
+		});
+	});
+
 	describe('update (save existing document)', () => {
 		beforeEach(async () => {
 			await context.load(INVARIANT_DOCUMENT_ID);
@@ -172,6 +211,23 @@ describe('UmbDocumentWorkspaceContext (CRUD)', () => {
 			const newContext = new UmbDocumentWorkspaceContext(hostElement);
 			await newContext.load(VARIANT_DOCUMENT_ID);
 			expect(newContext.getPropertyValue('variantText', da)).to.equal('Dette er den danske varianttekst.');
+		});
+
+		it('reports the saved culture on the entity-updated event', async () => {
+			const enUs = UmbVariantId.Create({ culture: 'en-US', segment: null });
+			await context.setPropertyValue('variantText', 'Updated en-US by test', enUs);
+
+			const eventContext = await context.getContext(UMB_ACTION_EVENT_CONTEXT);
+			let updatedEvent: UmbEntityUpdatedEvent | undefined;
+			eventContext!.addEventListener(UmbEntityUpdatedEvent.TYPE, ((event: UmbEntityUpdatedEvent) => {
+				updatedEvent = event;
+			}) as EventListener);
+
+			await context.requestSave();
+
+			expect(updatedEvent, 'entity-updated event was not dispatched').to.exist;
+			expect(updatedEvent!.getVariantIds().some((v) => v.culture === 'en-US')).to.be.true;
+			expect(updatedEvent!.getVariantIds().some((v) => v.culture === 'da')).to.be.false;
 		});
 	});
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/22150
Also fixes https://github.com/umbraco/Umbraco-CMS/issues/22857

### Description
Two issues that I've encountered while creating packages for Umbraco:
- There is no create entity event. While there is an edit event, it doesn't get called when you create an entity
- You don't know which variants have been saved/published.

This PR tries to solve both issues. It introduces a create event (so this also shouldn't be breaking if people are expecting the update event in their packages) and it adds a new property for the variantIds.

### How to test

Add the following files to an examples folder:

entity-events-demo.controller.ts
```
import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
import { UmbEntityCreatedEvent, UmbEntityUpdatedEvent } from '@umbraco-cms/backoffice/entity-action';
import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';

/**
 * Listens on the global action event context and reports whenever an entity is created or updated,
 * demonstrating {@link UmbEntityCreatedEvent} and the variant information now carried by both events.
 */
export class UmbEntityEventsDemoController extends UmbControllerBase {
	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;

	constructor(host: UmbControllerHost) {
		super(host);

		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (context) => {
			this.#notificationContext = context;
		});

		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (context) => {
			this.#removeListeners();
			this.#actionEventContext = context;
			this.#addListeners();
		});
	}

	#addListeners() {
		this.#actionEventContext?.addEventListener(UmbEntityCreatedEvent.TYPE, this.#onCreated as EventListener);
		this.#actionEventContext?.addEventListener(UmbEntityUpdatedEvent.TYPE, this.#onUpdated as EventListener);
	}

	#removeListeners() {
		this.#actionEventContext?.removeEventListener(UmbEntityCreatedEvent.TYPE, this.#onCreated as EventListener);
		this.#actionEventContext?.removeEventListener(UmbEntityUpdatedEvent.TYPE, this.#onUpdated as EventListener);
	}

	#onCreated = (event: UmbEntityCreatedEvent) => this.#report('created', event);
	#onUpdated = (event: UmbEntityUpdatedEvent) => this.#report('updated', event);

	#report(kind: 'created' | 'updated', event: UmbEntityCreatedEvent | UmbEntityUpdatedEvent) {
		const entityType = event.getEntityType();
		const unique = event.getUnique();
		const variants = event.getVariantIds().map((variantId) => variantId.culture ?? 'invariant');

		console.log(`[entity-events-demo] entity ${kind}`, { entityType, unique, variants, event });

		const variantText = variants.length ? ` — variants: ${variants.join(', ')}` : '';
		this.#notificationContext?.peek('positive', {
			data: {
				headline: `Entity ${kind}`,
				message: `${entityType} (${unique})${variantText}`,
			},
		});
	}

	override destroy(): void {
		this.#removeListeners();
		super.destroy();
	}
}
```

entry-point.ts
```
import { UmbEntityEventsDemoController } from './entity-events-demo.controller.js';
import type { UmbEntryPointOnInit, UmbEntryPointOnUnload } from '@umbraco-cms/backoffice/extension-api';

let controller: UmbEntityEventsDemoController | undefined;

export const onInit: UmbEntryPointOnInit = (host) => {
	controller = new UmbEntityEventsDemoController(host);
};

export const onUnload: UmbEntryPointOnUnload = () => {
	controller?.destroy();
	controller = undefined;
};
```

index.ts
```
export const manifests: Array<UmbExtensionManifest> = [
	{
		type: 'backofficeEntryPoint',
		alias: 'example.entityEvents.entryPoint',
		name: 'Example Entity Events Entry Point',
		js: () => import('./entry-point.js'),
	},
];
```

Run the example and see toasts appear regarding the events whenever you save/create an entity.


<!-- Thanks for contributing to Umbraco CMS! -->
