### PR TITLE
Publishing: Save the document before publishing it with descendants (closes #14925)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
@@ -319,6 +319,8 @@ export default {
 		createFromClipboard: 'Zalijepi iz međuspremnika',
 		nodeIsInTrash: 'Ova stavka je u korpi za otpatke',
 		saveModalTitle: 'Spremi',
+		saveAndPublishDescendantsModalTitle: 'Spremi i objavi sa potomcima',
+		saveAndScheduleModalTitle: 'Spremi i zakaži objavljivanje',
 	},
 	blueprints: {
 		createBlueprintFrom: 'Kreirajte novi predložak sadržaja iz <em>%0%</em>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cs.ts
@@ -301,6 +301,8 @@ export default {
 		createFromClipboard: 'Paste from clipboard',
 		nodeIsInTrash: 'This item is in the Recycle Bin',
 		saveModalTitle: 'Uložit',
+		saveAndPublishDescendantsModalTitle: 'Uložit a publikovat s potomky',
+		saveAndScheduleModalTitle: 'Uložit a naplánovat publikování',
 	},
 	blueprints: {
 		createBlueprintFrom: 'Vytvořit novou šablonu obsahu z <em>%0%</em>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -356,6 +356,8 @@ export default {
 		variantUnpublishNotAllowed: 'Unpublish is not allowed',
 		saveModalTitle: 'Gem',
 		saveAndPublishModalTitle: 'Gem og udgiv',
+		saveAndPublishDescendantsModalTitle: 'Gem og udgiv med undersider',
+		saveAndScheduleModalTitle: 'Gem og planlæg udgivelse',
 		publishModalTitle: 'Udgiv',
 		selectAllVariants: 'Vælg alle varianter',
 		scheduledPendingChanges: 'Denne tidsplan har ændringer, der træder i kraft, når du klikker på "%0%".',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
@@ -338,6 +338,8 @@ export default {
 		variantScheduleNotAllowed: 'Plannung ist nicht erlaubt',
 		variantUnpublishNotAllowed: 'Veröffentlichung zurücknehmen ist nicht erlaubt.',
 		saveModalTitle: 'Speichern',
+		saveAndPublishDescendantsModalTitle: 'Speichern und veröffentlichen mit Unterknoten',
+		saveAndScheduleModalTitle: 'Speichern und Veröffentlichung planen',
 	},
 	blueprints: {
 		createBlueprintFrom: 'Erzeuge eine neue Inhaltsvorlage von <em>%0%</em>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -288,9 +288,9 @@ export default {
 		publishedPendingChanges: 'Published (pending changes)',
 		publishStatus: 'Publication Status',
 		publishDescendantsHelp:
-			'Publish <strong>%0%</strong> and all items underneath and thereby making their content publicly available.',
+			'Save and publish <strong>%0%</strong> and publish all items underneath thereby making their content publicly available.',
 		publishDescendantsWithVariantsHelp:
-			'Publish variants and variants of same type underneath and thereby making their content publicly available.',
+			'Save and publish variants and publish variants of same type underneath thereby making their content publicly available.',
 		noVariantsToProcess: 'There are no available variants',
 		releaseDate: 'Publish at',
 		unpublishDate: 'Unpublish at',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -368,6 +368,8 @@ export default {
 		selectAllVariants: 'Select all variants',
 		saveModalTitle: 'Save',
 		saveAndPublishModalTitle: 'Save and publish',
+		saveAndPublishDescendantsModalTitle: 'Save and publish with descendants',
+		saveAndScheduleModalTitle: 'Save and schedule publishing',
 		publishModalTitle: 'Publish',
 		openSplitViewForVariant: (variant: string) => `Open ${variant} in split view`,
 		sharedAcrossCultures: 'Shared across cultures',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
@@ -298,6 +298,8 @@ export default {
 		createEmpty: 'Créer nouveau',
 		createFromClipboard: 'Copier du clipboard',
 		saveModalTitle: 'Sauver',
+		saveAndPublishDescendantsModalTitle: 'Sauver et publier avec les descendants',
+		saveAndScheduleModalTitle: 'Sauver et planifier la publication',
 	},
 	blueprints: {
 		createBlueprintFrom: 'Créer un nouveau Modèle de Contenu à partir de <em>%0%</em>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/hr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/hr.ts
@@ -320,6 +320,8 @@ export default {
 		createFromClipboard: 'Zalijepi iz međuspremnika',
 		nodeIsInTrash: 'Ova stavka je u košu za smeće',
 		saveModalTitle: 'Spremi',
+		saveAndPublishDescendantsModalTitle: 'Spremi i objavi sa potomcima',
+		saveAndScheduleModalTitle: 'Spremi i zakaži objavu',
 	},
 	blueprints: {
 		createBlueprintFrom: 'Kreirajte novi predložak sadržaja iz <em>%0%</em>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
@@ -332,6 +332,8 @@ export default {
 		createFromClipboard: 'Incolla dagli appunti',
 		nodeIsInTrash: 'Questo articolo è nel cestino',
 		saveModalTitle: 'Salva',
+		saveAndPublishDescendantsModalTitle: 'Salva e pubblica con discendenti',
+		saveAndScheduleModalTitle: 'Salva e pianifica la pubblicazione',
 	},
 	blueprints: {
 		createBlueprintFrom: "Crea un nuovo modello di contenuto da '%0%'",

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
@@ -227,6 +227,8 @@ export default {
 		routeError: 'Dette dokumentet er publisert, men URL-en kolliderer med innhold %0%',
 		routeErrorCannotRoute: 'Dette dokumentet er publisert, men URL-en kan ikke rutes',
 		saveModalTitle: 'Lagre',
+		saveAndPublishDescendantsModalTitle: 'Lagre og publiser med undersider',
+		saveAndScheduleModalTitle: 'Lagre og planlegg publisering',
 		schedulePublishHelp: 'Velg dato og tid for å publisere og/eller avpublisere innholdselementet.',
 		scheduledPublishDocumentation:
 			'<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">Hva betyr dette?</a>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
@@ -320,6 +320,8 @@ export default {
 		createFromClipboard: 'Plakken vanaf het klembord',
 		nodeIsInTrash: 'Dit item is in de prullenbak',
 		saveModalTitle: 'Opslaan',
+		saveAndPublishDescendantsModalTitle: 'Opslaan en publiceren met onderliggende nodes',
+		saveAndScheduleModalTitle: 'Opslaan en publicatie plannen',
 	},
 	blueprints: {
 		createBlueprintFrom: 'Nieuw Inhoudssjabloon aanmaken voor <em>%0%</em>',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
@@ -351,6 +351,8 @@ export default {
 		selectAllVariants: 'Selecionar todas as variantes',
 		saveModalTitle: 'Guardar',
 		saveAndPublishModalTitle: 'Guardar e publicar',
+		saveAndPublishDescendantsModalTitle: 'Guardar e publicar com descendentes',
+		saveAndScheduleModalTitle: 'Guardar e agendar publicação',
 		publishModalTitle: 'Publicar',
 	},
 	blueprints: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/sv.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/sv.ts
@@ -237,6 +237,8 @@ export default {
 		noChanges: 'Inga ändringar har gjorts',
 		notCreated: 'Ej skapad',
 		saveModalTitle: 'Spara',
+		saveAndPublishDescendantsModalTitle: 'Spara och publicera med undersidor',
+		saveAndScheduleModalTitle: 'Spara och schemalägg publicering',
 	},
 	contentTypeEditor: {
 		yesDelete: 'Ja, ta bort',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
@@ -354,6 +354,8 @@ export default {
 		selectAllVariants: 'Chọn tất cả các biến thể',
 		saveModalTitle: 'Lưu',
 		saveAndPublishModalTitle: 'Lưu và xuất bản',
+		saveAndPublishDescendantsModalTitle: 'Lưu và xuất bản cùng với các phần tử con',
+		saveAndScheduleModalTitle: 'Lưu và lên lịch xuất bản',
 		publishModalTitle: 'Xuất bản',
 	},
 	blueprints: {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
@@ -97,7 +97,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 	}
 
 	override render() {
-		return html`<uui-dialog-layout headline=${this.localize.term('buttons_publishDescendants')}>
+		return html`<uui-dialog-layout headline=${this.localize.term('content_saveAndPublishDescendantsModalTitle')}>
 			<p id="subtitle">
 				${this._options.length === 1
 					? html`<umb-localize

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -160,7 +160,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 	}
 
 	override render() {
-		return html`<uui-dialog-layout headline=${this.localize.term('general_scheduledPublishing')}>
+		return html`<uui-dialog-layout headline=${this.localize.term('content_saveAndScheduleModalTitle')}>
 			${this.#renderOptions()}
 
 			<div slot="actions">

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
@@ -59,6 +59,23 @@ async function countPublishWithDescendantsCalls(run: () => Promise<unknown>): Pr
 	return calls;
 }
 
+/**
+ * Makes the publish-with-descendants endpoint fail while `run` executes, leaving the preceding save
+ * to succeed — the split Andy Butland reproduced by returning BadRequest from the controller.
+ */
+async function withFailingPublish(run: () => Promise<unknown>): Promise<void> {
+	const originalPublish = UmbDocumentPublishingServerDataSource.prototype.publishWithDescendants;
+	UmbDocumentPublishingServerDataSource.prototype.publishWithDescendants = async () => ({
+		error: new Error('Simulated publish failure'),
+	});
+
+	try {
+		await run();
+	} finally {
+		UmbDocumentPublishingServerDataSource.prototype.publishWithDescendants = originalPublish;
+	}
+}
+
 describe('UmbDocumentPublishingWorkspaceContext', function () {
 	// The publish-with-descendants mock polls once with a one second delay before completing.
 	this.timeout(10000);
@@ -132,6 +149,29 @@ describe('UmbDocumentPublishingWorkspaceContext', function () {
 				context.getChangedVariants().some((v) => v.culture === 'da'),
 				'da is still reported as changed',
 			).to.be.true;
+		});
+
+		// The save and the publish are separate calls, so a failing publish must still leave the
+		// document saved and the workspace clean rather than dirty against a stale snapshot. (#14925)
+		it('leaves the document saved when only the publish fails', async () => {
+			await context.setName('Renamed root', EN_US);
+
+			let rejected = false;
+			await withFailingPublish(() =>
+				publishingContext.publishWithDescendants().then(
+					() => undefined,
+					() => {
+						rejected = true;
+					},
+				),
+			);
+
+			expect(rejected, 'the action reports failure').to.be.true;
+			expect(context.getHasUnpersistedChanges(), 'workspace is not left dirty').to.be.false;
+
+			const freshContext = new UmbDocumentWorkspaceContext(hostElement);
+			await freshContext.load(VARIANT_DOCUMENT_ID);
+			expect(freshContext.getName(EN_US), 'the save survived the failed publish').to.equal('Renamed root');
 		});
 
 		// Saving first means the save's mandatory validation now gates the whole operation.

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
@@ -9,6 +9,7 @@ import {
 	UmbTestDocumentWorkspaceHostElement,
 } from '../../workspace/context/document-workspace-context.test-utils.js';
 import { UMB_DISCARD_CHANGES_MODAL, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
+import { UmbDocumentPublishingServerDataSource } from '../repository/document-publishing.server.data-source.js';
 
 const VARIANT_DOCUMENT_ID = 'variant-documents-variant-document-id';
 const EN_US = UmbVariantId.Create({ culture: 'en-US', segment: null });
@@ -37,6 +38,26 @@ async function recordOpenedModals(run: () => Promise<unknown>): Promise<Array<st
 	}
 
 	return aliases;
+}
+
+/**
+ * Counts calls to the publish-with-descendants endpoint while `run` executes.
+ */
+async function countPublishWithDescendantsCalls(run: () => Promise<unknown>): Promise<number> {
+	let calls = 0;
+	const originalPublish = UmbDocumentPublishingServerDataSource.prototype.publishWithDescendants;
+	UmbDocumentPublishingServerDataSource.prototype.publishWithDescendants = function (...args) {
+		calls++;
+		return originalPublish.apply(this, args as never);
+	};
+
+	try {
+		await run();
+	} finally {
+		UmbDocumentPublishingServerDataSource.prototype.publishWithDescendants = originalPublish;
+	}
+
+	return calls;
 }
 
 describe('UmbDocumentPublishingWorkspaceContext', () => {
@@ -92,6 +113,20 @@ describe('UmbDocumentPublishingWorkspaceContext', () => {
 			await publishingContext.publishWithDescendants();
 
 			expect(context.getName(EN_US)).to.equal('Renamed root');
+		});
+
+		// Saving first means the save's mandatory validation now gates the whole operation.
+		it('publishes nothing when the document fails mandatory validation', async () => {
+			await context.setName('', EN_US);
+
+			const publishCalls = await countPublishWithDescendantsCalls(() =>
+				publishingContext.publishWithDescendants().then(
+					() => undefined,
+					() => undefined,
+				),
+			);
+
+			expect(publishCalls, 'descendants were not published').to.equal(0);
 		});
 	});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
@@ -8,11 +8,38 @@ import {
 	TEST_MANIFESTS,
 	UmbTestDocumentWorkspaceHostElement,
 } from '../../workspace/context/document-workspace-context.test-utils.js';
+import { UMB_DISCARD_CHANGES_MODAL, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 
 const VARIANT_DOCUMENT_ID = 'variant-documents-variant-document-id';
 const EN_US = UmbVariantId.Create({ culture: 'en-US', segment: null });
 
-describe('UmbDocumentPublishingWorkspaceContext (publish with descendants)', () => {
+/**
+ * Records the aliases of every modal opened while `run` executes. The test host auto-submits modals,
+ * so what a flow asks for is observable, but the user's answer is not. Failures are swallowed: the
+ * unpublish entity action needs contexts the test host does not provide, and it runs after the point
+ * these tests are about.
+ */
+async function recordOpenedModals(run: () => Promise<unknown>): Promise<Array<string>> {
+	const aliases: Array<string> = [];
+	const originalOpen = UmbModalManagerContext.prototype.open;
+	UmbModalManagerContext.prototype.open = function (
+		this: UmbModalManagerContext,
+		...args: Parameters<typeof originalOpen>
+	) {
+		aliases.push(String(args[1]));
+		return originalOpen.apply(this, args as never);
+	} as typeof originalOpen;
+
+	try {
+		await run().catch(() => undefined);
+	} finally {
+		UmbModalManagerContext.prototype.open = originalOpen;
+	}
+
+	return aliases;
+}
+
+describe('UmbDocumentPublishingWorkspaceContext', () => {
 	let hostElement: UmbTestDocumentWorkspaceHostElement;
 	let context: UmbDocumentWorkspaceContext;
 	let publishingContext: UmbDocumentPublishingWorkspaceContext;
@@ -42,25 +69,46 @@ describe('UmbDocumentPublishingWorkspaceContext (publish with descendants)', () 
 		document.body.innerHTML = '';
 	});
 
-	// The action used to publish descendants without saving the document it was invoked from, so any
-	// edit made in the workspace was silently discarded by the reload that follows. (#14925)
-	it('saves the document it is invoked from', async () => {
-		await context.setName('Renamed root', EN_US);
-		await context.setPropertyValue('variantText', 'Edited English', EN_US);
+	describe('publish with descendants', () => {
+		// The action used to publish descendants without saving the document it was invoked from, so any
+		// edit made in the workspace was silently discarded by the reload that follows. (#14925)
+		it('saves the document it is invoked from', async () => {
+			await context.setName('Renamed root', EN_US);
+			await context.setPropertyValue('variantText', 'Edited English', EN_US);
 
-		await publishingContext.publishWithDescendants();
+			await publishingContext.publishWithDescendants();
 
-		const freshContext = new UmbDocumentWorkspaceContext(hostElement);
-		await freshContext.load(VARIANT_DOCUMENT_ID);
-		expect(freshContext.getName(EN_US), 'name saved on server').to.equal('Renamed root');
-		expect(freshContext.getPropertyValue('variantText', EN_US), 'property saved on server').to.equal('Edited English');
+			const freshContext = new UmbDocumentWorkspaceContext(hostElement);
+			await freshContext.load(VARIANT_DOCUMENT_ID);
+			expect(freshContext.getName(EN_US), 'name saved on server').to.equal('Renamed root');
+			expect(freshContext.getPropertyValue('variantText', EN_US), 'property saved on server').to.equal(
+				'Edited English',
+			);
+		});
+
+		it('keeps the edit in the workspace after the reload that follows', async () => {
+			await context.setName('Renamed root', EN_US);
+
+			await publishingContext.publishWithDescendants();
+
+			expect(context.getName(EN_US)).to.equal('Renamed root');
+		});
 	});
 
-	it('keeps the edit in the workspace after the reload that follows', async () => {
-		await context.setName('Renamed root', EN_US);
+	describe('unpublish', () => {
+		// Unpublishing reloads the workspace, which throws away unsaved edits, so the user gets a say.
+		it('asks to discard unsaved changes', async () => {
+			await context.setName('Renamed root', EN_US);
 
-		await publishingContext.publishWithDescendants();
+			const opened = await recordOpenedModals(() => publishingContext.unpublish());
 
-		expect(context.getName(EN_US)).to.equal('Renamed root');
+			expect(opened).to.include(UMB_DISCARD_CHANGES_MODAL.toString());
+		});
+
+		it('does not ask when there is nothing to discard', async () => {
+			const opened = await recordOpenedModals(() => publishingContext.unpublish());
+
+			expect(opened).to.not.include(UMB_DISCARD_CHANGES_MODAL.toString());
+		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
@@ -10,34 +10,33 @@ import {
 } from '../../workspace/context/document-workspace-context.test-utils.js';
 import { UMB_DISCARD_CHANGES_MODAL, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import { UmbDocumentPublishingServerDataSource } from '../repository/document-publishing.server.data-source.js';
+import { UmbContentUnpublishEntityAction } from '@umbraco-cms/backoffice/content';
 
 const VARIANT_DOCUMENT_ID = 'variant-documents-variant-document-id';
 const EN_US = UmbVariantId.Create({ culture: 'en-US', segment: null });
+const DA = UmbVariantId.Create({ culture: 'da', segment: null });
 
 /**
- * Records the aliases of every modal opened while `run` executes. The test host auto-submits modals,
- * so what a flow asks for is observable, but the user's answer is not. Failures are swallowed: the
- * unpublish entity action needs contexts the test host does not provide, and it runs after the point
- * these tests are about.
+ * Forces the value every modal is submitted with while `run` executes. The test host's modal manager
+ * submits with whatever value the context holds when `open` returns, so setting it here decides the
+ * answer — which the auto-submitting mock alone cannot express.
  */
-async function recordOpenedModals(run: () => Promise<unknown>): Promise<Array<string>> {
-	const aliases: Array<string> = [];
+async function answerModalsWith(value: unknown, run: () => Promise<unknown>): Promise<void> {
 	const originalOpen = UmbModalManagerContext.prototype.open;
 	UmbModalManagerContext.prototype.open = function (
 		this: UmbModalManagerContext,
 		...args: Parameters<typeof originalOpen>
 	) {
-		aliases.push(String(args[1]));
-		return originalOpen.apply(this, args as never);
+		const modalContext = originalOpen.apply(this, args as never);
+		modalContext.setValue(value as never);
+		return modalContext;
 	} as typeof originalOpen;
 
 	try {
-		await run().catch(() => undefined);
+		await run();
 	} finally {
 		UmbModalManagerContext.prototype.open = originalOpen;
 	}
-
-	return aliases;
 }
 
 /**
@@ -60,7 +59,10 @@ async function countPublishWithDescendantsCalls(run: () => Promise<unknown>): Pr
 	return calls;
 }
 
-describe('UmbDocumentPublishingWorkspaceContext', () => {
+describe('UmbDocumentPublishingWorkspaceContext', function () {
+	// The publish-with-descendants mock polls once with a one second delay before completing.
+	this.timeout(10000);
+
 	let hostElement: UmbTestDocumentWorkspaceHostElement;
 	let context: UmbDocumentWorkspaceContext;
 	let publishingContext: UmbDocumentPublishingWorkspaceContext;
@@ -115,6 +117,23 @@ describe('UmbDocumentPublishingWorkspaceContext', () => {
 			expect(context.getName(EN_US)).to.equal('Renamed root');
 		});
 
+		// Saving merges the server response into the published variants only, so an edit in a variant that
+		// was not selected must survive rather than be replaced by a wholesale reload.
+		it('keeps edits in variants that were not published', async () => {
+			await context.setPropertyValue('variantText', 'Edited English', EN_US);
+			await context.setPropertyValue('variantText', 'Redigeret dansk', DA);
+
+			await answerModalsWith({ selection: [EN_US.toString()], includeUnpublishedDescendants: false }, () =>
+				publishingContext.publishWithDescendants(),
+			);
+
+			expect(context.getPropertyValue('variantText', DA), 'da edit still in the editor').to.equal('Redigeret dansk');
+			expect(
+				context.getChangedVariants().some((v) => v.culture === 'da'),
+				'da is still reported as changed',
+			).to.be.true;
+		});
+
 		// Saving first means the save's mandatory validation now gates the whole operation.
 		it('publishes nothing when the document fails mandatory validation', async () => {
 			await context.setName('', EN_US);
@@ -131,19 +150,68 @@ describe('UmbDocumentPublishingWorkspaceContext', () => {
 	});
 
 	describe('unpublish', () => {
+		/**
+		 * Stubs out the unpublish entity action — it needs contexts the test host does not provide — so
+		 * whether the flow got past the guard is observable, and optionally answers every modal with cancel.
+		 */
+		async function runUnpublish(options: { cancelModals?: boolean } = {}) {
+			const modals: Array<string> = [];
+			let reachedUnpublish = false;
+
+			const originalOpen = UmbModalManagerContext.prototype.open;
+			UmbModalManagerContext.prototype.open = function (
+				this: UmbModalManagerContext,
+				...args: Parameters<typeof originalOpen>
+			) {
+				modals.push(String(args[1]));
+				const modalContext = originalOpen.apply(this, args as never);
+				if (options.cancelModals) {
+					modalContext.reject();
+				}
+				return modalContext;
+			} as typeof originalOpen;
+
+			const originalExecute = UmbContentUnpublishEntityAction.prototype.executeWithResult;
+			UmbContentUnpublishEntityAction.prototype.executeWithResult = async function () {
+				reachedUnpublish = true;
+				return false;
+			};
+
+			try {
+				await publishingContext.unpublish();
+			} finally {
+				UmbModalManagerContext.prototype.open = originalOpen;
+				UmbContentUnpublishEntityAction.prototype.executeWithResult = originalExecute;
+			}
+
+			return { modals, reachedUnpublish };
+		}
+
 		// Unpublishing reloads the workspace, which throws away unsaved edits, so the user gets a say.
-		it('asks to discard unsaved changes', async () => {
+		it('asks to discard unsaved changes, and unpublishes once discarded', async () => {
 			await context.setName('Renamed root', EN_US);
 
-			const opened = await recordOpenedModals(() => publishingContext.unpublish());
+			const { modals, reachedUnpublish } = await runUnpublish();
 
-			expect(opened).to.include(UMB_DISCARD_CHANGES_MODAL.toString());
+			expect(modals, 'asked to discard').to.include(UMB_DISCARD_CHANGES_MODAL.toString());
+			expect(reachedUnpublish, 'went on to unpublish').to.be.true;
+		});
+
+		it('does not unpublish when the discard is cancelled', async () => {
+			await context.setName('Renamed root', EN_US);
+
+			const { modals, reachedUnpublish } = await runUnpublish({ cancelModals: true });
+
+			expect(modals, 'asked to discard').to.include(UMB_DISCARD_CHANGES_MODAL.toString());
+			expect(reachedUnpublish, 'stopped before unpublishing').to.be.false;
+			expect(context.getName(EN_US), 'the edit is untouched').to.equal('Renamed root');
 		});
 
 		it('does not ask when there is nothing to discard', async () => {
-			const opened = await recordOpenedModals(() => publishingContext.unpublish());
+			const { modals, reachedUnpublish } = await runUnpublish();
 
-			expect(opened).to.not.include(UMB_DISCARD_CHANGES_MODAL.toString());
+			expect(modals, 'no discard prompt').to.not.include(UMB_DISCARD_CHANGES_MODAL.toString());
+			expect(reachedUnpublish, 'went straight to unpublishing').to.be.true;
 		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.test.ts
@@ -1,0 +1,66 @@
+import { aTimeout, expect } from '@open-wc/testing';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import { useMockSet } from '@umbraco-cms/internal/mock-manager';
+import { UmbDocumentPublishingWorkspaceContext } from './document-publishing.workspace-context.js';
+import { UmbDocumentWorkspaceContext } from '../../workspace/context/document-workspace.context.js';
+import {
+	TEST_MANIFESTS,
+	UmbTestDocumentWorkspaceHostElement,
+} from '../../workspace/context/document-workspace-context.test-utils.js';
+
+const VARIANT_DOCUMENT_ID = 'variant-documents-variant-document-id';
+const EN_US = UmbVariantId.Create({ culture: 'en-US', segment: null });
+
+describe('UmbDocumentPublishingWorkspaceContext (publish with descendants)', () => {
+	let hostElement: UmbTestDocumentWorkspaceHostElement;
+	let context: UmbDocumentWorkspaceContext;
+	let publishingContext: UmbDocumentPublishingWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.registerMany(TEST_MANIFESTS);
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregisterMany(TEST_MANIFESTS.map((m) => m.alias));
+	});
+
+	beforeEach(async () => {
+		await useMockSet('documents');
+		hostElement = new UmbTestDocumentWorkspaceHostElement();
+		document.body.appendChild(hostElement);
+		await hostElement.init();
+		context = new UmbDocumentWorkspaceContext(hostElement);
+		// The workspace element hosts additional workspace contexts on the workspace API itself, so that
+		// contexts sharing a context alias resolve against each other correctly. (see UmbWorkspaceElement)
+		publishingContext = new UmbDocumentPublishingWorkspaceContext(context);
+		await context.load(VARIANT_DOCUMENT_ID);
+		await aTimeout(0);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	// The action used to publish descendants without saving the document it was invoked from, so any
+	// edit made in the workspace was silently discarded by the reload that follows. (#14925)
+	it('saves the document it is invoked from', async () => {
+		await context.setName('Renamed root', EN_US);
+		await context.setPropertyValue('variantText', 'Edited English', EN_US);
+
+		await publishingContext.publishWithDescendants();
+
+		const freshContext = new UmbDocumentWorkspaceContext(hostElement);
+		await freshContext.load(VARIANT_DOCUMENT_ID);
+		expect(freshContext.getName(EN_US), 'name saved on server').to.equal('Renamed root');
+		expect(freshContext.getPropertyValue('variantText', EN_US), 'property saved on server').to.equal('Edited English');
+	});
+
+	it('keeps the edit in the workspace after the reload that follows', async () => {
+		await context.setName('Renamed root', EN_US);
+
+		await publishingContext.publishWithDescendants();
+
+		expect(context.getName(EN_US)).to.equal('Renamed root');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -295,21 +295,25 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 					},
 				});
 
-				let error;
 				try {
 					// Save the document before publishing it and its descendants
 					await this.#documentWorkspaceContext.performCreateOrUpdate(variantIds, saveData);
 
-					({ error } = await this.#publishingRepository.publishWithDescendants(
+					const { error } = await this.#publishingRepository.publishWithDescendants(
 						unique,
 						variantIds,
 						result.includeUnpublishedDescendants ?? false,
-					));
+					);
+					if (error) throw error;
+				} catch (error) {
+					// The save may have succeeded, so the operation must not resolve as if it published. [JOV]
+					this.#notificationContext?.peek('danger', {
+						data: { message: this.#localize.term('speechBubbles_editContentPublishedFailed') },
+					});
+					return Promise.reject(error);
 				} finally {
 					waitNotice?.close();
 				}
-
-				if (error) return;
 
 				this.#notificationContext?.peek('positive', {
 					data: {
@@ -347,7 +351,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 	}
 
 	/**
-	 * Unpublish the document
+	 * Unpublish the document, asking to discard any unsaved changes first
 	 * @returns {Promise<void>}
 	 * @memberof UmbDocumentPublishingWorkspaceContext
 	 */

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -295,7 +295,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		} catch (error) {
 			// This throws before the submit flow starts, so nothing downstream tells the user why. [JOV]
 			this.#notify('danger', 'speechBubbles_editContentPublishedFailedByValidation');
-			return Promise.reject(error);
+			throw error;
 		}
 
 		await workspaceContext.askServerToValidate(saveData, variantIds);
@@ -332,7 +332,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		} catch (error) {
 			// The save may have succeeded, so the operation must not resolve as if it published. [JOV]
 			this.#notify('danger', 'speechBubbles_editContentPublishedFailed');
-			return Promise.reject(error);
+			throw error;
 		} finally {
 			waitNotice?.close();
 		}
@@ -413,7 +413,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		await this.#documentWorkspaceContext.performCreateOrUpdate(variantIds, saveData);
 		// TODO: Get rid of the save notification.
 		this.#notify('danger', 'speechBubbles_editContentPublishedFailedByValidation');
-		return Promise.reject(reason);
+		throw reason;
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -5,7 +5,6 @@ import type {
 	UmbDocumentVariantPublishModel,
 } from '../../types.js';
 import { UmbDocumentPublishingRepository } from '../repository/index.js';
-import { UmbDocumentDetailRepository } from '../../repository/index.js';
 import { UmbDocumentPublishedPendingChangesManager } from '../pending-changes/index.js';
 import { UMB_DOCUMENT_SCHEDULE_MODAL } from '../schedule-publish/constants.js';
 import { UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL } from '../publish-with-descendants/constants.js';
@@ -56,7 +55,6 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 	#documentWorkspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
 	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 	#publishingRepository = new UmbDocumentPublishingRepository(this);
-	#detailRepository = new UmbDocumentDetailRepository(this);
 	#publishedDocumentData?: UmbDocumentDetailModel;
 	#loadingPublishedData = false;
 	#currentUnique?: UmbEntityUnique;
@@ -328,11 +326,9 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		let readBackFailed: boolean;
 		try {
+			// Each failure path notifies at the point it happens, so that a publish failure after a
+			// successful save does not claim the document was not saved. (#14925 review)
 			readBackFailed = await this.#saveAndPublishDescendants(args);
-		} catch (error) {
-			// The save may have succeeded, so the operation must not resolve as if it published. [JOV]
-			this.#notify('danger', 'speechBubbles_editContentPublishedFailed');
-			throw error;
 		} finally {
 			waitNotice?.close();
 		}
@@ -343,7 +339,8 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		}
 
 		await this.#loadAndProcessLastPublished();
-		this.#requestReloadOfEntityAndChildren(unique, entityType);
+		// The save above already dispatched the structure-reload event; the descendants need the children one.
+		this.#eventContext?.dispatchEvent(new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique }));
 	}
 
 	/** Peeks a single-message notification, when a notification context is available. */
@@ -351,52 +348,44 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		this.#notificationContext?.peek(color, { data: { message: this.#localize.term(messageKey, ...args) } });
 	}
 
-	#requestReloadOfEntityAndChildren(unique: string, entityType: string): void {
-		this.#eventContext?.dispatchEvent(new UmbRequestReloadStructureForEntityEvent({ entityType, unique }));
-		this.#eventContext?.dispatchEvent(new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique }));
-	}
-
 	/**
-	 * Saves the selected variants and publishes them with their descendants, merging the server response
-	 * into those variants only so that edits elsewhere in the document survive.
+	 * Saves the selected variants, then publishes them with their descendants. The two are separate
+	 * server calls, so the save goes through the default persistence path first: it merges the response
+	 * into those variants only and dispatches the save events, leaving the workspace correctly saved
+	 * even when the publish leg fails afterwards.
 	 * @returns {Promise<boolean>} whether reading the document back after publishing failed
 	 */
 	async #saveAndPublishDescendants(args: UmbDocumentPublishWithDescendantsArgs): Promise<boolean> {
 		const { workspaceContext, unique, variantIds, saveData, includeUnpublishedDescendants } = args;
 
-		// The publish already succeeded server-side once we reach the read-back; a failed read-back must
-		// not be reported as a publish failure, so we fall back to the submitted data.
-		let readBackFailed = false;
-		const loadAfterPublish = async (): Promise<UmbDocumentDetailModel> => {
-			try {
-				return await workspaceContext.loadWithoutPersist();
-			} catch {
-				readBackFailed = true;
-				return saveData;
-			}
-		};
+		try {
+			await workspaceContext.performCreateOrUpdate(variantIds, saveData);
+		} catch (error) {
+			this.#notify('danger', 'speechBubbles_editContentPublishedFailed');
+			throw error;
+		}
 
-		await workspaceContext.performCreateOrUpdate(variantIds, saveData, {
-			update: async (data, ids) => {
-				const { error: saveError } = await this.#detailRepository.save(data);
-				if (saveError) {
-					throw new Error('Error saving document', { cause: saveError });
-				}
+		const { error } = await this.#publishingRepository.publishWithDescendants(
+			unique,
+			variantIds,
+			includeUnpublishedDescendants,
+		);
+		if (error) {
+			// The document is saved at this point, so do not tell the user that it is not.
+			this.#notify('danger', 'speechBubbles_editContentPublishedFailedByValidation');
+			throw new Error('Error publishing document with descendants', { cause: error });
+		}
 
-				const { error } = await this.#publishingRepository.publishWithDescendants(
-					unique,
-					ids,
-					includeUnpublishedDescendants,
-				);
-				if (error) {
-					throw new Error('Error publishing document with descendants', { cause: error });
-				}
-
-				return loadAfterPublish();
-			},
-		});
-
-		return readBackFailed;
+		// Publishing changed the variant states, so read them back the same variant-scoped way rather
+		// than through reload(), which would replace edits in variants that were not published.
+		try {
+			await workspaceContext.performCreateOrUpdate(variantIds, saveData, {
+				update: () => workspaceContext.loadWithoutPersist(),
+			});
+			return false;
+		} catch {
+			return true;
+		}
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -294,89 +294,118 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		return workspaceContext.validateVariantsAndSubmit(
 			variantIds,
-			async () => {
-				const primaryVariantName = workspaceContext.getName(variantIds[0]) ?? '';
-
-				const waitNotice = this.#notificationContext?.peek('warning', {
-					data: {
-						headline: this.#localize.term('publish_publishAll', primaryVariantName),
-						message: this.#localize.term('publish_inProgress'),
-					},
-				});
-
-				// The publish already succeeded server-side once we reach the read-back; a failed read-back must
-				// not be reported as a publish failure, so we fall back to the submitted data.
-				let reloadAfterPublishFailed = false;
-
-				try {
-					// Saving through performCreateOrUpdate merges the server response into the selected variants
-					// only, so edits in variants that were not published stay dirty rather than being discarded.
-					await workspaceContext.performCreateOrUpdate(variantIds, saveData, {
-						update: async (data, ids) => {
-							const { data: saved, error: saveError } = await this.#detailRepository.save(data);
-							if (!saved || saveError) {
-								throw new Error('Error saving document', { cause: saveError });
-							}
-
-							const { error } = await this.#publishingRepository.publishWithDescendants(
-								unique,
-								ids,
-								result.includeUnpublishedDescendants ?? false,
-							);
-							if (error) {
-								throw new Error('Error publishing document with descendants', { cause: error });
-							}
-
-							try {
-								return await workspaceContext.loadWithoutPersist();
-							} catch {
-								reloadAfterPublishFailed = true;
-								return data;
-							}
-						},
-					});
-				} catch (error) {
-					// The save may have succeeded, so the operation must not resolve as if it published. [JOV]
-					this.#notificationContext?.peek('danger', {
-						data: { message: this.#localize.term('speechBubbles_editContentPublishedFailed') },
-					});
-					return Promise.reject(error);
-				} finally {
-					waitNotice?.close();
-				}
-
-				this.#notificationContext?.peek('positive', {
-					data: {
-						message: this.#localize.term('publish_nodePublishAll', primaryVariantName),
-					},
-				});
-
-				if (reloadAfterPublishFailed) {
-					this.#notificationContext?.peek('warning', {
-						data: { message: this.#localize.term('speechBubbles_editContentPublishedReloadFailed') },
-					});
-				}
-
-				await this.#loadAndProcessLastPublished();
-
-				// request reload of this entity
-				const structureEvent = new UmbRequestReloadStructureForEntityEvent({ entityType, unique });
-				this.#eventContext?.dispatchEvent(structureEvent);
-
-				// request reload of the children
-				const childrenEvent = new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique });
-				this.#eventContext?.dispatchEvent(childrenEvent);
-			},
-			async (reason?: unknown) => {
-				// If data of the selection is not valid, then just save:
-				await workspaceContext.performCreateOrUpdate(variantIds, saveData);
-				this.#notificationContext?.peek('danger', {
-					data: { message: this.#localize.term('speechBubbles_editContentPublishedFailedByValidation') },
-				});
-				// Reject even though the save was successful, as we did not publish. [NL]
-				return Promise.reject(reason);
-			},
+			() => this.#performPublishWithDescendants(variantIds, saveData, result.includeUnpublishedDescendants ?? false),
+			(reason?: unknown) => this.#saveWithoutPublishing(variantIds, saveData, reason),
 		);
+	}
+
+	async #performPublishWithDescendants(
+		variantIds: Array<UmbVariantId>,
+		saveData: UmbDocumentDetailModel,
+		includeUnpublishedDescendants: boolean,
+	): Promise<void> {
+		const workspaceContext = this.#documentWorkspaceContext;
+		if (!workspaceContext) throw new Error('Document workspace context is missing');
+
+		const unique = workspaceContext.getUnique();
+		if (!unique) throw new Error('Unique is missing');
+
+		const entityType = workspaceContext.getEntityType();
+		if (!entityType) throw new Error('Entity type is missing');
+
+		const primaryVariantName = workspaceContext.getName(variantIds[0]) ?? '';
+
+		const waitNotice = this.#notificationContext?.peek('warning', {
+			data: {
+				headline: this.#localize.term('publish_publishAll', primaryVariantName),
+				message: this.#localize.term('publish_inProgress'),
+			},
+		});
+
+		// The publish already succeeded server-side once we reach the read-back; a failed read-back must
+		// not be reported as a publish failure, so we fall back to the submitted data.
+		let reloadAfterPublishFailed = false;
+		const loadAfterPublish = async (): Promise<UmbDocumentDetailModel> => {
+			try {
+				return await workspaceContext.loadWithoutPersist();
+			} catch {
+				reloadAfterPublishFailed = true;
+				return saveData;
+			}
+		};
+
+		try {
+			// Saving through performCreateOrUpdate merges the server response into the selected variants
+			// only, so edits in variants that were not published stay dirty rather than being discarded.
+			await workspaceContext.performCreateOrUpdate(variantIds, saveData, {
+				update: async (data, ids) => {
+					const { error: saveError } = await this.#detailRepository.save(data);
+					if (saveError) {
+						throw new Error('Error saving document', { cause: saveError });
+					}
+
+					const { error } = await this.#publishingRepository.publishWithDescendants(
+						unique,
+						ids,
+						includeUnpublishedDescendants,
+					);
+					if (error) {
+						throw new Error('Error publishing document with descendants', { cause: error });
+					}
+
+					return loadAfterPublish();
+				},
+			});
+		} catch (error) {
+			// The save may have succeeded, so the operation must not resolve as if it published. [JOV]
+			this.#notificationContext?.peek('danger', {
+				data: { message: this.#localize.term('speechBubbles_editContentPublishedFailed') },
+			});
+			return Promise.reject(error);
+		} finally {
+			waitNotice?.close();
+		}
+
+		this.#notificationContext?.peek('positive', {
+			data: {
+				message: this.#localize.term('publish_nodePublishAll', primaryVariantName),
+			},
+		});
+
+		if (reloadAfterPublishFailed) {
+			this.#notificationContext?.peek('warning', {
+				data: { message: this.#localize.term('speechBubbles_editContentPublishedReloadFailed') },
+			});
+		}
+
+		await this.#loadAndProcessLastPublished();
+
+		// request reload of this entity
+		const structureEvent = new UmbRequestReloadStructureForEntityEvent({ entityType, unique });
+		this.#eventContext?.dispatchEvent(structureEvent);
+
+		// request reload of the children
+		const childrenEvent = new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique });
+		this.#eventContext?.dispatchEvent(childrenEvent);
+	}
+
+	/**
+	 * Save the selected variants without publishing them, for when validation rejects the publish.
+	 * Rejects even though the save succeeded, to symbolize that we did not publish. [NL]
+	 */
+	async #saveWithoutPublishing(
+		variantIds: Array<UmbVariantId>,
+		saveData: UmbDocumentDetailModel,
+		reason?: unknown,
+	): Promise<void> {
+		if (!this.#documentWorkspaceContext) throw new Error('Document workspace context is missing');
+
+		await this.#documentWorkspaceContext.performCreateOrUpdate(variantIds, saveData);
+		// TODO: Get rid of the save notification.
+		this.#notificationContext?.peek('danger', {
+			data: { message: this.#localize.term('speechBubbles_editContentPublishedFailedByValidation') },
+		});
+		return Promise.reject(reason);
 	}
 
 	/**
@@ -471,21 +500,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 					return Promise.reject(error);
 				});
 			},
-			async (reason?: any) => {
-				// If data of the selection is not valid Then just save:
-				await this.#documentWorkspaceContext!.performCreateOrUpdate(variantIds, saveData);
-				// Notifying that the save was successful, but we did not publish, which is what we want to symbolize here. [NL]
-				const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
-				if (!notificationContext) {
-					throw new Error('Notification context is missing');
-				}
-				// TODO: Get rid of the save notification.
-				notificationContext.peek('danger', {
-					data: { message: this.#localize.term('speechBubbles_editContentPublishedFailedByValidation') },
-				});
-				// Reject even thought the save was successful, but we did not publish, which is what we want to symbolize here. [NL]
-				return await Promise.reject(reason);
-			},
+			(reason?: unknown) => this.#saveWithoutPublishing(variantIds, saveData, reason),
 		);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -436,13 +436,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		if (!entityType) throw new Error('Entity type is missing');
 
 		// Unpublishing reloads the workspace, which discards any unsaved edit, so let the user confirm that.
-		if (this.#documentWorkspaceContext.getHasUnpersistedChanges()) {
-			const discardChanges = await umbOpenModal(this, UMB_DISCARD_CHANGES_MODAL).then(
-				() => true,
-				() => false,
-			);
-			if (!discardChanges) return;
-		}
+		if (!(await this.#confirmDiscardingUnsavedChanges())) return;
 
 		const action = new UmbContentUnpublishEntityAction(this, {
 			unique,
@@ -456,6 +450,19 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		// TODO: It seems wrong to make a full reload, In this case I think we can just update the variants status? [NL]
 		await this.#documentWorkspaceContext.reload();
 		await this.#loadAndProcessLastPublished();
+	}
+
+	/**
+	 * Asks whether to discard unsaved changes, for actions that replace the workspace data.
+	 * @returns {Promise<boolean>} false when the user chose to keep their changes
+	 */
+	async #confirmDiscardingUnsavedChanges(): Promise<boolean> {
+		if (!this.#documentWorkspaceContext?.getHasUnpersistedChanges()) return true;
+
+		return umbOpenModal(this, UMB_DISCARD_CHANGES_MODAL).then(
+			() => true,
+			() => false,
+		);
 	}
 
 	async #handleSaveAndPublish(executionOptions?: UmbWorkspaceActionExecutionOptions) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -35,6 +35,15 @@ import type {
 	UmbWorkspaceActionExecutionOptions,
 } from '@umbraco-cms/backoffice/workspace';
 
+interface UmbDocumentPublishWithDescendantsArgs {
+	workspaceContext: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
+	unique: string;
+	entityType: string;
+	variantIds: Array<UmbVariantId>;
+	saveData: UmbDocumentDetailModel;
+	includeUnpublishedDescendants: boolean;
+}
+
 export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implements UmbPublishableWorkspaceContext {
 	/**
 	 * Manages the pending changes for the published document.
@@ -294,25 +303,21 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		return workspaceContext.validateVariantsAndSubmit(
 			variantIds,
-			() => this.#performPublishWithDescendants(variantIds, saveData, result.includeUnpublishedDescendants ?? false),
+			() =>
+				this.#performPublishWithDescendants({
+					workspaceContext,
+					unique,
+					entityType,
+					variantIds,
+					saveData,
+					includeUnpublishedDescendants: result.includeUnpublishedDescendants ?? false,
+				}),
 			(reason?: unknown) => this.#saveWithoutPublishing(variantIds, saveData, reason),
 		);
 	}
 
-	async #performPublishWithDescendants(
-		variantIds: Array<UmbVariantId>,
-		saveData: UmbDocumentDetailModel,
-		includeUnpublishedDescendants: boolean,
-	): Promise<void> {
-		const workspaceContext = this.#documentWorkspaceContext;
-		if (!workspaceContext) throw new Error('Document workspace context is missing');
-
-		const unique = workspaceContext.getUnique();
-		if (!unique) throw new Error('Unique is missing');
-
-		const entityType = workspaceContext.getEntityType();
-		if (!entityType) throw new Error('Entity type is missing');
-
+	async #performPublishWithDescendants(args: UmbDocumentPublishWithDescendantsArgs): Promise<void> {
+		const { workspaceContext, unique, entityType, variantIds } = args;
 		const primaryVariantName = workspaceContext.getName(variantIds[0]) ?? '';
 
 		const waitNotice = this.#notificationContext?.peek('warning', {
@@ -322,40 +327,9 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 			},
 		});
 
-		// The publish already succeeded server-side once we reach the read-back; a failed read-back must
-		// not be reported as a publish failure, so we fall back to the submitted data.
-		let reloadAfterPublishFailed = false;
-		const loadAfterPublish = async (): Promise<UmbDocumentDetailModel> => {
-			try {
-				return await workspaceContext.loadWithoutPersist();
-			} catch {
-				reloadAfterPublishFailed = true;
-				return saveData;
-			}
-		};
-
+		let readBackFailed: boolean;
 		try {
-			// Saving through performCreateOrUpdate merges the server response into the selected variants
-			// only, so edits in variants that were not published stay dirty rather than being discarded.
-			await workspaceContext.performCreateOrUpdate(variantIds, saveData, {
-				update: async (data, ids) => {
-					const { error: saveError } = await this.#detailRepository.save(data);
-					if (saveError) {
-						throw new Error('Error saving document', { cause: saveError });
-					}
-
-					const { error } = await this.#publishingRepository.publishWithDescendants(
-						unique,
-						ids,
-						includeUnpublishedDescendants,
-					);
-					if (error) {
-						throw new Error('Error publishing document with descendants', { cause: error });
-					}
-
-					return loadAfterPublish();
-				},
-			});
+			readBackFailed = await this.#saveAndPublishDescendants(args);
 		} catch (error) {
 			// The save may have succeeded, so the operation must not resolve as if it published. [JOV]
 			this.#notificationContext?.peek('danger', {
@@ -372,7 +346,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 			},
 		});
 
-		if (reloadAfterPublishFailed) {
+		if (readBackFailed) {
 			this.#notificationContext?.peek('warning', {
 				data: { message: this.#localize.term('speechBubbles_editContentPublishedReloadFailed') },
 			});
@@ -380,13 +354,51 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		await this.#loadAndProcessLastPublished();
 
-		// request reload of this entity
-		const structureEvent = new UmbRequestReloadStructureForEntityEvent({ entityType, unique });
-		this.#eventContext?.dispatchEvent(structureEvent);
+		this.#eventContext?.dispatchEvent(new UmbRequestReloadStructureForEntityEvent({ entityType, unique }));
+		this.#eventContext?.dispatchEvent(new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique }));
+	}
 
-		// request reload of the children
-		const childrenEvent = new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique });
-		this.#eventContext?.dispatchEvent(childrenEvent);
+	/**
+	 * Saves the selected variants and publishes them with their descendants, merging the server response
+	 * into those variants only so that edits elsewhere in the document survive.
+	 * @returns {Promise<boolean>} whether reading the document back after publishing failed
+	 */
+	async #saveAndPublishDescendants(args: UmbDocumentPublishWithDescendantsArgs): Promise<boolean> {
+		const { workspaceContext, unique, variantIds, saveData, includeUnpublishedDescendants } = args;
+
+		// The publish already succeeded server-side once we reach the read-back; a failed read-back must
+		// not be reported as a publish failure, so we fall back to the submitted data.
+		let readBackFailed = false;
+		const loadAfterPublish = async (): Promise<UmbDocumentDetailModel> => {
+			try {
+				return await workspaceContext.loadWithoutPersist();
+			} catch {
+				readBackFailed = true;
+				return saveData;
+			}
+		};
+
+		await workspaceContext.performCreateOrUpdate(variantIds, saveData, {
+			update: async (data, ids) => {
+				const { error: saveError } = await this.#detailRepository.save(data);
+				if (saveError) {
+					throw new Error('Error saving document', { cause: saveError });
+				}
+
+				const { error } = await this.#publishingRepository.publishWithDescendants(
+					unique,
+					ids,
+					includeUnpublishedDescendants,
+				);
+				if (error) {
+					throw new Error('Error publishing document with descendants', { cause: error });
+				}
+
+				return loadAfterPublish();
+			},
+		});
+
+		return readBackFailed;
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -244,7 +244,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 	}
 
 	/**
-	 * Publish the document with descendants
+	 * Save the document and publish it with descendants
 	 * @returns {Promise<void>}
 	 * @memberof UmbDocumentPublishingWorkspaceContext
 	 */
@@ -275,46 +275,75 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		if (!variantIds.length) return;
 
-		const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
-		const localize = new UmbLocalizationController(this);
+		const saveData = await this.#documentWorkspaceContext.constructSaveData(variantIds);
+		await this.#documentWorkspaceContext.runMandatoryValidationForSaveData(saveData, variantIds);
+		await this.#documentWorkspaceContext.askServerToValidate(saveData, variantIds);
 
-		const primaryVariantName = this.#documentWorkspaceContext.getName(variantIds[0]) ?? '';
-
-		const waitNotice = notificationContext?.peek('warning', {
-			data: {
-				headline: localize.term('publish_publishAll', primaryVariantName),
-				message: localize.term('publish_inProgress'),
-			},
-		});
-
-		const { error } = await this.#publishingRepository.publishWithDescendants(
-			unique,
+		return this.#documentWorkspaceContext.validateVariantsAndSubmit(
 			variantIds,
-			result.includeUnpublishedDescendants ?? false,
+			async () => {
+				if (!this.#documentWorkspaceContext) {
+					throw new Error('Document workspace context is missing');
+				}
+
+				const primaryVariantName = this.#documentWorkspaceContext.getName(variantIds[0]) ?? '';
+
+				const waitNotice = this.#notificationContext?.peek('warning', {
+					data: {
+						headline: this.#localize.term('publish_publishAll', primaryVariantName),
+						message: this.#localize.term('publish_inProgress'),
+					},
+				});
+
+				let error;
+				try {
+					// Save the document before publishing it and its descendants
+					await this.#documentWorkspaceContext.performCreateOrUpdate(variantIds, saveData);
+
+					({ error } = await this.#publishingRepository.publishWithDescendants(
+						unique,
+						variantIds,
+						result.includeUnpublishedDescendants ?? false,
+					));
+				} finally {
+					waitNotice?.close();
+				}
+
+				if (error) return;
+
+				this.#notificationContext?.peek('positive', {
+					data: {
+						message: this.#localize.term('publish_nodePublishAll', primaryVariantName),
+					},
+				});
+
+				// reload the document so all states are updated after the publish operation
+				// TODO: It seems wrong to make a full reload, I think we should only load the selected variants. [NL]
+				await this.#documentWorkspaceContext.reload();
+				await this.#loadAndProcessLastPublished();
+
+				// request reload of this entity
+				const structureEvent = new UmbRequestReloadStructureForEntityEvent({ entityType, unique });
+				this.#eventContext?.dispatchEvent(structureEvent);
+
+				// request reload of the children
+				const childrenEvent = new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique });
+				this.#eventContext?.dispatchEvent(childrenEvent);
+			},
+			async (reason?: any) => {
+				// If data of the selection is not valid, then just save:
+				await this.#documentWorkspaceContext!.performCreateOrUpdate(variantIds, saveData);
+				const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+				if (!notificationContext) {
+					throw new Error('Notification context is missing');
+				}
+				notificationContext.peek('danger', {
+					data: { message: this.#localize.term('speechBubbles_editContentPublishedFailedByValidation') },
+				});
+				// Reject even though the save was successful, as we did not publish. [NL]
+				return Promise.reject(reason);
+			},
 		);
-
-		waitNotice?.close();
-
-		if (!error) {
-			notificationContext?.peek('positive', {
-				data: {
-					message: localize.term('publish_nodePublishAll', primaryVariantName),
-				},
-			});
-
-			// reload the document so all states are updated after the publish operation
-			// TODO: It seems wrong to make a full reload, I think we should only load the selected variants. [NL]
-			await this.#documentWorkspaceContext.reload();
-			await this.#loadAndProcessLastPublished();
-
-			// request reload of this entity
-			const structureEvent = new UmbRequestReloadStructureForEntityEvent({ entityType, unique });
-			this.#eventContext?.dispatchEvent(structureEvent);
-
-			// request reload of the children
-			const childrenEvent = new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique });
-			this.#eventContext?.dispatchEvent(childrenEvent);
-		}
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -27,6 +27,7 @@ import {
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
+import type { UmbNotificationColor } from '@umbraco-cms/backoffice/notification';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
 import { notifyWorkspaceActionStarting } from '@umbraco-cms/backoffice/workspace';
@@ -293,9 +294,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 			await workspaceContext.runMandatoryValidationForSaveData(saveData, variantIds);
 		} catch (error) {
 			// This throws before the submit flow starts, so nothing downstream tells the user why. [JOV]
-			this.#notificationContext?.peek('danger', {
-				data: { message: this.#localize.term('speechBubbles_editContentPublishedFailedByValidation') },
-			});
+			this.#notify('danger', 'speechBubbles_editContentPublishedFailedByValidation');
 			return Promise.reject(error);
 		}
 
@@ -332,28 +331,27 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 			readBackFailed = await this.#saveAndPublishDescendants(args);
 		} catch (error) {
 			// The save may have succeeded, so the operation must not resolve as if it published. [JOV]
-			this.#notificationContext?.peek('danger', {
-				data: { message: this.#localize.term('speechBubbles_editContentPublishedFailed') },
-			});
+			this.#notify('danger', 'speechBubbles_editContentPublishedFailed');
 			return Promise.reject(error);
 		} finally {
 			waitNotice?.close();
 		}
 
-		this.#notificationContext?.peek('positive', {
-			data: {
-				message: this.#localize.term('publish_nodePublishAll', primaryVariantName),
-			},
-		});
-
+		this.#notify('positive', 'publish_nodePublishAll', primaryVariantName);
 		if (readBackFailed) {
-			this.#notificationContext?.peek('warning', {
-				data: { message: this.#localize.term('speechBubbles_editContentPublishedReloadFailed') },
-			});
+			this.#notify('warning', 'speechBubbles_editContentPublishedReloadFailed');
 		}
 
 		await this.#loadAndProcessLastPublished();
+		this.#requestReloadOfEntityAndChildren(unique, entityType);
+	}
 
+	/** Peeks a single-message notification, when a notification context is available. */
+	#notify(color: UmbNotificationColor, messageKey: string, ...args: Array<string>): void {
+		this.#notificationContext?.peek(color, { data: { message: this.#localize.term(messageKey, ...args) } });
+	}
+
+	#requestReloadOfEntityAndChildren(unique: string, entityType: string): void {
 		this.#eventContext?.dispatchEvent(new UmbRequestReloadStructureForEntityEvent({ entityType, unique }));
 		this.#eventContext?.dispatchEvent(new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique }));
 	}
@@ -414,9 +412,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		await this.#documentWorkspaceContext.performCreateOrUpdate(variantIds, saveData);
 		// TODO: Get rid of the save notification.
-		this.#notificationContext?.peek('danger', {
-			data: { message: this.#localize.term('speechBubbles_editContentPublishedFailedByValidation') },
-		});
+		this.#notify('danger', 'speechBubbles_editContentPublishedFailedByValidation');
 		return Promise.reject(reason);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -15,7 +15,7 @@ import { UMB_DOCUMENT_PUBLISHING_SHORTCUT_UNIQUE } from './constants.js';
 import { UmbDocumentVariantState } from '../../variant-state.js';
 import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
-import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
+import { UMB_DISCARD_CHANGES_MODAL, umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import { UMB_CONTENT_PUBLISH_MODAL, UmbContentUnpublishEntityAction } from '@umbraco-cms/backoffice/content';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
@@ -360,6 +360,15 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		const entityType = this.#documentWorkspaceContext.getEntityType();
 		if (!entityType) throw new Error('Entity type is missing');
+
+		// Unpublishing reloads the workspace, which discards any unsaved edit, so let the user confirm that.
+		if (this.#documentWorkspaceContext.getHasUnpersistedChanges()) {
+			const discardChanges = await umbOpenModal(this, UMB_DISCARD_CHANGES_MODAL).then(
+				() => true,
+				() => false,
+			);
+			if (!discardChanges) return;
+		}
 
 		const action = new UmbContentUnpublishEntityAction(this, {
 			unique,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -5,6 +5,7 @@ import type {
 	UmbDocumentVariantPublishModel,
 } from '../../types.js';
 import { UmbDocumentPublishingRepository } from '../repository/index.js';
+import { UmbDocumentDetailRepository } from '../../repository/index.js';
 import { UmbDocumentPublishedPendingChangesManager } from '../pending-changes/index.js';
 import { UMB_DOCUMENT_SCHEDULE_MODAL } from '../schedule-publish/constants.js';
 import { UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL } from '../publish-with-descendants/constants.js';
@@ -45,6 +46,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 	#documentWorkspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
 	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 	#publishingRepository = new UmbDocumentPublishingRepository(this);
+	#detailRepository = new UmbDocumentDetailRepository(this);
 	#publishedDocumentData?: UmbDocumentDetailModel;
 	#loadingPublishedData = false;
 	#currentUnique?: UmbEntityUnique;
@@ -275,18 +277,25 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		if (!variantIds.length) return;
 
-		const saveData = await this.#documentWorkspaceContext.constructSaveData(variantIds);
-		await this.#documentWorkspaceContext.runMandatoryValidationForSaveData(saveData, variantIds);
-		await this.#documentWorkspaceContext.askServerToValidate(saveData, variantIds);
+		const workspaceContext = this.#documentWorkspaceContext;
+		const saveData = await workspaceContext.constructSaveData(variantIds);
 
-		return this.#documentWorkspaceContext.validateVariantsAndSubmit(
+		try {
+			await workspaceContext.runMandatoryValidationForSaveData(saveData, variantIds);
+		} catch (error) {
+			// This throws before the submit flow starts, so nothing downstream tells the user why. [JOV]
+			this.#notificationContext?.peek('danger', {
+				data: { message: this.#localize.term('speechBubbles_editContentPublishedFailedByValidation') },
+			});
+			return Promise.reject(error);
+		}
+
+		await workspaceContext.askServerToValidate(saveData, variantIds);
+
+		return workspaceContext.validateVariantsAndSubmit(
 			variantIds,
 			async () => {
-				if (!this.#documentWorkspaceContext) {
-					throw new Error('Document workspace context is missing');
-				}
-
-				const primaryVariantName = this.#documentWorkspaceContext.getName(variantIds[0]) ?? '';
+				const primaryVariantName = workspaceContext.getName(variantIds[0]) ?? '';
 
 				const waitNotice = this.#notificationContext?.peek('warning', {
 					data: {
@@ -295,16 +304,37 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 					},
 				});
 
-				try {
-					// Save the document before publishing it and its descendants
-					await this.#documentWorkspaceContext.performCreateOrUpdate(variantIds, saveData);
+				// The publish already succeeded server-side once we reach the read-back; a failed read-back must
+				// not be reported as a publish failure, so we fall back to the submitted data.
+				let reloadAfterPublishFailed = false;
 
-					const { error } = await this.#publishingRepository.publishWithDescendants(
-						unique,
-						variantIds,
-						result.includeUnpublishedDescendants ?? false,
-					);
-					if (error) throw error;
+				try {
+					// Saving through performCreateOrUpdate merges the server response into the selected variants
+					// only, so edits in variants that were not published stay dirty rather than being discarded.
+					await workspaceContext.performCreateOrUpdate(variantIds, saveData, {
+						update: async (data, ids) => {
+							const { data: saved, error: saveError } = await this.#detailRepository.save(data);
+							if (!saved || saveError) {
+								throw new Error('Error saving document', { cause: saveError });
+							}
+
+							const { error } = await this.#publishingRepository.publishWithDescendants(
+								unique,
+								ids,
+								result.includeUnpublishedDescendants ?? false,
+							);
+							if (error) {
+								throw new Error('Error publishing document with descendants', { cause: error });
+							}
+
+							try {
+								return await workspaceContext.loadWithoutPersist();
+							} catch {
+								reloadAfterPublishFailed = true;
+								return data;
+							}
+						},
+					});
 				} catch (error) {
 					// The save may have succeeded, so the operation must not resolve as if it published. [JOV]
 					this.#notificationContext?.peek('danger', {
@@ -321,9 +351,12 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 					},
 				});
 
-				// reload the document so all states are updated after the publish operation
-				// TODO: It seems wrong to make a full reload, I think we should only load the selected variants. [NL]
-				await this.#documentWorkspaceContext.reload();
+				if (reloadAfterPublishFailed) {
+					this.#notificationContext?.peek('warning', {
+						data: { message: this.#localize.term('speechBubbles_editContentPublishedReloadFailed') },
+					});
+				}
+
 				await this.#loadAndProcessLastPublished();
 
 				// request reload of this entity
@@ -334,14 +367,10 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 				const childrenEvent = new UmbRequestReloadChildrenOfEntityEvent({ entityType, unique });
 				this.#eventContext?.dispatchEvent(childrenEvent);
 			},
-			async (reason?: any) => {
+			async (reason?: unknown) => {
 				// If data of the selection is not valid, then just save:
-				await this.#documentWorkspaceContext!.performCreateOrUpdate(variantIds, saveData);
-				const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
-				if (!notificationContext) {
-					throw new Error('Notification context is missing');
-				}
-				notificationContext.peek('danger', {
+				await workspaceContext.performCreateOrUpdate(variantIds, saveData);
+				this.#notificationContext?.peek('danger', {
 					data: { message: this.#localize.term('speechBubbles_editContentPublishedFailedByValidation') },
 				});
 				// Reject even though the save was successful, as we did not publish. [NL]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #14925

AB#33601

### Description

"Publish with descendants" never saved the document it was invoked from. Any edit made in the workspace — a rename, a property change — was silently discarded by the reload that follows the publish, so the user lost their work with no warning.

`publishWithDescendants()` went straight from the variant-picker modal to the publish endpoint. Its two siblings in the same context, `#handleSaveAndPublish()` and `schedule()`, both construct the save data, validate it and persist it first. This makes the descendants flow do the same, so all three workspace publishing actions behave consistently.

#### What changed

**Save before publishing** — `publishWithDescendants()` now runs `constructSaveData` → `runMandatoryValidationForSaveData` → `askServerToValidate` → `validateVariantsAndSubmit`, and saves before calling the publish-with-descendants endpoint. Invalid data takes the save-only path with the same notification the other two flows use.

The save and the publish share a single `performCreateOrUpdate` persistence override, the way `#performSaveAndPublish` does. That matters: the plain `reload()` this replaces did a wholesale `setCurrent`, so an edit in a variant the user had *not* ticked was still discarded — the same data loss, one step narrower. Going through the override merges the server response into the published variants only, leaving other variants' edits dirty and intact, and removes the need for the reload (and the `TODO` that sat on it).

**Feedback on rejection** — the action now fails rather than resolving when the publish call errors after a successful save, and mandatory-validation failures get a notification. That validation throws before the submit flow starts, so nothing downstream would otherwise tell the user why clicking the button did nothing.

**Modal titles** — both actions save the document they are invoked from, but neither said so. Following Niels' suggestion on the work item, the modal headlines now read "Save and publish with descendants" and "Save and schedule publishing" (new `content_*` keys, English + Danish). The action labels and the modal submit buttons are unchanged.

**Structure** — the publish work lives in `#performPublishWithDescendants`, mirroring how `#handleSaveAndPublish` delegates to `#performSaveAndPublish`; CodeScene flagged the combined method as complex otherwise. Its save-without-publishing branch is now shared with save-and-publish, which had an identical copy (the one behaviour difference: a missing notification context no longer replaces the real rejection reason with a throw).

**Unpublish guard** — unpublishing from a workspace also reloads, and also threw away unsaved edits without asking. It now opens the standard discard-changes modal first when there is something to lose. The tree entity action is unaffected, as it has no editor state.

#### Behaviour changes worth a second opinion

1. Validation now gates the whole operation. If the root document is invalid it is saved, but neither it nor its descendants are published — previously descendants were published regardless of the root's validity.
2. Two modal headlines changed, and unpublish from a workspace can now show an extra confirmation. No action or button labels changed.
3. `docs/design-choices.md` uses "Publish with descendants" as the *Do* example in its dialog-headline table — the exact string this changes. The rule it illustrates is about not stuffing the target into the headline ("Publish 'My Page 1' with descendants"), which this doesn't do, so I don't think it's a real conflict. Worth refreshing the example anyway.

### How to test

1. Create a root document with at least one child.
2. Open the root, rename it (or edit a property), and choose **Save and publish** → **Publish with descendants**.
3. Confirm the modal now reads "Save and publish with descendants", and publish.
4. Reload the page — the rename is still there. On `v17/dev` it is gone.

For the unpublish guard: open a published document, edit something, then **Unpublish**. You should be asked whether to discard your changes before the unpublish confirmation appears.

### Testing

Seven unit tests in `document-publishing.workspace-context.test.ts`. Each was verified to fail against the code it fixes, by reverting that change and re-running:

- the edit reaches the server, and survives in the editor
- an edit in a variant that was *not* published stays dirty and intact
- nothing is published when the document fails mandatory validation (checked against a positive control, so the zero isn't incidental)
- unpublish asks to discard when there are unsaved changes, goes on to unpublish once discarded, stops when the discard is cancelled, and does not ask when there is nothing to lose

`tsc`, eslint, prettier and the circular-dependency check are clean; the documents and content package suites pass (177 tests). No acceptance-test locators are affected — they target action and submit-button labels, none of which changed, and nothing drives the workspace unpublish button.

### Known gaps and deliberate non-changes

- **`schedule()` has the same variant-preservation gap** this PR fixes for descendants — it still saves and then `reload()`s. Left alone to keep the change reviewable; worth a follow-up.
- **The save-validate-submit preamble still appears three times** in this file. The save-without-publishing branch is now shared between publish-with-descendants and save-and-publish (they had character-identical copies), but collapsing the whole preamble would mean refactoring `schedule()` too, so not here.
- **No spinner on the menu item.** `workspaceActionMenuItem` calls `execute()` with no arguments and has no `isExecuting` plumbing, so threading `UmbWorkspaceActionExecutionOptions` through would be dead code. Applies equally to schedule publish.
- **The server-validation `onInvalid` branch is not unit-tested** — reaching it needs a per-test MSW handler override, which nothing else in this repo does.
- **The discard prompt precedes the unpublish confirmation**, so a user who discards and then cancels the unpublish was asked for nothing. Reordering means restructuring the shared entity action.

### Note for reviewers

The publishing workspace context and the document workspace context share the context alias `UmbWorkspaceContext` and are separated only by discriminator — and `UmbDocumentPublishingWorkspaceContext.getEntityType()` returns `'document'`, so it also satisfies the *document* workspace context's discriminator. Host it anywhere other than on the workspace API and it resolves `UMB_DOCUMENT_WORKSPACE_CONTEXT` to itself, then swallows the resulting TypeError in the `.catch()` on `#init`. That is why the new test constructs it the way `UmbWorkspaceElement` does. Nothing here changes that, but it cost some time to find and is worth knowing about.
