### PR TITLE
Imaging: Bound image processing memory so containers are not OOM-killed when browsing media (target: v13, closes #23556)

### DIFF
--- a/src/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddleware.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddleware.cs
@@ -1,0 +1,88 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using SixLabors.ImageSharp.Web.Processors;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace Umbraco.Cms.Imaging.ImageSharp;
+
+/// <summary>
+/// Bounds the number of images processed concurrently.
+/// </summary>
+/// <remarks>
+/// The imaging middleware only de-duplicates concurrent requests for the same URL, so a page of
+/// distinct thumbnails decodes every source at full resolution in parallel. Peak memory is then
+/// the number of concurrent requests multiplied by the size of a decoded source, which on a host
+/// with a hard memory limit is enough to have the process killed. Requests over the limit wait
+/// here instead.
+/// </remarks>
+public sealed class ImageProcessingThrottleMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly SemaphoreSlim _semaphore;
+    private readonly HashSet<string> _commands;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageProcessingThrottleMiddleware" /> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="imagingSettings">The Umbraco imaging settings.</param>
+    /// <param name="processors">The registered image processors, used to recognise processing requests.</param>
+    public ImageProcessingThrottleMiddleware(
+        RequestDelegate next,
+        IOptions<ImagingSettings> imagingSettings,
+        IEnumerable<IImageWebProcessor> processors)
+    {
+        _next = next;
+
+        var maximumConcurrentProcessing = imagingSettings.Value.Memory.ResolveMaximumConcurrentProcessing(
+            GC.GetGCMemoryInfo().TotalAvailableMemoryBytes,
+            Environment.ProcessorCount);
+
+        _semaphore = new SemaphoreSlim(maximumConcurrentProcessing, maximumConcurrentProcessing);
+        _commands = new HashSet<string>(processors.SelectMany(x => x.Commands), StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Executes the middleware.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!IsProcessingRequest(context.Request))
+        {
+            await _next(context);
+            return;
+        }
+
+        await _semaphore.WaitAsync(context.RequestAborted);
+        try
+        {
+            await _next(context);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private bool IsProcessingRequest(HttpRequest request)
+    {
+        // The image provider resolves a file, so anything without an extension cannot reach it.
+        // Without this an unrelated request that happens to carry a "width" would queue here too.
+        if (!Path.HasExtension(request.Path.Value))
+        {
+            return false;
+        }
+
+        foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> query in request.Query)
+        {
+            if (_commands.Contains(query.Key))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddleware.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddleware.cs
@@ -13,12 +13,14 @@ namespace Umbraco.Cms.Imaging.ImageSharp;
 /// distinct thumbnails decodes every source at full resolution in parallel. Peak memory is then
 /// the number of concurrent requests multiplied by the size of a decoded source, which on a host
 /// with a hard memory limit is enough to have the process killed. Requests over the limit wait
-/// here instead.
+/// here instead. The gate engages only when memory is the binding constraint (see
+/// <see cref="ImagingMemorySettings.RequiresConcurrencyLimit" />); on any other host it steps
+/// aside so cache hits and other cheap requests are never made to wait.
 /// </remarks>
 public sealed class ImageProcessingThrottleMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly SemaphoreSlim _semaphore;
+    private readonly SemaphoreSlim? _semaphore;
     private readonly HashSet<string> _commands;
 
     /// <summary>
@@ -31,14 +33,31 @@ public sealed class ImageProcessingThrottleMiddleware
         RequestDelegate next,
         IOptions<ImagingSettings> imagingSettings,
         IEnumerable<IImageWebProcessor> processors)
+        : this(
+            next,
+            imagingSettings,
+            processors,
+            GC.GetGCMemoryInfo().TotalAvailableMemoryBytes,
+            Environment.ProcessorCount)
+    {
+    }
+
+    internal ImageProcessingThrottleMiddleware(
+        RequestDelegate next,
+        IOptions<ImagingSettings> imagingSettings,
+        IEnumerable<IImageWebProcessor> processors,
+        long availableMemoryBytes,
+        int processorCount)
     {
         _next = next;
 
-        var maximumConcurrentProcessing = imagingSettings.Value.Memory.ResolveMaximumConcurrentProcessing(
-            GC.GetGCMemoryInfo().TotalAvailableMemoryBytes,
-            Environment.ProcessorCount);
+        ImagingMemorySettings memory = imagingSettings.Value.Memory;
+        if (memory.RequiresConcurrencyLimit(availableMemoryBytes, processorCount))
+        {
+            var maximumConcurrentProcessing = memory.ResolveMaximumConcurrentProcessing(availableMemoryBytes, processorCount);
+            _semaphore = new SemaphoreSlim(maximumConcurrentProcessing, maximumConcurrentProcessing);
+        }
 
-        _semaphore = new SemaphoreSlim(maximumConcurrentProcessing, maximumConcurrentProcessing);
         _commands = new HashSet<string>(processors.SelectMany(x => x.Commands), StringComparer.OrdinalIgnoreCase);
     }
 
@@ -49,7 +68,7 @@ public sealed class ImageProcessingThrottleMiddleware
     /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     public async Task InvokeAsync(HttpContext context)
     {
-        if (!IsProcessingRequest(context.Request))
+        if (_semaphore is null || !IsProcessingRequest(context.Request))
         {
             await _next(context);
             return;

--- a/src/Umbraco.Cms.Imaging.ImageSharp/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/UmbracoBuilderExtensions.cs
@@ -1,9 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.DependencyInjection;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Providers;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Imaging.ImageSharp.ImageProcessors;
@@ -20,6 +26,20 @@ public static class UmbracoBuilderExtensions
     /// </summary>
     public static IServiceCollection AddUmbracoImageSharp(this IUmbracoBuilder builder)
     {
+        ImagingSettings imagingSettings = builder.Config
+            .GetSection(Constants.Configuration.ConfigImaging)
+            .Get<ImagingSettings>() ?? new ImagingSettings();
+
+        // ImageSharp pools unmanaged memory sized against the available memory and releases it only
+        // on a gen2 collection, so on a memory constrained host it sits at rest well above what the
+        // site needs. Applied before the configuration is shared so nothing allocates from the
+        // default pool first.
+        Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions
+        {
+            MaximumPoolSizeMegabytes = imagingSettings.Memory.ResolveMaximumPoolSizeMegabytes(
+                GC.GetGCMemoryInfo().TotalAvailableMemoryBytes),
+        });
+
         // Add default ImageSharp configuration and service implementations
         builder.Services.AddSingleton(Configuration.Default);
         builder.Services.AddUnique<IImageDimensionExtractor, ImageSharpDimensionExtractor>();
@@ -44,7 +64,11 @@ public static class UmbracoBuilderExtensions
         {
             options.AddFilter(new UmbracoPipelineFilter(nameof(ImageSharpComposer))
             {
-                PrePipeline = prePipeline => prePipeline.UseImageSharp()
+                PrePipeline = prePipeline =>
+                {
+                    prePipeline.UseMiddleware<ImageProcessingThrottleMiddleware>();
+                    prePipeline.UseImageSharp();
+                }
             });
         });
 

--- a/src/Umbraco.Cms.Imaging.ImageSharp/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp/UmbracoBuilderExtensions.cs
@@ -34,11 +34,14 @@ public static class UmbracoBuilderExtensions
         // on a gen2 collection, so on a memory constrained host it sits at rest well above what the
         // site needs. Applied before the configuration is shared so nothing allocates from the
         // default pool first.
-        Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions
+        if (imagingSettings.Memory.Enabled)
         {
-            MaximumPoolSizeMegabytes = imagingSettings.Memory.ResolveMaximumPoolSizeMegabytes(
-                GC.GetGCMemoryInfo().TotalAvailableMemoryBytes),
-        });
+            Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions
+            {
+                MaximumPoolSizeMegabytes = imagingSettings.Memory.ResolveMaximumPoolSizeMegabytes(
+                    GC.GetGCMemoryInfo().TotalAvailableMemoryBytes),
+            });
+        }
 
         // Add default ImageSharp configuration and service implementations
         builder.Services.AddSingleton(Configuration.Default);

--- a/src/Umbraco.Cms.Imaging.ImageSharp2/ImageProcessingThrottleMiddleware.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/ImageProcessingThrottleMiddleware.cs
@@ -1,0 +1,88 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using SixLabors.ImageSharp.Web.Processors;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace Umbraco.Cms.Imaging.ImageSharp;
+
+/// <summary>
+/// Bounds the number of images processed concurrently.
+/// </summary>
+/// <remarks>
+/// The imaging middleware only de-duplicates concurrent requests for the same URL, so a page of
+/// distinct thumbnails decodes every source at full resolution in parallel. Peak memory is then
+/// the number of concurrent requests multiplied by the size of a decoded source, which on a host
+/// with a hard memory limit is enough to have the process killed. Requests over the limit wait
+/// here instead.
+/// </remarks>
+public sealed class ImageProcessingThrottleMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly SemaphoreSlim _semaphore;
+    private readonly HashSet<string> _commands;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageProcessingThrottleMiddleware" /> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="imagingSettings">The Umbraco imaging settings.</param>
+    /// <param name="processors">The registered image processors, used to recognise processing requests.</param>
+    public ImageProcessingThrottleMiddleware(
+        RequestDelegate next,
+        IOptions<ImagingSettings> imagingSettings,
+        IEnumerable<IImageWebProcessor> processors)
+    {
+        _next = next;
+
+        var maximumConcurrentProcessing = imagingSettings.Value.Memory.ResolveMaximumConcurrentProcessing(
+            GC.GetGCMemoryInfo().TotalAvailableMemoryBytes,
+            Environment.ProcessorCount);
+
+        _semaphore = new SemaphoreSlim(maximumConcurrentProcessing, maximumConcurrentProcessing);
+        _commands = new HashSet<string>(processors.SelectMany(x => x.Commands), StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Executes the middleware.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!IsProcessingRequest(context.Request))
+        {
+            await _next(context);
+            return;
+        }
+
+        await _semaphore.WaitAsync(context.RequestAborted);
+        try
+        {
+            await _next(context);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private bool IsProcessingRequest(HttpRequest request)
+    {
+        // The image provider resolves a file, so anything without an extension cannot reach it.
+        // Without this an unrelated request that happens to carry a "width" would queue here too.
+        if (!Path.HasExtension(request.Path.Value))
+        {
+            return false;
+        }
+
+        foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> query in request.Query)
+        {
+            if (_commands.Contains(query.Key))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Umbraco.Cms.Imaging.ImageSharp2/ImageProcessingThrottleMiddleware.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/ImageProcessingThrottleMiddleware.cs
@@ -13,12 +13,14 @@ namespace Umbraco.Cms.Imaging.ImageSharp;
 /// distinct thumbnails decodes every source at full resolution in parallel. Peak memory is then
 /// the number of concurrent requests multiplied by the size of a decoded source, which on a host
 /// with a hard memory limit is enough to have the process killed. Requests over the limit wait
-/// here instead.
+/// here instead. The gate engages only when memory is the binding constraint (see
+/// <see cref="ImagingMemorySettings.RequiresConcurrencyLimit" />); on any other host it steps
+/// aside so cache hits and other cheap requests are never made to wait.
 /// </remarks>
 public sealed class ImageProcessingThrottleMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly SemaphoreSlim _semaphore;
+    private readonly SemaphoreSlim? _semaphore;
     private readonly HashSet<string> _commands;
 
     /// <summary>
@@ -31,14 +33,31 @@ public sealed class ImageProcessingThrottleMiddleware
         RequestDelegate next,
         IOptions<ImagingSettings> imagingSettings,
         IEnumerable<IImageWebProcessor> processors)
+        : this(
+            next,
+            imagingSettings,
+            processors,
+            GC.GetGCMemoryInfo().TotalAvailableMemoryBytes,
+            Environment.ProcessorCount)
+    {
+    }
+
+    internal ImageProcessingThrottleMiddleware(
+        RequestDelegate next,
+        IOptions<ImagingSettings> imagingSettings,
+        IEnumerable<IImageWebProcessor> processors,
+        long availableMemoryBytes,
+        int processorCount)
     {
         _next = next;
 
-        var maximumConcurrentProcessing = imagingSettings.Value.Memory.ResolveMaximumConcurrentProcessing(
-            GC.GetGCMemoryInfo().TotalAvailableMemoryBytes,
-            Environment.ProcessorCount);
+        ImagingMemorySettings memory = imagingSettings.Value.Memory;
+        if (memory.RequiresConcurrencyLimit(availableMemoryBytes, processorCount))
+        {
+            var maximumConcurrentProcessing = memory.ResolveMaximumConcurrentProcessing(availableMemoryBytes, processorCount);
+            _semaphore = new SemaphoreSlim(maximumConcurrentProcessing, maximumConcurrentProcessing);
+        }
 
-        _semaphore = new SemaphoreSlim(maximumConcurrentProcessing, maximumConcurrentProcessing);
         _commands = new HashSet<string>(processors.SelectMany(x => x.Commands), StringComparer.OrdinalIgnoreCase);
     }
 
@@ -49,7 +68,7 @@ public sealed class ImageProcessingThrottleMiddleware
     /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     public async Task InvokeAsync(HttpContext context)
     {
-        if (!IsProcessingRequest(context.Request))
+        if (_semaphore is null || !IsProcessingRequest(context.Request))
         {
             await _next(context);
             return;

--- a/src/Umbraco.Cms.Imaging.ImageSharp2/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/UmbracoBuilderExtensions.cs
@@ -1,10 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.DependencyInjection;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Providers;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Imaging.ImageSharp.ImageProcessors;
@@ -21,6 +26,20 @@ public static class UmbracoBuilderExtensions
     /// </summary>
     public static IServiceCollection AddUmbracoImageSharp(this IUmbracoBuilder builder)
     {
+        ImagingSettings imagingSettings = builder.Config
+            .GetSection(Constants.Configuration.ConfigImaging)
+            .Get<ImagingSettings>() ?? new ImagingSettings();
+
+        // ImageSharp pools unmanaged memory sized against the available memory and releases it only
+        // on a gen2 collection, so on a memory constrained host it sits at rest well above what the
+        // site needs. Applied before the configuration is shared so nothing allocates from the
+        // default pool first.
+        Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions
+        {
+            MaximumPoolSizeMegabytes = imagingSettings.Memory.ResolveMaximumPoolSizeMegabytes(
+                GC.GetGCMemoryInfo().TotalAvailableMemoryBytes),
+        });
+
         // Add default ImageSharp configuration and service implementations
         builder.Services.AddSingleton(Configuration.Default);
         builder.Services.AddUnique<IImageDimensionExtractor, ImageSharpDimensionExtractor>();
@@ -45,7 +64,11 @@ public static class UmbracoBuilderExtensions
         {
             options.AddFilter(new UmbracoPipelineFilter(nameof(ImageSharpComposer))
             {
-                PrePipeline = prePipeline => prePipeline.UseImageSharp()
+                PrePipeline = prePipeline =>
+                {
+                    prePipeline.UseMiddleware<ImageProcessingThrottleMiddleware>();
+                    prePipeline.UseImageSharp();
+                }
             });
         });
 

--- a/src/Umbraco.Cms.Imaging.ImageSharp2/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/UmbracoBuilderExtensions.cs
@@ -34,11 +34,14 @@ public static class UmbracoBuilderExtensions
         // on a gen2 collection, so on a memory constrained host it sits at rest well above what the
         // site needs. Applied before the configuration is shared so nothing allocates from the
         // default pool first.
-        Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions
+        if (imagingSettings.Memory.Enabled)
         {
-            MaximumPoolSizeMegabytes = imagingSettings.Memory.ResolveMaximumPoolSizeMegabytes(
-                GC.GetGCMemoryInfo().TotalAvailableMemoryBytes),
-        });
+            Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions
+            {
+                MaximumPoolSizeMegabytes = imagingSettings.Memory.ResolveMaximumPoolSizeMegabytes(
+                    GC.GetGCMemoryInfo().TotalAvailableMemoryBytes),
+            });
+        }
 
         // Add default ImageSharp configuration and service implementations
         builder.Services.AddSingleton(Configuration.Default);

--- a/src/Umbraco.Core/Configuration/Models/ImagingMemorySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingMemorySettings.cs
@@ -116,10 +116,33 @@ public class ImagingMemorySettings
             return MaximumConcurrentProcessing;
         }
 
-        long budgetBytes = availableMemoryBytes / ConcurrencyMemoryShareDivisor;
-        long derived = budgetBytes / (EstimatedMegabytesPerImage * OneMegabyte);
-
         // Decoding is CPU bound, so more concurrency than processors buys nothing but memory.
-        return (int)Math.Clamp(derived, 1, Math.Max(processorCount, 1));
+        return (int)Math.Clamp(DeriveConcurrentProcessing(availableMemoryBytes), 1, Math.Max(processorCount, 1));
     }
+
+    /// <summary>
+    /// Gets a value indicating whether the number of images processed concurrently needs to be
+    /// bounded on this host.
+    /// </summary>
+    /// <param name="availableMemoryBytes">
+    /// The memory available to the process, honouring any container limit. Typically
+    /// <see cref="GCMemoryInfo.TotalAvailableMemoryBytes" />.
+    /// </param>
+    /// <param name="processorCount">The number of processors available to the process.</param>
+    /// <returns>
+    /// <c>true</c> when a limit is configured explicitly, or when the memory budget cannot cover as
+    /// many concurrent decodes as the processors would otherwise run; otherwise <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// Decoding is CPU bound, so the processor count already caps how many images decode at once.
+    /// A concurrency limit only earns its keep when memory is the tighter constraint - a container
+    /// with a low limit relative to its core count. Everywhere else - an uncapped host, or a host
+    /// with few cores relative to its memory - bounding concurrency would only add latency to
+    /// requests the cache can serve without protecting against anything.
+    /// </remarks>
+    public bool RequiresConcurrencyLimit(long availableMemoryBytes, int processorCount)
+        => MaximumConcurrentProcessing > 0 || DeriveConcurrentProcessing(availableMemoryBytes) < processorCount;
+
+    private static long DeriveConcurrentProcessing(long availableMemoryBytes)
+        => availableMemoryBytes / ConcurrencyMemoryShareDivisor / (EstimatedMegabytesPerImage * OneMegabyte);
 }

--- a/src/Umbraco.Core/Configuration/Models/ImagingMemorySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingMemorySettings.cs
@@ -17,6 +17,11 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 public class ImagingMemorySettings
 {
     /// <summary>
+    /// Whether image processing memory is managed by default.
+    /// </summary>
+    internal const bool StaticEnabled = true;
+
+    /// <summary>
     /// The default maximum pool size, in megabytes. Zero means it is derived from the available memory.
     /// </summary>
     internal const int StaticMaximumPoolSizeMegabytes = 0;
@@ -58,6 +63,18 @@ public class ImagingMemorySettings
     private const int MaximumDerivedPoolSizeMegabytes = 64;
 
     private const int OneMegabyte = 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether image processing memory is managed.
+    /// </summary>
+    /// <remarks>
+    /// When enabled (the default), the pool the imaging library retains between requests is capped and
+    /// the number of images decoded at the same time is bounded on hosts where memory is the binding
+    /// constraint. Set to <c>false</c> to leave the imaging library's own memory behaviour untouched -
+    /// neither the pool cap nor the concurrency bound is applied.
+    /// </remarks>
+    [DefaultValue(StaticEnabled)]
+    public bool Enabled { get; set; } = StaticEnabled;
 
     /// <summary>
     /// Gets or sets the maximum size, in megabytes, of the pool the imaging library retains for
@@ -141,7 +158,7 @@ public class ImagingMemorySettings
     /// requests the cache can serve without protecting against anything.
     /// </remarks>
     public bool RequiresConcurrencyLimit(long availableMemoryBytes, int processorCount)
-        => MaximumConcurrentProcessing > 0 || DeriveConcurrentProcessing(availableMemoryBytes) < processorCount;
+        => Enabled && (MaximumConcurrentProcessing > 0 || DeriveConcurrentProcessing(availableMemoryBytes) < processorCount);
 
     private static long DeriveConcurrentProcessing(long availableMemoryBytes)
         => availableMemoryBytes / ConcurrencyMemoryShareDivisor / (EstimatedMegabytesPerImage * OneMegabyte);

--- a/src/Umbraco.Core/Configuration/Models/ImagingMemorySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingMemorySettings.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.ComponentModel;
+
+namespace Umbraco.Cms.Core.Configuration.Models;
+
+/// <summary>
+/// Typed configuration options for the memory used while processing images.
+/// </summary>
+/// <remarks>
+/// Image processing decodes the full-resolution source into memory before it is resized, so peak
+/// memory scales with the number of images being processed at the same time rather than with the
+/// size of the response. On a host with a hard memory limit - a container, most commonly - an
+/// unbounded number of concurrent decodes will exhaust the limit and the process will be killed.
+/// </remarks>
+public class ImagingMemorySettings
+{
+    /// <summary>
+    /// The default maximum pool size, in megabytes. Zero means it is derived from the available memory.
+    /// </summary>
+    internal const int StaticMaximumPoolSizeMegabytes = 0;
+
+    /// <summary>
+    /// The default maximum number of images processed concurrently. Zero means it is derived from
+    /// the available memory.
+    /// </summary>
+    internal const int StaticMaximumConcurrentProcessing = 0;
+
+    /// <summary>
+    /// The share of available memory image processing is allowed to occupy when deriving
+    /// <see cref="MaximumConcurrentProcessing" />.
+    /// </summary>
+    /// <remarks>
+    /// The available memory reported for a container is already a fraction of its limit, so this
+    /// only has to leave room for the rest of the site rather than for the whole overhead again.
+    /// </remarks>
+    private const int ConcurrencyMemoryShareDivisor = 2;
+
+    /// <summary>
+    /// The assumed peak cost of processing a single image, in megabytes, when deriving
+    /// <see cref="MaximumConcurrentProcessing" />. Measured against a 12 megapixel JPEG source.
+    /// </summary>
+    private const int EstimatedMegabytesPerImage = 64;
+
+    /// <summary>
+    /// The share of available memory used when deriving <see cref="MaximumPoolSizeMegabytes" />.
+    /// </summary>
+    /// <remarks>
+    /// ImageSharp itself defaults to an eighth of available memory, which it releases only on a
+    /// gen2 collection and then only in halves, at most once a minute. A tighter pool trades a
+    /// little throughput for markedly lower memory at rest.
+    /// </remarks>
+    private const int PoolMemoryShareDivisor = 32;
+
+    private const int MinimumPoolSizeMegabytes = 16;
+
+    private const int MaximumDerivedPoolSizeMegabytes = 64;
+
+    private const int OneMegabyte = 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum size, in megabytes, of the pool the imaging library retains for
+    /// reuse between requests.
+    /// </summary>
+    /// <remarks>
+    /// This memory is unmanaged, so it is not governed by any of the <c>DOTNET_GC*</c> settings and
+    /// does not appear in the managed heap. Set to zero to derive a value from the available memory.
+    /// </remarks>
+    [DefaultValue(StaticMaximumPoolSizeMegabytes)]
+    public int MaximumPoolSizeMegabytes { get; set; } = StaticMaximumPoolSizeMegabytes;
+
+    /// <summary>
+    /// Gets or sets the maximum number of images that may be processed at the same time.
+    /// </summary>
+    /// <remarks>
+    /// Requests beyond this limit wait rather than being rejected. Set to zero to derive a value
+    /// from the available memory and processor count.
+    /// </remarks>
+    [DefaultValue(StaticMaximumConcurrentProcessing)]
+    public int MaximumConcurrentProcessing { get; set; } = StaticMaximumConcurrentProcessing;
+
+    /// <summary>
+    /// Resolves <see cref="MaximumPoolSizeMegabytes" />, deriving a value when it is not configured.
+    /// </summary>
+    /// <param name="availableMemoryBytes">
+    /// The memory available to the process, honouring any container limit. Typically
+    /// <see cref="GCMemoryInfo.TotalAvailableMemoryBytes" />.
+    /// </param>
+    /// <returns>The maximum pool size, in megabytes.</returns>
+    public int ResolveMaximumPoolSizeMegabytes(long availableMemoryBytes)
+    {
+        if (MaximumPoolSizeMegabytes > 0)
+        {
+            return MaximumPoolSizeMegabytes;
+        }
+
+        long derived = availableMemoryBytes / PoolMemoryShareDivisor / OneMegabyte;
+
+        return (int)Math.Clamp(derived, MinimumPoolSizeMegabytes, MaximumDerivedPoolSizeMegabytes);
+    }
+
+    /// <summary>
+    /// Resolves <see cref="MaximumConcurrentProcessing" />, deriving a value when it is not configured.
+    /// </summary>
+    /// <param name="availableMemoryBytes">
+    /// The memory available to the process, honouring any container limit. Typically
+    /// <see cref="GCMemoryInfo.TotalAvailableMemoryBytes" />.
+    /// </param>
+    /// <param name="processorCount">The number of processors available to the process.</param>
+    /// <returns>The maximum number of images to process concurrently.</returns>
+    public int ResolveMaximumConcurrentProcessing(long availableMemoryBytes, int processorCount)
+    {
+        if (MaximumConcurrentProcessing > 0)
+        {
+            return MaximumConcurrentProcessing;
+        }
+
+        long budgetBytes = availableMemoryBytes / ConcurrencyMemoryShareDivisor;
+        long derived = budgetBytes / (EstimatedMegabytesPerImage * OneMegabyte);
+
+        // Decoding is CPU bound, so more concurrency than processors buys nothing but memory.
+        return (int)Math.Clamp(derived, 1, Math.Max(processorCount, 1));
+    }
+}

--- a/src/Umbraco.Core/Configuration/Models/ImagingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ImagingSettings.cs
@@ -27,4 +27,9 @@ public class ImagingSettings
     /// Gets or sets a value for imaging resize settings.
     /// </summary>
     public ImagingResizeSettings Resize { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets a value for the memory used while processing images.
+    /// </summary>
+    public ImagingMemorySettings Memory { get; set; } = new();
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using SixLabors.ImageSharp.Web;
+using SixLabors.ImageSharp.Web.Commands;
+using SixLabors.ImageSharp.Web.Processors;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Imaging.ImageSharp;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Imaging.ImageSharp;
+
+[TestFixture]
+public class ImageProcessingThrottleMiddlewareTests
+{
+    private const int Limit = 2;
+    private const int RequestCount = 12;
+
+    [Test]
+    public async Task InvokeAsync_ProcessingRequests_NeverExceedTheConfiguredLimit()
+    {
+        var concurrency = 0;
+        var observedPeak = 0;
+        var released = new TaskCompletionSource();
+
+        var middleware = CreateMiddleware(async _ =>
+        {
+            var current = Interlocked.Increment(ref concurrency);
+            InterlockedMax(ref observedPeak, current);
+
+            await released.Task;
+
+            Interlocked.Decrement(ref concurrency);
+        });
+
+        Task[] requests = Enumerable
+            .Range(0, RequestCount)
+            .Select(_ => middleware.InvokeAsync(CreateContext(("width", "400"))))
+            .ToArray();
+
+        // Give every request the chance to reach the gate before letting any through.
+        await WaitUntilAsync(() => Volatile.Read(ref concurrency) >= Limit);
+        Assert.That(Volatile.Read(ref observedPeak), Is.EqualTo(Limit));
+
+        released.SetResult();
+        await Task.WhenAll(requests);
+
+        Assert.That(observedPeak, Is.EqualTo(Limit), "More images were processed concurrently than configured.");
+    }
+
+    [Test]
+    public async Task InvokeAsync_RequestsWithoutProcessingCommands_AreNotThrottled()
+    {
+        var concurrency = 0;
+        var observedPeak = 0;
+        var released = new TaskCompletionSource();
+
+        var middleware = CreateMiddleware(async _ =>
+        {
+            var current = Interlocked.Increment(ref concurrency);
+            InterlockedMax(ref observedPeak, current);
+
+            await released.Task;
+
+            Interlocked.Decrement(ref concurrency);
+        });
+
+        Task[] requests = Enumerable
+            .Range(0, RequestCount)
+            .Select(_ => middleware.InvokeAsync(CreateContext(("v", "1234"))))
+            .ToArray();
+
+        await WaitUntilAsync(() => Volatile.Read(ref concurrency) >= RequestCount);
+
+        released.SetResult();
+        await Task.WhenAll(requests);
+
+        Assert.That(observedPeak, Is.EqualTo(RequestCount));
+    }
+
+    [Test]
+    public async Task InvokeAsync_RequestsWithoutAFileExtension_AreNotThrottled()
+    {
+        var concurrency = 0;
+        var observedPeak = 0;
+        var released = new TaskCompletionSource();
+
+        var middleware = CreateMiddleware(async _ =>
+        {
+            var current = Interlocked.Increment(ref concurrency);
+            InterlockedMax(ref observedPeak, current);
+
+            await released.Task;
+
+            Interlocked.Decrement(ref concurrency);
+        });
+
+        // An API call that happens to carry a "width" must not queue behind image processing.
+        Task[] requests = Enumerable
+            .Range(0, RequestCount)
+            .Select(_ => middleware.InvokeAsync(CreateContext("/umbraco/management/api/v1/tree", ("width", "400"))))
+            .ToArray();
+
+        await WaitUntilAsync(() => Volatile.Read(ref concurrency) >= RequestCount);
+
+        released.SetResult();
+        await Task.WhenAll(requests);
+
+        Assert.That(observedPeak, Is.EqualTo(RequestCount));
+    }
+
+    [Test]
+    public async Task InvokeAsync_ReleasesTheSlot_WhenTheRequestThrows()
+    {
+        var shouldThrow = true;
+        var completed = false;
+
+        // One middleware throughout, so the assertion is about this instance's semaphore.
+        var middleware = CreateMiddleware(_ =>
+        {
+            if (shouldThrow)
+            {
+                throw new InvalidOperationException("Decoding failed.");
+            }
+
+            completed = true;
+            return Task.CompletedTask;
+        });
+
+        // Exactly Limit failures, so every slot is consumed. Going further would block here rather
+        // than reaching the guarded assertion below.
+        for (var i = 0; i < Limit; i++)
+        {
+            Assert.ThrowsAsync<InvalidOperationException>(
+                () => middleware.InvokeAsync(CreateContext(("width", "400"))));
+        }
+
+        shouldThrow = false;
+
+        // Every slot would be leaked by now if the release were not in a finally, leaving the gate
+        // permanently closed and this waiting forever.
+        Task request = middleware.InvokeAsync(CreateContext(("width", "400")));
+        Task winner = await Task.WhenAny(request, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        Assert.That(winner, Is.SameAs(request), "The semaphore slot was not released after the failure.");
+        await request;
+        Assert.That(completed, Is.True);
+    }
+
+    private static ImageProcessingThrottleMiddleware CreateMiddleware(RequestDelegate next)
+    {
+        var settings = new ImagingSettings
+        {
+            Memory = new ImagingMemorySettings { MaximumConcurrentProcessing = Limit },
+        };
+
+        return new ImageProcessingThrottleMiddleware(
+            next,
+            Options.Create(settings),
+            new IImageWebProcessor[] { new TestImageWebProcessor() });
+    }
+
+    private static DefaultHttpContext CreateContext(params (string Key, string Value)[] query)
+        => CreateContext("/media/image.jpg", query);
+
+    private static DefaultHttpContext CreateContext(string path, params (string Key, string Value)[] query)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.QueryString = QueryString.Create(query.Select(x => new KeyValuePair<string, string?>(x.Key, x.Value)));
+        return context;
+    }
+
+    private static void InterlockedMax(ref int target, int value)
+    {
+        int current;
+        while (value > (current = Volatile.Read(ref target)))
+        {
+            if (Interlocked.CompareExchange(ref target, value, current) == current)
+            {
+                return;
+            }
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (!condition())
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            await Task.Delay(10, timeout.Token);
+        }
+    }
+
+    private sealed class TestImageWebProcessor : IImageWebProcessor
+    {
+        public IEnumerable<string> Commands { get; } = new[] { "width", "height" };
+
+        public FormattedImage Process(
+            FormattedImage image,
+            ILogger logger,
+            CommandCollection commands,
+            CommandParser parser,
+            CultureInfo culture) => image;
+
+        public bool RequiresTrueColorPixelFormat(CommandCollection commands, CommandParser parser, CultureInfo culture)
+            => false;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
@@ -114,6 +114,27 @@ public class ImageProcessingThrottleMiddlewareTests
     }
 
     [Test]
+    public async Task InvokeAsync_RequestsWithNoPath_AreNotThrottled()
+    {
+        var handled = false;
+        var middleware = CreateMiddleware(_ =>
+        {
+            handled = true;
+            return Task.CompletedTask;
+        });
+
+        // PathString.Empty exposes a null Value, which the extension check has to treat as
+        // "not an image request" rather than faulting the pipeline.
+        var context = new DefaultHttpContext();
+        context.Request.Path = PathString.Empty;
+        context.Request.QueryString = QueryString.Create("width", "400");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.That(handled, Is.True);
+    }
+
+    [Test]
     public async Task InvokeAsync_ReleasesTheSlot_WhenTheRequestThrows()
     {
         var shouldThrow = true;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
@@ -40,20 +40,8 @@ public class ImageProcessingThrottleMiddlewareTests
     // something the imaging middleware will process, so neither may queue behind it.
     [TestCase(ImagePath, "v", "1234")]
     [TestCase("/umbraco/management/api/v1/tree", "width", "400")]
-    public async Task InvokeAsync_NonProcessingRequests_AreNotThrottled(string path, string key, string value)
-    {
-        var probe = new ConcurrencyProbe();
-        var middleware = CreateMiddleware(probe.HandleAsync);
-
-        Task[] requests = Send(middleware, () => CreateContext(path, (key, value)));
-
-        await WaitUntilAsync(() => probe.Current >= RequestCount);
-
-        probe.Release();
-        await Task.WhenAll(requests);
-
-        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
-    }
+    public Task InvokeAsync_NonProcessingRequests_AreNotThrottled(string path, string key, string value)
+        => AssertAllRequestsPassThrough(CreateMiddleware, () => CreateContext(path, (key, value)));
 
     [Test]
     public async Task InvokeAsync_RequestsWithNoPath_AreNotThrottled()
@@ -76,42 +64,16 @@ public class ImageProcessingThrottleMiddlewareTests
         Assert.That(handled, Is.True);
     }
 
+    // Ample memory for a single processor: the processor count already bounds concurrent decodes,
+    // so the gate steps aside rather than serialising requests the cache could serve.
     [Test]
-    public async Task InvokeAsync_WhenMemoryIsNotConstrained_DoesNotThrottle()
-    {
-        var probe = new ConcurrencyProbe();
+    public Task InvokeAsync_WhenMemoryIsNotConstrained_DoesNotThrottle()
+        => AssertAllRequestsPassThrough(CreateUnconstrainedMiddleware, () => CreateContext(ImagePath, ("width", "400")));
 
-        // Ample memory for a single processor: the processor count already bounds concurrent
-        // decodes, so the gate steps aside rather than serialising requests the cache could serve.
-        var middleware = CreateUnconstrainedMiddleware(probe.HandleAsync);
-
-        Task[] requests = Send(middleware, () => CreateContext(ImagePath, ("width", "400")));
-
-        await WaitUntilAsync(() => probe.Current >= RequestCount);
-
-        probe.Release();
-        await Task.WhenAll(requests);
-
-        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
-    }
-
+    // An explicit limit is set, but the feature is switched off, so nothing is gated.
     [Test]
-    public async Task InvokeAsync_WhenDisabled_DoesNotThrottle()
-    {
-        var probe = new ConcurrencyProbe();
-
-        // An explicit limit is set, but the feature is switched off, so nothing is gated.
-        var middleware = CreateDisabledMiddleware(probe.HandleAsync);
-
-        Task[] requests = Send(middleware, () => CreateContext(ImagePath, ("width", "400")));
-
-        await WaitUntilAsync(() => probe.Current >= RequestCount);
-
-        probe.Release();
-        await Task.WhenAll(requests);
-
-        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
-    }
+    public Task InvokeAsync_WhenDisabled_DoesNotThrottle()
+        => AssertAllRequestsPassThrough(CreateDisabledMiddleware, () => CreateContext(ImagePath, ("width", "400")));
 
     [Test]
     public async Task InvokeAsync_ReleasesTheSlot_WhenTheRequestThrows()
@@ -177,6 +139,23 @@ public class ImageProcessingThrottleMiddlewareTests
         return availableMemoryBytes is { } memoryBytes && processorCount is { } cores
             ? new ImageProcessingThrottleMiddleware(next, Options.Create(settings), processors, memoryBytes, cores)
             : new ImageProcessingThrottleMiddleware(next, Options.Create(settings), processors);
+    }
+
+    private static async Task AssertAllRequestsPassThrough(
+        Func<RequestDelegate, ImageProcessingThrottleMiddleware> create,
+        Func<DefaultHttpContext> context)
+    {
+        var probe = new ConcurrencyProbe();
+        var middleware = create(probe.HandleAsync);
+
+        Task[] requests = Send(middleware, context);
+
+        await WaitUntilAsync(() => probe.Current >= RequestCount);
+
+        probe.Release();
+        await Task.WhenAll(requests);
+
+        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
     }
 
     private static Task[] Send(ImageProcessingThrottleMiddleware middleware, Func<DefaultHttpContext> context)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
@@ -96,6 +96,24 @@ public class ImageProcessingThrottleMiddlewareTests
     }
 
     [Test]
+    public async Task InvokeAsync_WhenDisabled_DoesNotThrottle()
+    {
+        var probe = new ConcurrencyProbe();
+
+        // An explicit limit is set, but the feature is switched off, so nothing is gated.
+        var middleware = CreateDisabledMiddleware(probe.HandleAsync);
+
+        Task[] requests = Send(middleware, () => CreateContext(ImagePath, ("width", "400")));
+
+        await WaitUntilAsync(() => probe.Current >= RequestCount);
+
+        probe.Release();
+        await Task.WhenAll(requests);
+
+        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
+    }
+
+    [Test]
     public async Task InvokeAsync_ReleasesTheSlot_WhenTheRequestThrows()
     {
         var shouldThrow = true;
@@ -164,6 +182,22 @@ public class ImageProcessingThrottleMiddlewareTests
             new[] { processor.Object },
             availableMemoryBytes: 2048L * 1024 * 1024,
             processorCount: 1);
+    }
+
+    private static ImageProcessingThrottleMiddleware CreateDisabledMiddleware(RequestDelegate next)
+    {
+        var settings = new ImagingSettings
+        {
+            Memory = new ImagingMemorySettings { Enabled = false, MaximumConcurrentProcessing = Limit },
+        };
+
+        var processor = new Mock<IImageWebProcessor>();
+        processor.SetupGet(x => x.Commands).Returns(new[] { "width", "height" });
+
+        return new ImageProcessingThrottleMiddleware(
+            next,
+            Options.Create(settings),
+            new[] { processor.Object });
     }
 
     private static Task[] Send(ImageProcessingThrottleMiddleware middleware, Func<DefaultHttpContext> context)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
@@ -152,52 +152,31 @@ public class ImageProcessingThrottleMiddlewareTests
     }
 
     private static ImageProcessingThrottleMiddleware CreateMiddleware(RequestDelegate next)
-    {
-        var settings = new ImagingSettings
-        {
-            Memory = new ImagingMemorySettings { MaximumConcurrentProcessing = Limit },
-        };
-
-        var processor = new Mock<IImageWebProcessor>();
-        processor.SetupGet(x => x.Commands).Returns(new[] { "width", "height" });
-
-        return new ImageProcessingThrottleMiddleware(
-            next,
-            Options.Create(settings),
-            new[] { processor.Object });
-    }
-
-    private static ImageProcessingThrottleMiddleware CreateUnconstrainedMiddleware(RequestDelegate next)
-    {
-        // Derived settings (zero) against 2 GB and a single processor, so memory is not the binding
-        // constraint and no limit is enforced.
-        var settings = new ImagingSettings { Memory = new ImagingMemorySettings() };
-
-        var processor = new Mock<IImageWebProcessor>();
-        processor.SetupGet(x => x.Commands).Returns(new[] { "width", "height" });
-
-        return new ImageProcessingThrottleMiddleware(
-            next,
-            Options.Create(settings),
-            new[] { processor.Object },
-            availableMemoryBytes: 2048L * 1024 * 1024,
-            processorCount: 1);
-    }
+        => Build(next, new ImagingMemorySettings { MaximumConcurrentProcessing = Limit });
 
     private static ImageProcessingThrottleMiddleware CreateDisabledMiddleware(RequestDelegate next)
+        => Build(next, new ImagingMemorySettings { Enabled = false, MaximumConcurrentProcessing = Limit });
+
+    // Derived settings (zero) against 2 GB and a single processor, so memory is not the binding
+    // constraint and no limit is enforced.
+    private static ImageProcessingThrottleMiddleware CreateUnconstrainedMiddleware(RequestDelegate next)
+        => Build(next, new ImagingMemorySettings(), availableMemoryBytes: 2048L * 1024 * 1024, processorCount: 1);
+
+    private static ImageProcessingThrottleMiddleware Build(
+        RequestDelegate next,
+        ImagingMemorySettings memory,
+        long? availableMemoryBytes = null,
+        int? processorCount = null)
     {
-        var settings = new ImagingSettings
-        {
-            Memory = new ImagingMemorySettings { Enabled = false, MaximumConcurrentProcessing = Limit },
-        };
+        var settings = new ImagingSettings { Memory = memory };
 
         var processor = new Mock<IImageWebProcessor>();
         processor.SetupGet(x => x.Commands).Returns(new[] { "width", "height" });
+        IImageWebProcessor[] processors = { processor.Object };
 
-        return new ImageProcessingThrottleMiddleware(
-            next,
-            Options.Create(settings),
-            new[] { processor.Object });
+        return availableMemoryBytes is { } memoryBytes && processorCount is { } cores
+            ? new ImageProcessingThrottleMiddleware(next, Options.Create(settings), processors, memoryBytes, cores)
+            : new ImageProcessingThrottleMiddleware(next, Options.Create(settings), processors);
     }
 
     private static Task[] Send(ImageProcessingThrottleMiddleware middleware, Func<DefaultHttpContext> context)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
@@ -36,30 +36,16 @@ public class ImageProcessingThrottleMiddlewareTests
         Assert.That(probe.Peak, Is.EqualTo(Limit), "More images were processed concurrently than configured.");
     }
 
-    [Test]
-    public async Task InvokeAsync_RequestsWithoutProcessingCommands_AreNotThrottled()
+    // A file with no processing command, and an API call that happens to carry one: neither is
+    // something the imaging middleware will process, so neither may queue behind it.
+    [TestCase(ImagePath, "v", "1234")]
+    [TestCase("/umbraco/management/api/v1/tree", "width", "400")]
+    public async Task InvokeAsync_NonProcessingRequests_AreNotThrottled(string path, string key, string value)
     {
         var probe = new ConcurrencyProbe();
         var middleware = CreateMiddleware(probe.HandleAsync);
 
-        Task[] requests = Send(middleware, () => CreateContext(ImagePath, ("v", "1234")));
-
-        await WaitUntilAsync(() => probe.Current >= RequestCount);
-
-        probe.Release();
-        await Task.WhenAll(requests);
-
-        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
-    }
-
-    [Test]
-    public async Task InvokeAsync_RequestsWithoutAFileExtension_AreNotThrottled()
-    {
-        var probe = new ConcurrencyProbe();
-        var middleware = CreateMiddleware(probe.HandleAsync);
-
-        // An API call that happens to carry a "width" must not queue behind image processing.
-        Task[] requests = Send(middleware, () => CreateContext("/umbraco/management/api/v1/tree", ("width", "400")));
+        Task[] requests = Send(middleware, () => CreateContext(path, (key, value)));
 
         await WaitUntilAsync(() => probe.Current >= RequestCount);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
@@ -77,6 +77,25 @@ public class ImageProcessingThrottleMiddlewareTests
     }
 
     [Test]
+    public async Task InvokeAsync_WhenMemoryIsNotConstrained_DoesNotThrottle()
+    {
+        var probe = new ConcurrencyProbe();
+
+        // Ample memory for a single processor: the processor count already bounds concurrent
+        // decodes, so the gate steps aside rather than serialising requests the cache could serve.
+        var middleware = CreateUnconstrainedMiddleware(probe.HandleAsync);
+
+        Task[] requests = Send(middleware, () => CreateContext(ImagePath, ("width", "400")));
+
+        await WaitUntilAsync(() => probe.Current >= RequestCount);
+
+        probe.Release();
+        await Task.WhenAll(requests);
+
+        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
+    }
+
+    [Test]
     public async Task InvokeAsync_ReleasesTheSlot_WhenTheRequestThrows()
     {
         var shouldThrow = true;
@@ -128,6 +147,23 @@ public class ImageProcessingThrottleMiddlewareTests
             next,
             Options.Create(settings),
             new[] { processor.Object });
+    }
+
+    private static ImageProcessingThrottleMiddleware CreateUnconstrainedMiddleware(RequestDelegate next)
+    {
+        // Derived settings (zero) against 2 GB and a single processor, so memory is not the binding
+        // constraint and no limit is enforced.
+        var settings = new ImagingSettings { Memory = new ImagingMemorySettings() };
+
+        var processor = new Mock<IImageWebProcessor>();
+        processor.SetupGet(x => x.Commands).Returns(new[] { "width", "height" });
+
+        return new ImageProcessingThrottleMiddleware(
+            next,
+            Options.Create(settings),
+            new[] { processor.Object },
+            availableMemoryBytes: 2048L * 1024 * 1024,
+            processorCount: 1);
     }
 
     private static Task[] Send(ImageProcessingThrottleMiddleware middleware, Func<DefaultHttpContext> context)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Imaging.ImageSharp/ImageProcessingThrottleMiddlewareTests.cs
@@ -1,13 +1,10 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Globalization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Moq;
 using NUnit.Framework;
-using SixLabors.ImageSharp.Web;
-using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Processors;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Imaging.ImageSharp;
@@ -19,98 +16,57 @@ public class ImageProcessingThrottleMiddlewareTests
 {
     private const int Limit = 2;
     private const int RequestCount = 12;
+    private const string ImagePath = "/media/image.jpg";
 
     [Test]
     public async Task InvokeAsync_ProcessingRequests_NeverExceedTheConfiguredLimit()
     {
-        var concurrency = 0;
-        var observedPeak = 0;
-        var released = new TaskCompletionSource();
+        var probe = new ConcurrencyProbe();
+        var middleware = CreateMiddleware(probe.HandleAsync);
 
-        var middleware = CreateMiddleware(async _ =>
-        {
-            var current = Interlocked.Increment(ref concurrency);
-            InterlockedMax(ref observedPeak, current);
+        Task[] requests = Send(middleware, () => CreateContext(ImagePath, ("width", "400")));
 
-            await released.Task;
+        // Let every request reach the gate before any is allowed through.
+        await WaitUntilAsync(() => probe.Current >= Limit);
+        Assert.That(probe.Peak, Is.EqualTo(Limit));
 
-            Interlocked.Decrement(ref concurrency);
-        });
-
-        Task[] requests = Enumerable
-            .Range(0, RequestCount)
-            .Select(_ => middleware.InvokeAsync(CreateContext(("width", "400"))))
-            .ToArray();
-
-        // Give every request the chance to reach the gate before letting any through.
-        await WaitUntilAsync(() => Volatile.Read(ref concurrency) >= Limit);
-        Assert.That(Volatile.Read(ref observedPeak), Is.EqualTo(Limit));
-
-        released.SetResult();
+        probe.Release();
         await Task.WhenAll(requests);
 
-        Assert.That(observedPeak, Is.EqualTo(Limit), "More images were processed concurrently than configured.");
+        Assert.That(probe.Peak, Is.EqualTo(Limit), "More images were processed concurrently than configured.");
     }
 
     [Test]
     public async Task InvokeAsync_RequestsWithoutProcessingCommands_AreNotThrottled()
     {
-        var concurrency = 0;
-        var observedPeak = 0;
-        var released = new TaskCompletionSource();
+        var probe = new ConcurrencyProbe();
+        var middleware = CreateMiddleware(probe.HandleAsync);
 
-        var middleware = CreateMiddleware(async _ =>
-        {
-            var current = Interlocked.Increment(ref concurrency);
-            InterlockedMax(ref observedPeak, current);
+        Task[] requests = Send(middleware, () => CreateContext(ImagePath, ("v", "1234")));
 
-            await released.Task;
+        await WaitUntilAsync(() => probe.Current >= RequestCount);
 
-            Interlocked.Decrement(ref concurrency);
-        });
-
-        Task[] requests = Enumerable
-            .Range(0, RequestCount)
-            .Select(_ => middleware.InvokeAsync(CreateContext(("v", "1234"))))
-            .ToArray();
-
-        await WaitUntilAsync(() => Volatile.Read(ref concurrency) >= RequestCount);
-
-        released.SetResult();
+        probe.Release();
         await Task.WhenAll(requests);
 
-        Assert.That(observedPeak, Is.EqualTo(RequestCount));
+        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
     }
 
     [Test]
     public async Task InvokeAsync_RequestsWithoutAFileExtension_AreNotThrottled()
     {
-        var concurrency = 0;
-        var observedPeak = 0;
-        var released = new TaskCompletionSource();
-
-        var middleware = CreateMiddleware(async _ =>
-        {
-            var current = Interlocked.Increment(ref concurrency);
-            InterlockedMax(ref observedPeak, current);
-
-            await released.Task;
-
-            Interlocked.Decrement(ref concurrency);
-        });
+        var probe = new ConcurrencyProbe();
+        var middleware = CreateMiddleware(probe.HandleAsync);
 
         // An API call that happens to carry a "width" must not queue behind image processing.
-        Task[] requests = Enumerable
-            .Range(0, RequestCount)
-            .Select(_ => middleware.InvokeAsync(CreateContext("/umbraco/management/api/v1/tree", ("width", "400"))))
-            .ToArray();
+        Task[] requests = Send(middleware, () => CreateContext("/umbraco/management/api/v1/tree", ("width", "400")));
 
-        await WaitUntilAsync(() => Volatile.Read(ref concurrency) >= RequestCount);
+        await WaitUntilAsync(() => probe.Current >= RequestCount);
 
-        released.SetResult();
+        probe.Release();
         await Task.WhenAll(requests);
 
-        Assert.That(observedPeak, Is.EqualTo(RequestCount));
+        Assert.That(probe.Peak, Is.EqualTo(RequestCount));
     }
 
     [Test]
@@ -157,14 +113,14 @@ public class ImageProcessingThrottleMiddlewareTests
         for (var i = 0; i < Limit; i++)
         {
             Assert.ThrowsAsync<InvalidOperationException>(
-                () => middleware.InvokeAsync(CreateContext(("width", "400"))));
+                () => middleware.InvokeAsync(CreateContext(ImagePath, ("width", "400"))));
         }
 
         shouldThrow = false;
 
         // Every slot would be leaked by now if the release were not in a finally, leaving the gate
         // permanently closed and this waiting forever.
-        Task request = middleware.InvokeAsync(CreateContext(("width", "400")));
+        Task request = middleware.InvokeAsync(CreateContext(ImagePath, ("width", "400")));
         Task winner = await Task.WhenAny(request, Task.Delay(TimeSpan.FromSeconds(10)));
 
         Assert.That(winner, Is.SameAs(request), "The semaphore slot was not released after the failure.");
@@ -179,14 +135,20 @@ public class ImageProcessingThrottleMiddlewareTests
             Memory = new ImagingMemorySettings { MaximumConcurrentProcessing = Limit },
         };
 
+        var processor = new Mock<IImageWebProcessor>();
+        processor.SetupGet(x => x.Commands).Returns(new[] { "width", "height" });
+
         return new ImageProcessingThrottleMiddleware(
             next,
             Options.Create(settings),
-            new IImageWebProcessor[] { new TestImageWebProcessor() });
+            new[] { processor.Object });
     }
 
-    private static DefaultHttpContext CreateContext(params (string Key, string Value)[] query)
-        => CreateContext("/media/image.jpg", query);
+    private static Task[] Send(ImageProcessingThrottleMiddleware middleware, Func<DefaultHttpContext> context)
+        => Enumerable
+            .Range(0, RequestCount)
+            .Select(_ => middleware.InvokeAsync(context()))
+            .ToArray();
 
     private static DefaultHttpContext CreateContext(string path, params (string Key, string Value)[] query)
     {
@@ -194,18 +156,6 @@ public class ImageProcessingThrottleMiddlewareTests
         context.Request.Path = path;
         context.Request.QueryString = QueryString.Create(query.Select(x => new KeyValuePair<string, string?>(x.Key, x.Value)));
         return context;
-    }
-
-    private static void InterlockedMax(ref int target, int value)
-    {
-        int current;
-        while (value > (current = Volatile.Read(ref target)))
-        {
-            if (Interlocked.CompareExchange(ref target, value, current) == current)
-            {
-                return;
-            }
-        }
     }
 
     private static async Task WaitUntilAsync(Func<bool> condition)
@@ -218,18 +168,41 @@ public class ImageProcessingThrottleMiddlewareTests
         }
     }
 
-    private sealed class TestImageWebProcessor : IImageWebProcessor
+    /// <summary>
+    /// Holds every request inside the middleware until released, recording how many were in flight
+    /// at once so a test can assert what the throttle actually allowed through.
+    /// </summary>
+    private sealed class ConcurrencyProbe
     {
-        public IEnumerable<string> Commands { get; } = new[] { "width", "height" };
+        private readonly TaskCompletionSource _released = new();
+        private int _current;
+        private int _peak;
 
-        public FormattedImage Process(
-            FormattedImage image,
-            ILogger logger,
-            CommandCollection commands,
-            CommandParser parser,
-            CultureInfo culture) => image;
+        public int Current => Volatile.Read(ref _current);
 
-        public bool RequiresTrueColorPixelFormat(CommandCollection commands, CommandParser parser, CultureInfo culture)
-            => false;
+        public int Peak => Volatile.Read(ref _peak);
+
+        public void Release() => _released.SetResult();
+
+        public async Task HandleAsync(HttpContext context)
+        {
+            RecordPeak(Interlocked.Increment(ref _current));
+
+            await _released.Task;
+
+            Interlocked.Decrement(ref _current);
+        }
+
+        private void RecordPeak(int value)
+        {
+            int current;
+            while (value > (current = Volatile.Read(ref _peak)))
+            {
+                if (Interlocked.CompareExchange(ref _peak, value, current) == current)
+                {
+                    return;
+                }
+            }
+        }
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/ImagingMemorySettingsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/ImagingMemorySettingsTests.cs
@@ -82,4 +82,41 @@ public class ImagingMemorySettingsTests
 
         Assert.That(settings.ResolveMaximumConcurrentProcessing(16 * OneMegabyte, 1), Is.EqualTo(1));
     }
+
+    [Test]
+    public void RequiresConcurrencyLimit_WhenConfigured_IsAlwaysTrue()
+    {
+        var settings = new ImagingMemorySettings { MaximumConcurrentProcessing = 4 };
+
+        // Explicit configuration is honoured even on a host with memory to spare.
+        Assert.That(settings.RequiresConcurrencyLimit(64L * 1024 * OneMegabyte, 4), Is.True);
+    }
+
+    // Memory is the binding constraint: it affords fewer concurrent decodes than there are
+    // processors, so an unbounded page of thumbnails would exhaust it.
+    [TestCase(384, 28)] // Many cores, little memory - the container that gets OOM-killed.
+    [TestCase(256, 8)]
+    [TestCase(1024, 32)]
+    public void RequiresConcurrencyLimit_WhenMemoryIsTheBindingConstraint_IsTrue(
+        int availableMegabytes,
+        int processorCount)
+    {
+        var settings = new ImagingMemorySettings();
+
+        Assert.That(settings.RequiresConcurrencyLimit(availableMegabytes * OneMegabyte, processorCount), Is.True);
+    }
+
+    // The processor count already bounds concurrent decodes below what memory could hold, so a
+    // limit would only add latency without preventing anything.
+    [TestCase(512, 4)] // Derived concurrency equals the processor count - not strictly constrained.
+    [TestCase(2048, 4)]
+    [TestCase(65536, 8)]
+    public void RequiresConcurrencyLimit_WhenMemoryIsNotTheBindingConstraint_IsFalse(
+        int availableMegabytes,
+        int processorCount)
+    {
+        var settings = new ImagingMemorySettings();
+
+        Assert.That(settings.RequiresConcurrencyLimit(availableMegabytes * OneMegabyte, processorCount), Is.False);
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/ImagingMemorySettingsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/ImagingMemorySettingsTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Configuration.Models;
+
+[TestFixture]
+public class ImagingMemorySettingsTests
+{
+    private const long OneMegabyte = 1024 * 1024;
+
+    [Test]
+    public void ResolveMaximumPoolSizeMegabytes_WhenConfigured_UsesConfiguredValue()
+    {
+        var settings = new ImagingMemorySettings { MaximumPoolSizeMegabytes = 256 };
+
+        Assert.That(settings.ResolveMaximumPoolSizeMegabytes(512 * OneMegabyte), Is.EqualTo(256));
+    }
+
+    [TestCase(512, 16)] // Clamped to the minimum.
+    [TestCase(2048, 64)]
+    [TestCase(16384, 64)] // Clamped to the maximum.
+    public void ResolveMaximumPoolSizeMegabytes_WhenNotConfigured_DerivesFromAvailableMemory(
+        int availableMegabytes,
+        int expected)
+    {
+        var settings = new ImagingMemorySettings();
+
+        Assert.That(settings.ResolveMaximumPoolSizeMegabytes(availableMegabytes * OneMegabyte), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ResolveMaximumPoolSizeMegabytes_StaysWellBelowTheImageSharpDefault()
+    {
+        // ImageSharp defaults to an eighth of available memory, which is what leaves a container
+        // sitting far above its working set at rest.
+        const long available = 2048 * OneMegabyte;
+        var imageSharpDefaultMegabytes = (int)(available / 8 / OneMegabyte);
+
+        var resolved = new ImagingMemorySettings().ResolveMaximumPoolSizeMegabytes(available);
+
+        Assert.That(resolved, Is.LessThan(imageSharpDefaultMegabytes));
+    }
+
+    [Test]
+    public void ResolveMaximumConcurrentProcessing_WhenConfigured_UsesConfiguredValue()
+    {
+        var settings = new ImagingMemorySettings { MaximumConcurrentProcessing = 12 };
+
+        Assert.That(settings.ResolveMaximumConcurrentProcessing(512 * OneMegabyte, 4), Is.EqualTo(12));
+    }
+
+    [TestCase(512, 32, 4)]
+    [TestCase(1024, 32, 8)]
+    [TestCase(2048, 32, 16)]
+    public void ResolveMaximumConcurrentProcessing_WhenNotConfigured_DerivesFromAvailableMemory(
+        int availableMegabytes,
+        int processorCount,
+        int expected)
+    {
+        var settings = new ImagingMemorySettings();
+
+        Assert.That(
+            settings.ResolveMaximumConcurrentProcessing(availableMegabytes * OneMegabyte, processorCount),
+            Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ResolveMaximumConcurrentProcessing_IsCappedByProcessorCount()
+    {
+        var settings = new ImagingMemorySettings();
+
+        Assert.That(settings.ResolveMaximumConcurrentProcessing(64L * 1024 * OneMegabyte, 4), Is.EqualTo(4));
+    }
+
+    [Test]
+    public void ResolveMaximumConcurrentProcessing_NeverReturnsLessThanOne()
+    {
+        var settings = new ImagingMemorySettings();
+
+        Assert.That(settings.ResolveMaximumConcurrentProcessing(16 * OneMegabyte, 1), Is.EqualTo(1));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/ImagingMemorySettingsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/ImagingMemorySettingsTests.cs
@@ -119,4 +119,14 @@ public class ImagingMemorySettingsTests
 
         Assert.That(settings.RequiresConcurrencyLimit(availableMegabytes * OneMegabyte, processorCount), Is.False);
     }
+
+    [Test]
+    public void RequiresConcurrencyLimit_WhenDisabled_IsFalse()
+    {
+        // Disabled wins over both an explicit limit and a memory-constrained host - the whole
+        // feature is off.
+        var settings = new ImagingMemorySettings { Enabled = false, MaximumConcurrentProcessing = 4 };
+
+        Assert.That(settings.RequiresConcurrencyLimit(384 * OneMegabyte, 28), Is.False);
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Umbraco.Cms.Imaging.ImageSharp\Umbraco.Cms.Imaging.ImageSharp.csproj" />
     <ProjectReference Include="..\Umbraco.Tests.Common\Umbraco.Tests.Common.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23556

Fixes #23556

> v13 (LTS) counterpart of #23557 (v17) and #23558 (v18). v13 ships the same SixLabors.ImageSharp 3.1.12 and the same registration - `Configuration.Default` with no allocator cap, and `PrePipeline = UseImageSharp()` with nothing ahead of it - so it is affected identically. The imaging projects have no CLAUDE.md on this branch, so that part of the v17/v18 change is omitted here.

### Multiple PRs, one for each version:

Notice this PR has two other related PRs with the same fix for other versions:
V13: https://github.com/umbraco/Umbraco-CMS/pull/23559
V17: https://github.com/umbraco/Umbraco-CMS/pull/23557
V18: https://github.com/umbraco/Umbraco-CMS/pull/23558

### Description

On a host with a hard memory limit — a Linux container, most commonly — browsing the media section
grows memory until the process is OOM-killed (exit 137). Windows hosts are not affected in the same
way, and `DOTNET_GC*` settings make no difference, which is what makes it look like a leak.

It is not a leak. `ImageSharpMiddleware` decodes the source image at **full resolution** before any
processor runs, and it only de-duplicates concurrent requests for the **same** URL. A media grid
renders a screenful of *distinct* thumbnails, so every source decodes in parallel with no ceiling.
Peak memory is `concurrent requests × decoded source size`, which is unbounded.

Measured with `VmHWM` (peak RSS), one request, no concurrency: **a single 300×300 thumbnail of a
4000×3000 JPEG costs +60 MB**. Sixteen concurrent thumbnail requests is ~960 MB, so a 512 MB
container dies in seconds.

Two things make the memory look like it is never released, both **unmanaged** and therefore outside
anything `DOTNET_GC*` controls:

1. ImageSharp's pool is sized at `GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / 8` and trims only
   on a gen2 collection, at most 50% per 60 s unless memory load exceeds 90%. Measured: 176 MB still
   held at idle in a 2 GB container, surviving a *forced* gen2 collection.
2. The blocks come from `Marshal.AllocHGlobal` (= `malloc`); `malloc_trim(0)` released a further
   20–45 MB that GC alone did not. That is glibc retention, hence the Linux/Windows difference.

#### What this changes

A new `Umbraco:CMS:Imaging:Memory` section (`ImagingMemorySettings`) with two values, both
defaulting to `0` meaning "derive from the memory available to the process":

| Setting | Purpose | Derived default |
|---------|---------|-----------------|
| `MaximumPoolSizeMegabytes` | Caps the unmanaged buffer pool ImageSharp retains between requests | available / 32, clamped to 16–64 MB |
| `MaximumConcurrentProcessing` | Caps how many images are processed at once | (available / 2) / 64 MB, capped at processor count |

The concurrency cap is enforced by a new `ImageProcessingThrottleMiddleware`, registered ahead of
`UseImageSharp()` in the pre-pipeline. Requests over the limit **wait** rather than being rejected,
and only requests whose path has a file extension *and* whose query carries a registered processor
command are gated — so an API call that happens to carry a `width` is not affected.

Applied to both `Umbraco.Cms.Imaging.ImageSharp` and `Umbraco.Cms.Imaging.ImageSharp2`.

Nothing is obsoleted and no existing signature changes. On a host without a container limit the
derived concurrency lands at the processor count, so non-containerised sites are effectively
unthrottled and unchanged.

### How to test

Reproduction and verification were done with a minimal ASP.NET Core app configured identically to
`AddUmbracoImageSharp()` (`ClearProviders()`, `WebRootImageProvider`, Umbraco's `CropWebProcessor`,
`ConfigureImageSharpMiddlewareOptions`, `PhysicalFileSystemCache`), on
`mcr.microsoft.com/dotnet/aspnet:10.0-noble`, cgroup v2, with ImageSharp 3.1.12 / ImageSharp.Web
3.2.0. Media: 40 JPEGs at 4000×3000 (~9.5 MB each). Every request is a distinct crop/resize, so
every request is a cache miss.

To reproduce against a real site instead:

1. Run Umbraco in Docker with `--memory=512m` on an Ubuntu-based `aspnet` image.
2. Upload a few dozen 4000×3000 JPEGs to the media section.
3. Browse the media section page by page so each page requests a screenful of distinct thumbnails
   not yet in the media cache.
4. Watch `docker stats`. Before this change the container is OOM-killed; after it is not.

#### Results

Same load that produced exit 137 (512 MB limit, 16 concurrent distinct crop requests):

| | before | after |
|---|---|---|
| outcome | **OOMKilled, exit 137** | survives |
| peak RSS | >512 MB | **285 MB** |
| idle RSS after two bursts | — | 189 MB |
| derived settings | — | `poolMB=16 maxConcurrent=3` (availableMB=384, cpus=28) |

Behaviour by concurrency before the change, 512 MB limit:

| concurrency | result |
|---|---|
| 1 | stable, 167 MB RSS |
| 8 | survives, peak 453 MB |
| 16 | OOMKilled, exit 137, within 5 s |

Steady state at a 2 GB limit, concurrency 8, idle after two bursts:

| | idle RSS | pooled unmanaged |
|---|---|---|
| default | 409 MB | 176 MB (44 handles × 4 MB) |
| pool capped | 251 MB | 16–32 MB |

Warm-cache throughput is unaffected: 200 cache hits complete in 3.5 s through a semaphore of 3
(cache hits are milliseconds, so the gate is never the bottleneck for them).

#### Tests

- `ImagingMemorySettingsTests` — the derivation, including the clamps and the processor-count cap.
- `ImageProcessingThrottleMiddlewareTests` — that concurrency never exceeds the configured limit,
  that requests without processor commands or without a file extension are not gated, and that a
  slot is released when a request throws.

Both new tests were confirmed to **fail without the fix**: with the throttle bypassed the
concurrency test observes 12 concurrent invocations against a limit of 2, and with the `finally`
removed the slot-release test fails on a 10 s guard rather than hanging.

Full unit test suite green on this branch (3174 passed, 0 failed, net8.0).

#### Notes

- I also measured scaled decoding via `DecoderOptions.TargetSize` on `OnBeforeLoadAsync`. It halves
  the per-request cost (60 MB → 26 MB) but **on its own still OOM-killed** at concurrency 16, and it
  changes decode output slightly, so it is deliberately not part of this PR. Happy to follow up with
  it separately if there is appetite.
- Related to #16226, which was closed as an external dependency issue. The underlying behaviour is
  ImageSharp's, but the concurrency ceiling is something Umbraco can set on the caller side without
  a site having to replace `IImageUrlGenerator`/`IImageDimensionExtractor`.
