### PR TITLE
Dependencies: Update Tiptap to 3.29.2

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -2407,12 +2407,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@remirror/core-constants": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-			"integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-			"license": "MIT"
-		},
 		"node_modules/@rollup/plugin-node-resolve": {
 			"version": "15.3.1",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
@@ -3197,16 +3191,16 @@
 			}
 		},
 		"node_modules/@tiptap/core": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
-			"integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.29.2.tgz",
+			"integrity": "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/pm": "^3.22.3"
+				"@tiptap/pm": "3.29.2"
 			}
 		},
 		"node_modules/@tiptap/extension-blockquote": {
@@ -3356,16 +3350,16 @@
 			}
 		},
 		"node_modules/@tiptap/extension-image": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.22.3.tgz",
-			"integrity": "sha512-Qpp8c5LOQaNpHrzjqZtoxtIR+8sSqJ7k8v+8anmYw3nxjvt2kpfT28Vd7aWMX55ZS43LaxMx+MkZqbmgUmMP0w==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.29.2.tgz",
+			"integrity": "sha512-F+S4iru247mNVZdkNwNDZHeb281DkjsBJinaOGsOyJTvXY+KU5Uq7vY1LQTn493dTfU48Z0yMBUXwJffCT92Mg==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "^3.22.3"
+				"@tiptap/core": "3.29.2"
 			}
 		},
 		"node_modules/@tiptap/extension-italic": {
@@ -3478,45 +3472,45 @@
 			}
 		},
 		"node_modules/@tiptap/extension-subscript": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.22.3.tgz",
-			"integrity": "sha512-fcHinQMye6tPSxTB74CLW4Z/HbA9FX4epKOQ0ld0wIFsQB2bVz0NH9FfwrTEsYWLjeFWkDcL41VOReZXqKz1jQ==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.29.2.tgz",
+			"integrity": "sha512-3fpp1B2kZWBfmVYZ1ak3yFWiKR3eV9GR/vYGPDMrkZoTdG9LKylRAJs3Fk2gDgTtOPmbrtilGQjl2o55RuoGxw==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "^3.22.3",
-				"@tiptap/pm": "^3.22.3"
+				"@tiptap/core": "3.29.2",
+				"@tiptap/pm": "3.29.2"
 			}
 		},
 		"node_modules/@tiptap/extension-superscript": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.22.3.tgz",
-			"integrity": "sha512-q+yPA+vbvaqiVGTJddjBhvWgqLXu6j39knz3TgJKw4nBuvoAXWrlWtgOy44wwIIs8vILI4wENoUuoI0+vOzynA==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.29.2.tgz",
+			"integrity": "sha512-/bPgdY7zUHtvToHizvzR6Yf4uIWO35cKj9EZsl/vyFb2mXyJ3a2mysCZgZq+5uvhZS/16eNNKOcezlkayhhkMA==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "^3.22.3",
-				"@tiptap/pm": "^3.22.3"
+				"@tiptap/core": "3.29.2",
+				"@tiptap/pm": "3.29.2"
 			}
 		},
 		"node_modules/@tiptap/extension-table": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.22.3.tgz",
-			"integrity": "sha512-inbQSusJad7H0T++L1APg/anfL5d15cNGp2YG3vwo6TQr71nn2c9pepvmz3xuAIt8eygZDRba+4GT/COP1f9QA==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.29.2.tgz",
+			"integrity": "sha512-HY3JWD8i/F8W1oWw56DMqEMqxScIAZFRrhL3rUwiuowHG8LLDqDdQjBV3w1DY8lUZOtNY9grpuMtGlPUFrOVAA==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "^3.22.3",
-				"@tiptap/pm": "^3.22.3"
+				"@tiptap/core": "3.29.2",
+				"@tiptap/pm": "3.29.2"
 			}
 		},
 		"node_modules/@tiptap/extension-text": {
@@ -3533,29 +3527,29 @@
 			}
 		},
 		"node_modules/@tiptap/extension-text-align": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.22.3.tgz",
-			"integrity": "sha512-dG1NHE0yGf7fYiOdabCJuecI2IJ1uogyY/QvZqvPNaxRjZDoXYuGlMtz9jEDiIdQSaPED2MSsS7KkuNFQIEMGg==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.29.2.tgz",
+			"integrity": "sha512-205FF87zjUEh79n6dgVy9SMj1P+rNserHMqPd8lF7YS2TOWikXPG4PFuQHWXXCYzaCvQXAiATSAyPXXmUWUvaQ==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "^3.22.3"
+				"@tiptap/core": "3.29.2"
 			}
 		},
 		"node_modules/@tiptap/extension-text-style": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.22.3.tgz",
-			"integrity": "sha512-JKmWAogM/LX9ZJmXJQalpcR77wWVtVXdRFgvHGsFomW9WFhZqcnIEDWR2sbpZHWtu8dml6eBQGhdLppJmxeFfA==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.29.2.tgz",
+			"integrity": "sha512-aQad9V9ROaEi3hE4g5z9wQ6lv5FSnzlnWFMVJxRjNlwXgm7H0fymxb4rGfca+pAwYkiRwpKYh1LatpJw2ECQAA==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "^3.22.3"
+				"@tiptap/core": "3.29.2"
 			}
 		},
 		"node_modules/@tiptap/extension-underline": {
@@ -3572,43 +3566,38 @@
 			}
 		},
 		"node_modules/@tiptap/extensions": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
-			"integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.29.2.tgz",
+			"integrity": "sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "^3.22.3",
-				"@tiptap/pm": "^3.22.3"
+				"@tiptap/core": "3.29.2",
+				"@tiptap/pm": "3.29.2"
 			}
 		},
 		"node_modules/@tiptap/pm": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
-			"integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.29.2.tgz",
+			"integrity": "sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==",
 			"license": "MIT",
 			"dependencies": {
-				"prosemirror-changeset": "^2.3.0",
-				"prosemirror-collab": "^1.3.1",
-				"prosemirror-commands": "^1.6.2",
-				"prosemirror-dropcursor": "^1.8.1",
-				"prosemirror-gapcursor": "^1.3.2",
-				"prosemirror-history": "^1.4.1",
-				"prosemirror-inputrules": "^1.4.0",
-				"prosemirror-keymap": "^1.2.2",
-				"prosemirror-markdown": "^1.13.1",
-				"prosemirror-menu": "^1.2.4",
-				"prosemirror-model": "^1.24.1",
-				"prosemirror-schema-basic": "^1.2.3",
-				"prosemirror-schema-list": "^1.5.0",
-				"prosemirror-state": "^1.4.3",
-				"prosemirror-tables": "^1.6.4",
-				"prosemirror-trailing-node": "^3.0.0",
-				"prosemirror-transform": "^1.10.2",
-				"prosemirror-view": "^1.38.1"
+				"prosemirror-changeset": "^2.4.1",
+				"prosemirror-commands": "^1.7.1",
+				"prosemirror-dropcursor": "^1.8.2",
+				"prosemirror-gapcursor": "^1.4.1",
+				"prosemirror-history": "^1.5.0",
+				"prosemirror-inputrules": "^1.5.1",
+				"prosemirror-keymap": "^1.2.3",
+				"prosemirror-model": "^1.25.11",
+				"prosemirror-schema-list": "^1.5.1",
+				"prosemirror-state": "^1.4.4",
+				"prosemirror-tables": "^1.8.5",
+				"prosemirror-transform": "^1.12.0",
+				"prosemirror-view": "^1.41.9"
 			},
 			"funding": {
 				"type": "github",
@@ -3616,35 +3605,35 @@
 			}
 		},
 		"node_modules/@tiptap/starter-kit": {
-			"version": "3.22.3",
-			"resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.3.tgz",
-			"integrity": "sha512-vdW/Oo1fdwTL1VOQ5YYbTov00ANeHLquBVEZyL/EkV7Xv5io9rXQsCysJfTSHhiQlyr2MtWFB4+CPGuwXjQWOQ==",
+			"version": "3.29.2",
+			"resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.29.2.tgz",
+			"integrity": "sha512-oTu0tysiqk4zgjEtxRHjAQgxUKaAevZwueOWwSWubHdokqp7SpcbE5n9USJv89HKuTUDm3GjnQH6q8HNn/2DsA==",
 			"license": "MIT",
 			"dependencies": {
-				"@tiptap/core": "^3.22.3",
-				"@tiptap/extension-blockquote": "^3.22.3",
-				"@tiptap/extension-bold": "^3.22.3",
-				"@tiptap/extension-bullet-list": "^3.22.3",
-				"@tiptap/extension-code": "^3.22.3",
-				"@tiptap/extension-code-block": "^3.22.3",
-				"@tiptap/extension-document": "^3.22.3",
-				"@tiptap/extension-dropcursor": "^3.22.3",
-				"@tiptap/extension-gapcursor": "^3.22.3",
-				"@tiptap/extension-hard-break": "^3.22.3",
-				"@tiptap/extension-heading": "^3.22.3",
-				"@tiptap/extension-horizontal-rule": "^3.22.3",
-				"@tiptap/extension-italic": "^3.22.3",
-				"@tiptap/extension-link": "^3.22.3",
-				"@tiptap/extension-list": "^3.22.3",
-				"@tiptap/extension-list-item": "^3.22.3",
-				"@tiptap/extension-list-keymap": "^3.22.3",
-				"@tiptap/extension-ordered-list": "^3.22.3",
-				"@tiptap/extension-paragraph": "^3.22.3",
-				"@tiptap/extension-strike": "^3.22.3",
-				"@tiptap/extension-text": "^3.22.3",
-				"@tiptap/extension-underline": "^3.22.3",
-				"@tiptap/extensions": "^3.22.3",
-				"@tiptap/pm": "^3.22.3"
+				"@tiptap/core": "^3.29.2",
+				"@tiptap/extension-blockquote": "^3.29.2",
+				"@tiptap/extension-bold": "^3.29.2",
+				"@tiptap/extension-bullet-list": "^3.29.2",
+				"@tiptap/extension-code": "^3.29.2",
+				"@tiptap/extension-code-block": "^3.29.2",
+				"@tiptap/extension-document": "^3.29.2",
+				"@tiptap/extension-dropcursor": "^3.29.2",
+				"@tiptap/extension-gapcursor": "^3.29.2",
+				"@tiptap/extension-hard-break": "^3.29.2",
+				"@tiptap/extension-heading": "^3.29.2",
+				"@tiptap/extension-horizontal-rule": "^3.29.2",
+				"@tiptap/extension-italic": "^3.29.2",
+				"@tiptap/extension-link": "^3.29.2",
+				"@tiptap/extension-list": "^3.29.2",
+				"@tiptap/extension-list-item": "^3.29.2",
+				"@tiptap/extension-list-keymap": "^3.29.2",
+				"@tiptap/extension-ordered-list": "^3.29.2",
+				"@tiptap/extension-paragraph": "^3.29.2",
+				"@tiptap/extension-strike": "^3.29.2",
+				"@tiptap/extension-text": "^3.29.2",
+				"@tiptap/extension-underline": "^3.29.2",
+				"@tiptap/extensions": "^3.29.2",
+				"@tiptap/pm": "^3.29.2"
 			},
 			"funding": {
 				"type": "github",
@@ -4100,28 +4089,12 @@
 				"@types/koa": "*"
 			}
 		},
-		"node_modules/@types/linkify-it": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-			"license": "MIT"
-		},
 		"node_modules/@types/luxon": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.2.tgz",
 			"integrity": "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/markdown-it": {
-			"version": "14.1.2",
-			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/linkify-it": "^5",
-				"@types/mdurl": "^2"
-			}
 		},
 		"node_modules/@types/mdast": {
 			"version": "4.0.4",
@@ -4132,12 +4105,6 @@
 			"dependencies": {
 				"@types/unist": "*"
 			}
-		},
-		"node_modules/@types/mdurl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-			"license": "MIT"
 		},
 		"node_modules/@types/mdx": {
 			"version": "2.0.14",
@@ -5568,6 +5535,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
 			"license": "Python-2.0"
 		},
 		"node_modules/aria-query": {
@@ -6750,12 +6718,6 @@
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/crelt": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
-			"integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
 			"license": "MIT"
 		},
 		"node_modules/cross-env": {
@@ -8092,6 +8054,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -10818,6 +10781,7 @@
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
 			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -11080,6 +11044,7 @@
 			"version": "14.3.0",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
 			"integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -11107,6 +11072,7 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
@@ -11379,6 +11345,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
 			"integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/media-typer": {
@@ -14157,15 +14124,6 @@
 				"prosemirror-transform": "^1.0.0"
 			}
 		},
-		"node_modules/prosemirror-collab": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-			"integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-			"license": "MIT",
-			"dependencies": {
-				"prosemirror-state": "^1.0.0"
-			}
-		},
 		"node_modules/prosemirror-commands": {
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
@@ -14232,29 +14190,6 @@
 				"w3c-keyname": "^2.2.0"
 			}
 		},
-		"node_modules/prosemirror-markdown": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.5.tgz",
-			"integrity": "sha512-ac8trNQ01ybKDRTcfUc56LZufG3oYyU4N25qSXgp8dS0U4JtzzCj7oQlKu5v09VSmS5IseYoQ2yDkTbo7f7D8Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/markdown-it": "^14.0.0",
-				"markdown-it": "^14.0.0",
-				"prosemirror-model": "^1.25.0"
-			}
-		},
-		"node_modules/prosemirror-menu": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.2.tgz",
-			"integrity": "sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==",
-			"license": "MIT",
-			"dependencies": {
-				"crelt": "^1.0.0",
-				"prosemirror-commands": "^1.0.0",
-				"prosemirror-history": "^1.0.0",
-				"prosemirror-state": "^1.0.0"
-			}
-		},
 		"node_modules/prosemirror-model": {
 			"version": "1.25.11",
 			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
@@ -14262,15 +14197,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"orderedmap": "^2.0.0"
-			}
-		},
-		"node_modules/prosemirror-schema-basic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-			"integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-			"license": "MIT",
-			"dependencies": {
-				"prosemirror-model": "^1.25.0"
 			}
 		},
 		"node_modules/prosemirror-schema-list": {
@@ -14306,21 +14232,6 @@
 				"prosemirror-state": "^1.4.4",
 				"prosemirror-transform": "^1.10.5",
 				"prosemirror-view": "^1.41.4"
-			}
-		},
-		"node_modules/prosemirror-trailing-node": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-			"integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@remirror/core-constants": "3.0.0",
-				"escape-string-regexp": "^4.0.0"
-			},
-			"peerDependencies": {
-				"prosemirror-model": "^1.22.1",
-				"prosemirror-state": "^1.4.2",
-				"prosemirror-view": "^1.33.8"
 			}
 		},
 		"node_modules/prosemirror-transform": {
@@ -14416,6 +14327,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
 			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -16935,6 +16847,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
 			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unbox-primitive": {
@@ -18057,16 +17970,16 @@
 		"src/packages/tiptap": {
 			"name": "@umbraco-backoffice/tiptap",
 			"dependencies": {
-				"@tiptap/core": "3.22.3",
-				"@tiptap/extension-image": "3.22.3",
-				"@tiptap/extension-subscript": "3.22.3",
-				"@tiptap/extension-superscript": "3.22.3",
-				"@tiptap/extension-table": "3.22.3",
-				"@tiptap/extension-text-align": "3.22.3",
-				"@tiptap/extension-text-style": "3.22.3",
-				"@tiptap/extensions": "3.22.3",
-				"@tiptap/pm": "3.22.3",
-				"@tiptap/starter-kit": "3.22.3"
+				"@tiptap/core": "3.29.2",
+				"@tiptap/extension-image": "3.29.2",
+				"@tiptap/extension-subscript": "3.29.2",
+				"@tiptap/extension-superscript": "3.29.2",
+				"@tiptap/extension-table": "3.29.2",
+				"@tiptap/extension-text-align": "3.29.2",
+				"@tiptap/extension-text-style": "3.29.2",
+				"@tiptap/extensions": "3.29.2",
+				"@tiptap/pm": "3.29.2",
+				"@tiptap/starter-kit": "3.29.2"
 			}
 		},
 		"src/packages/translation": {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/package.json
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/package.json
@@ -6,15 +6,15 @@
 		"build": "vite build"
 	},
 	"dependencies": {
-		"@tiptap/core": "3.22.3",
-		"@tiptap/extension-image": "3.22.3",
-		"@tiptap/extension-subscript": "3.22.3",
-		"@tiptap/extension-superscript": "3.22.3",
-		"@tiptap/extension-table": "3.22.3",
-		"@tiptap/extension-text-align": "3.22.3",
-		"@tiptap/extension-text-style": "3.22.3",
-		"@tiptap/starter-kit": "3.22.3",
-		"@tiptap/extensions": "3.22.3",
-		"@tiptap/pm": "3.22.3"
+		"@tiptap/core": "3.29.2",
+		"@tiptap/extension-image": "3.29.2",
+		"@tiptap/extension-subscript": "3.29.2",
+		"@tiptap/extension-superscript": "3.29.2",
+		"@tiptap/extension-table": "3.29.2",
+		"@tiptap/extension-text-align": "3.29.2",
+		"@tiptap/extension-text-style": "3.29.2",
+		"@tiptap/starter-kit": "3.29.2",
+		"@tiptap/extensions": "3.29.2",
+		"@tiptap/pm": "3.29.2"
 	}
 }


### PR DESCRIPTION
## Description

A prior lockfile-sync commit (3f9244ca092232bdd81083641c12babeb2f62336) drifted the Tiptap dependency tree: our exact `3.22.3` pins on `@tiptap/core`, `@tiptap/pm`, `@tiptap/extensions` and `@tiptap/starter-kit` (etc.) stayed put, but `starter-kit`'s own dependencies use caret ranges — so 15 transitive `@tiptap/extension-*` packages, and `prosemirror-model` (1.25.4 → 1.25.11), resolved to newer versions independently. The result was an internally inconsistent tree: 3.29.2 extensions running against `@tiptap/core@3.22.3`.

This aligns all 10 pinned packages in `src/packages/tiptap/package.json` to `3.29.2` (current `latest`), which is also the release that formally bumped `prosemirror-model` to `^1.25.11` — the version we were already transitively running.

No breaking changes to `renderHTML` / `DOMOutputSpec` / serialization occur across the 3.22.3 → 3.29.2 range.

Note: the published `peerDependencies` range (via `devops/publish/cleanse-pkg.js`) for `@tiptap/*` moves from `^3.22.3` to `^3.29.2`, raising the floor for plugin developers.

This is a dependency-alignment task on its own — it does not fix the embedded-media RTE crash (that requires `prosemirror-model ^1.25.11`'s stricter `renderSpec`, which this version also carries forward). That fix is stacked on top in #23563.

