### PR TITLE
Tiptap RTE: Fix crash when content contains an embedded media node

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/block/block.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/block/block.tiptap-api.ts
@@ -84,9 +84,12 @@ export default class UmbTiptapBlockElementApi extends UmbTiptapExtensionApiBase 
 		if (!editor) return;
 
 		// Find existing blocks in the editor
-		const existingBlocks = Array.from(editor.view.dom.querySelectorAll('umb-rte-block, umb-rte-block-inline')).map(
-			(x) => x.getAttribute(UMB_BLOCK_RTE_DATA_CONTENT_KEY),
-		);
+		const existingBlocks: Array<string> = [];
+		editor.state.doc.descendants((node) => {
+			const contentKey = node.attrs[UMB_BLOCK_RTE_DATA_CONTENT_KEY];
+			if (contentKey) existingBlocks.push(contentKey);
+			return true;
+		});
 
 		// ADD blocks that are in contents but NOT in editor
 		const newBlocks = contents.filter((x) => !existingBlocks.includes(x.key));

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/block/block.tiptap-extension.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/block/block.tiptap-extension.test.ts
@@ -1,0 +1,42 @@
+import { Document, Editor, Paragraph, Text } from '../../externals.js';
+import { UMB_BLOCK_RTE_DATA_CONTENT_KEY } from '@umbraco-cms/backoffice/rte';
+import { umbRteBlock, umbRteBlockInline } from './block.tiptap-extension.js';
+import { expect } from '@open-wc/testing';
+
+describe('block.tiptap-extension', () => {
+	let editor: Editor;
+	let host: HTMLDivElement;
+
+	beforeEach(() => {
+		host = document.createElement('div');
+		document.body.appendChild(host);
+		editor = new Editor({
+			element: host,
+			extensions: [Document, Paragraph, Text, umbRteBlock, umbRteBlockInline],
+		});
+	});
+
+	afterEach(() => {
+		editor.destroy();
+		host.remove();
+	});
+
+	// #updateBlocks (block.tiptap-api.ts) discovers existing blocks by walking `editor.state.doc`
+	// rather than querying `editor.view.dom`, since `view` is not available before the editor mounts.
+	// This asserts that walk finds the same content keys the DOM query used to.
+	it('finds block and inline-block content keys by walking the document', () => {
+		editor.commands.setContent(
+			'<umb-rte-block data-content-key="block-1"></umb-rte-block>' +
+				'<p>Hello <umb-rte-block-inline data-content-key="inline-1"></umb-rte-block-inline> world.</p>',
+		);
+
+		const foundKeys: Array<string> = [];
+		editor.state.doc.descendants((node) => {
+			const contentKey = node.attrs[UMB_BLOCK_RTE_DATA_CONTENT_KEY];
+			if (contentKey) foundKeys.push(contentKey);
+			return true;
+		});
+
+		expect(foundKeys).to.deep.equal(['block-1', 'inline-1']);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/embedded-media/embedded-media.tiptap-extension.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/embedded-media/embedded-media.tiptap-extension.test.ts
@@ -1,0 +1,36 @@
+import { Document, Editor, Paragraph, Text } from '../../externals.js';
+import { umbEmbeddedMedia } from './embedded-media.tiptap-extension.js';
+import { expect } from '@open-wc/testing';
+
+describe('embedded-media.tiptap-extension', () => {
+	let editor: Editor;
+	let host: HTMLDivElement;
+
+	beforeEach(() => {
+		host = document.createElement('div');
+		document.body.appendChild(host);
+		editor = new Editor({
+			element: host,
+			extensions: [Document, Paragraph, Text, umbEmbeddedMedia.configure({ inline: true })],
+		});
+	});
+
+	afterEach(() => {
+		editor.destroy();
+		host.remove();
+	});
+
+	it('parses and serializes an embed without throwing (regression for the renderSpec RangeError)', () => {
+		const markup =
+			'<p><span class="umb-embed-holder" data-embed-constrain="false" data-embed-height="240" data-embed-url="https://example.com/embed" data-embed-width="360"><iframe src="https://example.com/embed" width="360" height="240"></iframe></span></p>';
+
+		expect(() => editor.commands.setContent(markup)).to.not.throw();
+		expect(editor.getHTML()).to.equal(markup);
+	});
+
+	it('does not render the literal text "null" when the markup attribute is unset', () => {
+		editor.commands.insertContent({ type: 'umbEmbeddedMedia', attrs: { 'data-embed-url': 'https://example.com' } });
+
+		expect(editor.getHTML()).to.not.include('null');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/embedded-media/embedded-media.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/embedded-media/embedded-media.tiptap-extension.ts
@@ -34,8 +34,14 @@ export const umbEmbeddedMedia = Node.create<UmbEmbeddedMediaOptions>({
 
 	renderHTML({ HTMLAttributes }) {
 		const { markup, ...attrs } = HTMLAttributes;
-		const embed = document.createRange().createContextualFragment(markup);
-		return [this.options.inline ? 'span' : 'div', mergeAttributes({ class: 'umb-embed-holder' }, attrs), embed];
+		const dom = document.createElement(this.options.inline ? 'span' : 'div');
+		for (const [name, value] of Object.entries(mergeAttributes({ class: 'umb-embed-holder' }, attrs))) {
+			if (value != null) dom.setAttribute(name, value);
+		}
+		if (markup) {
+			dom.append(document.createRange().createContextualFragment(markup));
+		}
+		return dom;
 	},
 
 	addCommands() {


### PR DESCRIPTION
## Description

Stacked on #23562.

Navigating to a Tiptap RTE property whose value contains an embed (`<span class="umb-embed-holder">…<iframe…></span>`) throws during editor construction and the editor never mounts:

```
RangeError: Invalid array passed to renderSpec
  at renderSpec → EditorView → createView → new Editor (input-tiptap.element.ts)
```

`embedded-media.tiptap-extension.ts`'s `renderHTML` returned a `DocumentFragment` as a spec child. ProseMirror's `renderSpec` only accepts `Element` children (`structure.nodeType == 1`); a `DocumentFragment` (`nodeType 11`) falls through to `structure[0]` being `undefined`, throwing the `RangeError`. This became reachable once `prosemirror-model` moved past 1.25.4 (see #23562) — `DOMOutputSpec` never legally permitted a fragment, but the array's `readonly [string, ...any[]]` typing masked it at compile time.

Because the constructor aborts, `editorView` is never assigned. Every later block-content emission then dereferences the unmounted `editor.view.dom` in `block.tiptap-api.ts`'s `#updateBlocks`, throwing a second, cascading error that masks the real one.

- **`embedded-media.tiptap-extension.ts`**: `renderHTML` now builds a real `Element` and appends the embed markup into it, instead of returning a `DocumentFragment`. Also fixes a latent bug where an unset `markup` attribute rendered the literal text `"null"`.
- **`block.tiptap-api.ts`**: `#updateBlocks` now walks `editor.state.doc` to find existing block content keys, matching the pattern its sibling `#removeBlocksFromEditor` already used, instead of querying `editor.view.dom` (which throws pre-mount).

## Test plan
- [x] Added `embedded-media.tiptap-extension.test.ts` — confirmed it fails with the real `RangeError` when the fix is reverted, passes once restored
- [x] Added `block.tiptap-extension.test.ts` — confirms the doc-walk finds block/inline-block content keys
- [x] Full tiptap test suite passes, `npm run build` clean, no circular dependencies
- [ ] Manual verification in a running instance against RTE content containing an embed, blocks, tables, links and heavy inline styles (reviewer)