### PR TITLE
Block Editors: Publish segment variant values on culture varying document types (closes #23553)

### DIFF
--- a/src/Umbraco.Core/Models/Property.cs
+++ b/src/Umbraco.Core/Models/Property.cs
@@ -183,7 +183,7 @@ public class Property : EntityBase, IProperty
     /// <remarks>
     ///     This method is for internal use and must be invoked by the content item.
     ///     It does not validate the value - the content item must validate first.
-    ///     The neutral value is published along with the value of every segment supported by the property type.
+    ///     The default value is published along with the value of every segment supported by the property type.
     /// </remarks>
     /// <exception cref="NotSupportedException">Thrown when attempting to publish merged culture values for culture variant properties.</exception>
     public void PublishPartialValues(IDataEditor dataEditor, string? culture)

--- a/src/Umbraco.Core/Models/Property.cs
+++ b/src/Umbraco.Core/Models/Property.cs
@@ -183,6 +183,7 @@ public class Property : EntityBase, IProperty
     /// <remarks>
     ///     This method is for internal use and must be invoked by the content item.
     ///     It does not validate the value - the content item must validate first.
+    ///     The neutral value is published along with the value of every segment supported by the property type.
     /// </remarks>
     /// <exception cref="NotSupportedException">Thrown when attempting to publish merged culture values for culture variant properties.</exception>
     public void PublishPartialValues(IDataEditor dataEditor, string? culture)
@@ -194,8 +195,27 @@ public class Property : EntityBase, IProperty
 
         culture = culture?.NullOrWhiteSpaceAsNull();
 
-        var value = dataEditor.MergePartialPropertyValueForCulture(_pvalue?.EditedValue, _pvalue?.PublishedValue, culture);
-        PublishValue(_pvalue, value);
+        PublishPartialValue(dataEditor, _pvalue, culture);
+
+        if (_vvalues == null)
+        {
+            return;
+        }
+
+        // The property does not vary by culture, so everything that varies here is a segment value (see issue #23553).
+        IEnumerable<IPropertyValue> pvalues = _vvalues.Values
+            .Where(x => PropertyType.SupportsVariation(x.Culture, x.Segment, true));
+
+        foreach (IPropertyValue pvalue in pvalues)
+        {
+            PublishPartialValue(dataEditor, pvalue, culture);
+        }
+    }
+
+    private void PublishPartialValue(IDataEditor dataEditor, IPropertyValue? pvalue, string? culture)
+    {
+        var value = dataEditor.MergePartialPropertyValueForCulture(pvalue?.EditedValue, pvalue?.PublishedValue, culture);
+        PublishValue(pvalue, value);
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -248,19 +248,24 @@ internal sealed class ContentEditingService
         // we need perform a merge between the edited property value and the current property value
         foreach ((IProperty Property, IDataEditor DataEditor) propertyWithEditor in invariantWithVariantSupportProperties)
         {
-            var currentValue = existingContent?.Properties.First(x => x.Alias == propertyWithEditor.Property.Alias)
-                .GetValue(null, null, false);
-            var editedValue = contentWithPotentialUnallowedChanges.Properties
-                .First(x => x.Alias == propertyWithEditor.Property.Alias).GetValue(null, null, false);
+            IProperty property = propertyWithEditor.Property;
+            IProperty? existingProperty = existingContent?.Properties.First(x => x.Alias == property.Alias);
 
-            // update the editedValue with a merged value of invariant data and allowed culture data using the currentValue as a fallback.
-            var mergedValue = propertyWithEditor.DataEditor.MergeVariantInvariantPropertyValue(
-                currentValue,
-                editedValue,
-                ContentSettings.AllowEditInvariantFromNonDefault || (defaultLanguage is not null && allowedCultures.Contains(defaultLanguage.IsoCode)),
-                allowedCultures);
+            // The property may vary by segment, in which case each segment holds its own value to merge.
+            foreach (var segment in GetSegmentsToRestore(property, existingProperty, null))
+            {
+                var currentValue = existingProperty?.GetValue(null, segment, false);
+                var editedValue = property.GetValue(null, segment, false);
 
-            propertyWithEditor.Property.SetValue(mergedValue, null, null);
+                // update the editedValue with a merged value of invariant data and allowed culture data using the currentValue as a fallback.
+                var mergedValue = propertyWithEditor.DataEditor.MergeVariantInvariantPropertyValue(
+                    currentValue,
+                    editedValue,
+                    ContentSettings.AllowEditInvariantFromNonDefault || (defaultLanguage is not null && allowedCultures.Contains(defaultLanguage.IsoCode)),
+                    allowedCultures);
+
+                property.SetValue(mergedValue, null, segment);
+            }
         }
 
         return contentWithPotentialUnallowedChanges;
@@ -277,18 +282,28 @@ internal sealed class ContentEditingService
     {
         IProperty? existingProperty = existingContent?.Properties.First(x => x.Alias == property.Alias);
 
-        IEnumerable<string?> segments = property.Values
-            .Concat(existingProperty?.Values ?? [])
-            .Where(value => culture.InvariantEquals(value.Culture))
-            .Select(value => value.Segment)
-            .Append(null)
-            .Distinct();
-
-        foreach (var segment in segments)
+        foreach (var segment in GetSegmentsToRestore(property, existingProperty, culture))
         {
             property.SetValue(existingProperty?.GetValue(culture, segment, false), culture, segment);
         }
     }
+
+    /// <summary>
+    /// Gets every segment of a culture held by either the edited or the existing property, along with the
+    /// segment-less value, so all of them can be restored or merged.
+    /// </summary>
+    /// <remarks>
+    /// Materialized because writing to a segment can add a property value, which would otherwise modify the
+    /// collection being enumerated.
+    /// </remarks>
+    private static string?[] GetSegmentsToRestore(IProperty property, IProperty? existingProperty, string? culture)
+        => property.Values
+            .Concat(existingProperty?.Values ?? [])
+            .Where(value => culture.InvariantEquals(value.Culture))
+            .Select(value => value.Segment)
+            .Append(null)
+            .Distinct()
+            .ToArray();
 
     private async Task<HashSet<string>> GetAllowedCulturesForEditingUser(Guid userKey)
     {

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -225,14 +225,13 @@ internal sealed class ContentEditingService
             }
         }
 
-        // if the property varies by culture, simply overwrite the edited property value with the current property value for every culture
+        // If the property varies by culture, simply overwrite the edited property value with the current property value
+        // for every culture.
         foreach (IProperty property in variantProperties)
         {
             foreach (var culture in disallowedCultures)
             {
-                    var currentValue = existingContent?.Properties.First(x => x.Alias == property.Alias)
-                        .GetValue(culture, null, false);
-                    property.SetValue(currentValue, culture, null);
+                RestoreExistingPropertyValues(property, existingContent, culture);
             }
         }
 
@@ -241,9 +240,7 @@ internal sealed class ContentEditingService
         {
             foreach (IProperty property in invariantProperties)
             {
-                var currentValue = existingContent?.Properties.First(x => x.Alias == property.Alias)
-                    .GetValue(null, null, false);
-                property.SetValue(currentValue, null, null);
+                RestoreExistingPropertyValues(property, existingContent, null);
             }
         }
 
@@ -267,6 +264,30 @@ internal sealed class ContentEditingService
         }
 
         return contentWithPotentialUnallowedChanges;
+    }
+
+    /// <summary>
+    /// Overwrites the edited values of a property for one culture with the values held by the existing content.
+    /// </summary>
+    /// <remarks>
+    /// The property may vary by segment, so every segment of the culture has to be restored, not only its
+    /// segment-less value - including any segment the edit added, which is restored to no value.
+    /// </remarks>
+    private static void RestoreExistingPropertyValues(IProperty property, IContent? existingContent, string? culture)
+    {
+        IProperty? existingProperty = existingContent?.Properties.First(x => x.Alias == property.Alias);
+
+        IEnumerable<string?> segments = property.Values
+            .Concat(existingProperty?.Values ?? [])
+            .Where(value => culture.InvariantEquals(value.Culture))
+            .Select(value => value.Segment)
+            .Append(null)
+            .Distinct();
+
+        foreach (var segment in segments)
+        {
+            property.SetValue(existingProperty?.GetValue(culture, segment, false), culture, segment);
+        }
     }
 
     private async Task<HashSet<string>> GetAllowedCulturesForEditingUser(Guid userKey)

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -521,8 +521,12 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
 
             foreach (BlockPropertyValue targetBlockPropertyValue in targetBlockItem.Values)
             {
+                // The segment has to take part in the match, or a segment variant value would be restored from
+                // another segment of the same culture.
                 BlockPropertyValue? sourceBlockPropertyValue = sourceBlockItem?.Values.FirstOrDefault(v
-                    => v.Alias == targetBlockPropertyValue.Alias && v.Culture == targetBlockPropertyValue.Culture);
+                    => v.Alias == targetBlockPropertyValue.Alias
+                       && v.Culture == targetBlockPropertyValue.Culture
+                       && v.Segment == targetBlockPropertyValue.Segment);
 
                 // todo double check if this path can have an invariant value, but it shouldn't right???
                 // => it can be a null culture, but we shouldn't do anything? as the invariant section should have done it already

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
@@ -1466,6 +1466,200 @@ internal partial class BlockListElementLevelVariationTests
         });
     }
 
+    /// <summary>
+    /// Tests whether the segment values of a culture the user cannot edit are each restored from their own
+    /// segment, rather than from another segment of the same culture.
+    /// </summary>
+    /// <param name="updateWithLimitedUserAccess">true => danish only which is not the default. false => admin which is all languages</param>
+    [TestCase(true)]
+    [TestCase(false)]
+    [ConfigureBuilder(ActionName = nameof(ConfigureAllowEditInvariantFromNonDefaultTrue))]
+    public async Task Can_Handle_Limited_User_Access_To_Languages_With_Segment_Variant_Elements(bool updateWithLimitedUserAccess)
+    {
+        // Arrange: prepare an invariant block property whose element type varies by culture AND segment,
+        // holding a value per culture and segment, and an editor restricted to Danish.
+        var userKey = updateWithLimitedUserAccess
+            ? (await CreateLimitedUser()).Key
+            : Constants.Security.SuperUserKey;
+
+        var elementType = CreateElementType(ContentVariation.CultureAndSegment);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.CultureAndSegment, blockListDataType);
+        var content = CreateContent(contentType, elementType, [], false);
+
+        var blockListValue = BlockListPropertyValue(
+            elementType,
+            [
+                (
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    new BlockProperty(
+                        new List<BlockPropertyValue>
+                        {
+                            new() { Alias = "invariantText", Value = "The first invariant content value" },
+                            new() { Alias = "variantText", Value = "The first content value in English", Culture = "en-US" },
+                            new() { Alias = "variantText", Value = "The first content value in English (Segment 1)", Culture = "en-US", Segment = "s1" },
+                            new() { Alias = "variantText", Value = "The first content value in Danish", Culture = "da-DK" },
+                            new() { Alias = "variantText", Value = "The first content value in Danish (Segment 1)", Culture = "da-DK", Segment = "s1" }
+                        },
+                        [],
+                        null,
+                        null))
+            ]);
+
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+
+        foreach (BlockPropertyValue value in blockListValue.ContentData[0].Values)
+        {
+            value.Value = ((string)value.Value!).Replace("The first", "The second");
+        }
+
+        var updateModel = new ContentUpdateModel
+        {
+            Properties = new[]
+            {
+                new PropertyValueModel { Alias = "blocks", Value = JsonSerializer.Serialize(blockListValue) }
+            },
+            Variants = new[]
+            {
+                new VariantModel { Name = content.GetCultureName("en-US")!, Culture = "en-US" },
+                new VariantModel { Name = content.GetCultureName("da-DK")!, Culture = "da-DK" }
+            }
+        };
+
+        // Act: update the content, attempting to change every culture and segment of the block.
+        var result = await ContentEditingService.UpdateAsync(content.Key, updateModel, userKey);
+        Assert.IsTrue(result.Success);
+
+        // Assert: the Danish values are updated, and for a limited user the English values are rolled back
+        // per segment - the segmented value must not be restored from the segment-less one.
+        content = ContentService.GetById(content.Key);
+        var savedBlocksValue = content?.Properties["blocks"]?.GetValue()?.ToString();
+        Assert.NotNull(savedBlocksValue);
+        blockListValue = JsonSerializer.Deserialize<BlockListValue>(savedBlocksValue);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("The second invariant content value", BlockValue(null, null));
+            Assert.AreEqual("The second content value in Danish", BlockValue("da-DK", null));
+            Assert.AreEqual("The second content value in Danish (Segment 1)", BlockValue("da-DK", "s1"));
+
+            Assert.AreEqual(
+                updateWithLimitedUserAccess ? "The first content value in English" : "The second content value in English",
+                BlockValue("en-US", null));
+            Assert.AreEqual(
+                updateWithLimitedUserAccess ? "The first content value in English (Segment 1)" : "The second content value in English (Segment 1)",
+                BlockValue("en-US", "s1"));
+        });
+
+        string? BlockValue(string? culture, string? segment)
+            => blockListValue.ContentData[0].Values
+                .Single(value => value.Culture == culture && value.Segment == segment).Value as string;
+    }
+
+    /// <summary>
+    /// Tests whether a block property that varies by segment has every one of its segments merged for a user
+    /// with limited language access, rather than only its segment-less value.
+    /// </summary>
+    /// <param name="updateWithLimitedUserAccess">true => danish only which is not the default. false => admin which is all languages</param>
+    [TestCase(true)]
+    [TestCase(false)]
+    [ConfigureBuilder(ActionName = nameof(ConfigureAllowEditInvariantFromNonDefaultTrue))]
+    public async Task Can_Handle_Limited_User_Access_To_Languages_With_Segment_Variant_Block_Property(bool updateWithLimitedUserAccess)
+    {
+        // Arrange: prepare a culture invariant, segment variant block property holding a separate block
+        // value per segment, each with a value per culture, and an editor restricted to Danish.
+        var userKey = updateWithLimitedUserAccess
+            ? (await CreateLimitedUser()).Key
+            : Constants.Security.SuperUserKey;
+
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.CultureAndSegment, blockListDataType, ContentVariation.Segment);
+        var content = CreateContent(contentType, elementType, [], false);
+
+        var contentElementKey = Guid.NewGuid();
+        var settingsElementKey = Guid.NewGuid();
+
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(BlockValueForSegment("default")), null, null);
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(BlockValueForSegment("s1")), null, "s1");
+        ContentService.Save(content);
+
+        var updateModel = new ContentUpdateModel
+        {
+            Properties = new[]
+            {
+                new PropertyValueModel { Alias = "blocks", Value = JsonSerializer.Serialize(UpdatedBlockValueForSegment("default")) },
+                new PropertyValueModel { Alias = "blocks", Value = JsonSerializer.Serialize(UpdatedBlockValueForSegment("s1")), Segment = "s1" }
+            },
+            Variants = new[]
+            {
+                new VariantModel { Name = content.GetCultureName("en-US")!, Culture = "en-US" },
+                new VariantModel { Name = content.GetCultureName("da-DK")!, Culture = "da-DK" }
+            }
+        };
+
+        // Act: update the content, attempting to change every culture in every segment.
+        var result = await ContentEditingService.UpdateAsync(content.Key, updateModel, userKey);
+        Assert.IsTrue(result.Success);
+
+        // Assert: the Danish values are updated in both segments, and for a limited user the English values
+        // are rolled back in both segments - not only in the segment-less one.
+        content = ContentService.GetById(content.Key);
+
+        Assert.Multiple(() =>
+        {
+            foreach (var segment in new[] { null, "s1" })
+            {
+                var label = segment ?? "default";
+                Assert.AreEqual($"The second content value in Danish ({label})", BlockValue(segment, "da-DK"));
+                Assert.AreEqual(
+                    updateWithLimitedUserAccess
+                        ? $"The first content value in English ({label})"
+                        : $"The second content value in English ({label})",
+                    BlockValue(segment, "en-US"));
+            }
+        });
+
+        BlockListValue BlockValueForSegment(string label) => BlockListPropertyValue(
+            elementType,
+            [
+                (
+                    contentElementKey,
+                    settingsElementKey,
+                    new BlockProperty(
+                        new List<BlockPropertyValue>
+                        {
+                            new() { Alias = "invariantText", Value = $"The first invariant content value ({label})" },
+                            new() { Alias = "variantText", Value = $"The first content value in English ({label})", Culture = "en-US" },
+                            new() { Alias = "variantText", Value = $"The first content value in Danish ({label})", Culture = "da-DK" }
+                        },
+                        [],
+                        null,
+                        null))
+            ]);
+
+        BlockListValue UpdatedBlockValueForSegment(string label)
+        {
+            BlockListValue blockListValue = BlockValueForSegment(label);
+            foreach (BlockPropertyValue value in blockListValue.ContentData[0].Values)
+            {
+                value.Value = ((string)value.Value!).Replace("The first", "The second");
+            }
+
+            return blockListValue;
+        }
+
+        string? BlockValue(string? segment, string culture)
+        {
+            var savedBlocksValue = content?.Properties["blocks"]?.GetValue(null, segment)?.ToString();
+            Assert.NotNull(savedBlocksValue);
+            return JsonSerializer.Deserialize<BlockListValue>(savedBlocksValue)!.ContentData[0].Values
+                .Single(value => value.Alias == "variantText" && value.Culture == culture).Value as string;
+        }
+    }
+
     private async Task<IUser> CreateLimitedUser()
     {
         var userGroupService = GetRequiredService<IUserGroupService>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -908,6 +908,118 @@ internal partial class BlockListElementLevelVariationTests
         }
     }
 
+    /// <summary>
+    /// A segment variant, culture invariant block property on a culture variant content type opts into
+    /// partial property publishing, which publishes every segment of the property, not just the default one.
+    /// </summary>
+    /// <remarks>
+    /// Regression test for https://github.com/umbraco/Umbraco-CMS/issues/23553.
+    /// </remarks>
+    [Test]
+    public async Task Can_Publish_Segment_Variant_Blocks_On_Culture_Variant_Content_Type()
+    {
+        // Arrange: prepare a culture variant content type with a segment variant block property,
+        // and create content with values for the default segment and one other segment.
+        const string Segment1 = "s1";
+
+        var elementType = CreateElementType(ContentVariation.Nothing);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateSegmentVariantPropertiesContentType(blockListDataType);
+
+        var content = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithCultureName("en-US", "Home (en)")
+            .WithCultureName("da-DK", "Home (da)")
+            .Build();
+
+        content.SetValue("title", "The default segment title");
+        content.SetValue("title", "The segment 1 title", null, Segment1);
+        content.SetValue("blocks", BlockListPropertyValueJson("The default segment block value"));
+        content.SetValue("blocks", BlockListPropertyValueJson("The segment 1 block value"), null, Segment1);
+
+        // Act: save and publish the content.
+        ContentService.Save(content);
+        PublishContent(content, contentType);
+
+        // Assert: retrieve the published content and assert that all segments of the block property
+        // are published, and the published cache has the same values.
+        var publishedContent = ContentService.GetById(content.Key);
+        Assert.IsNotNull(publishedContent);
+
+        Assert.Multiple(() =>
+        {
+            // A non-block property with the same variation publishes all its segments...
+            Assert.AreEqual("The default segment title", publishedContent.GetValue<string>("title", published: true));
+            Assert.AreEqual("The segment 1 title", publishedContent.GetValue<string>("title", segment: Segment1, published: true));
+
+            // ...and so should the block property.
+            Assert.AreEqual("The default segment block value", PublishedBlockValue(publishedContent, null));
+            Assert.AreEqual("The segment 1 block value", PublishedBlockValue(publishedContent, Segment1));
+        });
+
+        AssertPublishedCacheBlockValue(null, "The default segment block value");
+        AssertPublishedCacheBlockValue(Segment1, "The segment 1 block value");
+
+        string BlockListPropertyValueJson(string invariantTextValue)
+        {
+            var blockListValue = BlockListPropertyValue(
+                elementType,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                new BlockProperty(
+                    [new() { Alias = "invariantText", Value = invariantTextValue }],
+                    [],
+                    null,
+                    null));
+            return JsonSerializer.Serialize(blockListValue);
+        }
+
+        string? PublishedBlockValue(IContent target, string? segment)
+        {
+            var value = target.GetValue<string>("blocks", segment: segment, published: true);
+            return value is null
+                ? null
+                : JsonSerializer.Deserialize<BlockListValue>(value)?.ContentData.FirstOrDefault()?.Values
+                    .FirstOrDefault(propertyValue => propertyValue.Alias == "invariantText")?.Value as string;
+        }
+
+        void AssertPublishedCacheBlockValue(string? segment, string expectedInvariantContentValue)
+        {
+            SetVariationContext("en-US", segment);
+            var cachedContent = GetPublishedContent(content.Key);
+
+            var value = cachedContent.Value<BlockListModel>("blocks");
+            Assert.IsNotNull(value);
+            Assert.AreEqual(1, value.Count);
+            Assert.AreEqual(expectedInvariantContentValue, value.First().Content.Value<string>("invariantText"));
+        }
+    }
+
+    private IContentType CreateSegmentVariantPropertiesContentType(IDataType blocksEditorDataType)
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("myPage")
+            .WithName("My Page")
+            .WithContentVariation(ContentVariation.CultureAndSegment)
+            .AddPropertyType()
+            .WithAlias("title")
+            .WithName("Title")
+            .WithDataTypeId(Constants.DataTypes.Textbox)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+            .WithValueStorageType(ValueStorageType.Nvarchar)
+            .WithVariations(ContentVariation.Segment)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("blocks")
+            .WithName("Blocks")
+            .WithDataTypeId(blocksEditorDataType.Id)
+            .WithVariations(ContentVariation.Segment)
+            .Done()
+            .Build();
+        ContentTypeService.Save(contentType);
+        return contentType;
+    }
+
     [Test]
     public async Task Can_Publish_With_Blocks_Removed()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -924,7 +924,7 @@ internal partial class BlockListElementLevelVariationTests
 
         var elementType = CreateElementType(ContentVariation.Nothing);
         var blockListDataType = await CreateBlockListDataType(elementType);
-        var contentType = CreateSegmentVariantPropertiesContentType(blockListDataType);
+        var contentType = await CreateSegmentVariantPropertiesContentType(blockListDataType);
 
         var content = new ContentBuilder()
             .WithContentType(contentType)
@@ -995,7 +995,7 @@ internal partial class BlockListElementLevelVariationTests
         }
     }
 
-    private IContentType CreateSegmentVariantPropertiesContentType(IDataType blocksEditorDataType)
+    private async Task<IContentType> CreateSegmentVariantPropertiesContentType(IDataType blocksEditorDataType)
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias("myPage")
@@ -1016,7 +1016,7 @@ internal partial class BlockListElementLevelVariationTests
             .WithVariations(ContentVariation.Segment)
             .Done()
             .Build();
-        ContentTypeService.Save(contentType);
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
         return contentType;
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Update.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Update.cs
@@ -244,6 +244,132 @@ public partial class ContentEditingServiceTests
         }
     }
 
+    /// <summary>
+    /// A culture the editing user has no access to is restored from the existing content for every segment of
+    /// that culture, not only its segment-less value.
+    /// </summary>
+    [Test]
+    public async Task Can_Retain_Existing_Segment_Values_For_Culture_Without_Access()
+    {
+        // Arrange: prepare culture and segment variant content, and an editor with access to
+        // English only, so every segment of the Danish culture is off limits to them.
+        var content = await CreateCultureAndSegmentVariantContent(ContentVariation.Segment);
+        var editor = await CreateEnglishLanguageOnlyEditor();
+
+        var updateModel = new ContentUpdateModel
+        {
+            Properties =
+            [
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated default English title", Culture = "en-US" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-1 English title", Culture = "en-US", Segment = "seg-1" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-2 English title", Culture = "en-US", Segment = "seg-2" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated default Danish title", Culture = "da-DK" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-1 Danish title", Culture = "da-DK", Segment = "seg-1" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-2 Danish title", Culture = "da-DK", Segment = "seg-2" },
+                new PropertyValueModel { Alias = "otherTitle", Value = "The updated other default title" },
+                new PropertyValueModel { Alias = "otherTitle", Value = "The updated other seg-1 title", Segment = "seg-1" },
+                new PropertyValueModel { Alias = "otherTitle", Value = "The updated other seg-2 title", Segment = "seg-2" },
+            ],
+            Variants =
+            [
+                new VariantModel { Name = "The Updated English Name", Culture = "en-US" },
+                new VariantModel { Name = "The Updated Danish Name", Culture = "da-DK" },
+            ],
+        };
+
+        // Act: update the content as the English only editor, attempting to change every culture and segment.
+        var result = await ContentEditingService.UpdateAsync(content.Key, updateModel, editor.Key);
+        Assert.IsTrue(result.Success);
+
+        // Assert: the English values are updated and every segment of the Danish culture keeps its
+        // initial value, both on the returned content and on a re-get.
+        VerifyUpdate(result.Result.Content);
+        VerifyUpdate(await ContentEditingService.GetAsync(content.Key));
+
+        void VerifyUpdate(IContent? updatedContent)
+        {
+            Assert.IsNotNull(updatedContent);
+            Assert.Multiple(() =>
+            {
+                // The editor has access to English, so all of its segments are updated.
+                Assert.AreEqual("The updated default English title", updatedContent.GetValue<string>("variantTitle", culture: "en-US", segment: null));
+                Assert.AreEqual("The updated seg-1 English title", updatedContent.GetValue<string>("variantTitle", culture: "en-US", segment: "seg-1"));
+                Assert.AreEqual("The updated seg-2 English title", updatedContent.GetValue<string>("variantTitle", culture: "en-US", segment: "seg-2"));
+
+                // The editor has no access to Danish, so every segment of it keeps its initial value.
+                Assert.AreEqual("The initial title in Danish", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: null));
+                Assert.AreEqual("The initial seg-1 title in Danish", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: "seg-1"));
+                Assert.AreEqual("The initial seg-2 title in Danish", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: "seg-2"));
+
+                // The editor has access to the default language, so the culture invariant property is updated.
+                Assert.AreEqual("The updated other default title", updatedContent.GetValue<string>("otherTitle", culture: null, segment: null));
+                Assert.AreEqual("The updated other seg-1 title", updatedContent.GetValue<string>("otherTitle", culture: null, segment: "seg-1"));
+                Assert.AreEqual("The updated other seg-2 title", updatedContent.GetValue<string>("otherTitle", culture: null, segment: "seg-2"));
+            });
+        }
+    }
+
+    /// <summary>
+    /// A culture invariant property the editing user is not allowed to change is restored from the existing
+    /// content for every segment, not only its segment-less value.
+    /// </summary>
+    /// <remarks>
+    /// The editor is restricted to a non-default language, which is what withholds access to culture
+    /// invariant properties when the AllowEditInvariantFromNonDefault content setting is false.
+    /// </remarks>
+    [Test]
+    public async Task Can_Retain_Existing_Segment_Values_For_Invariant_Property_Without_Access()
+    {
+        // Arrange: prepare culture and segment variant content with a culture invariant, segment variant
+        // "otherTitle" property, and an editor with access to Danish only - not the default language.
+        var content = await CreateCultureAndSegmentVariantContent(ContentVariation.Segment);
+        var editor = await CreateSingleLanguageEditor("da-DK");
+
+        var updateModel = new ContentUpdateModel
+        {
+            Properties =
+            [
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated default Danish title", Culture = "da-DK" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-1 Danish title", Culture = "da-DK", Segment = "seg-1" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-2 Danish title", Culture = "da-DK", Segment = "seg-2" },
+                new PropertyValueModel { Alias = "otherTitle", Value = "The updated other default title" },
+                new PropertyValueModel { Alias = "otherTitle", Value = "The updated other seg-1 title", Segment = "seg-1" },
+                new PropertyValueModel { Alias = "otherTitle", Value = "The updated other seg-2 title", Segment = "seg-2" },
+            ],
+            Variants =
+            [
+                new VariantModel { Name = "The Updated Danish Name", Culture = "da-DK" },
+            ],
+        };
+
+        // Act: update the content as the Danish only editor, attempting to change the culture invariant property.
+        var result = await ContentEditingService.UpdateAsync(content.Key, updateModel, editor.Key);
+        Assert.IsTrue(result.Success);
+
+        // Assert: the Danish values are updated and every segment of the culture invariant property keeps
+        // its initial value, both on the returned content and on a re-get.
+        VerifyUpdate(result.Result.Content);
+        VerifyUpdate(await ContentEditingService.GetAsync(content.Key));
+
+        void VerifyUpdate(IContent? updatedContent)
+        {
+            Assert.IsNotNull(updatedContent);
+            Assert.Multiple(() =>
+            {
+                // The editor has access to Danish, so all of its segments are updated.
+                Assert.AreEqual("The updated default Danish title", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: null));
+                Assert.AreEqual("The updated seg-1 Danish title", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: "seg-1"));
+                Assert.AreEqual("The updated seg-2 Danish title", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: "seg-2"));
+
+                // The editor has no access to the default language, so every segment of the culture
+                // invariant property keeps its initial value.
+                Assert.AreEqual("The initial other default title", updatedContent.GetValue<string>("otherTitle", culture: null, segment: null));
+                Assert.AreEqual("The initial other seg-1 title", updatedContent.GetValue<string>("otherTitle", culture: null, segment: "seg-1"));
+                Assert.AreEqual("The initial other seg-2 title", updatedContent.GetValue<string>("otherTitle", culture: null, segment: "seg-2"));
+            });
+        }
+    }
+
     [Test]
     public async Task Can_Update_Template()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Update.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Update.cs
@@ -310,6 +310,56 @@ public partial class ContentEditingServiceTests
     }
 
     /// <summary>
+    /// A segment omitted from the update model is restored for a culture the editing user has no access to,
+    /// rather than being cleared by the omission.
+    /// </summary>
+    [Test]
+    public async Task Can_Retain_Omitted_Segment_Value_For_Culture_Without_Access()
+    {
+        // Arrange: prepare culture and segment variant content, and an editor with access to English only.
+        var content = await CreateCultureAndSegmentVariantContent(ContentVariation.Segment);
+        var editor = await CreateEnglishLanguageOnlyEditor();
+
+        // The update model deliberately omits the seg-2 value of the Danish culture, so the segment is
+        // only present on the existing content.
+        var updateModel = new ContentUpdateModel
+        {
+            Properties =
+            [
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated default English title", Culture = "en-US" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-1 English title", Culture = "en-US", Segment = "seg-1" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-2 English title", Culture = "en-US", Segment = "seg-2" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated default Danish title", Culture = "da-DK" },
+                new PropertyValueModel { Alias = "variantTitle", Value = "The updated seg-1 Danish title", Culture = "da-DK", Segment = "seg-1" },
+            ],
+            Variants =
+            [
+                new VariantModel { Name = "The Updated English Name", Culture = "en-US" },
+                new VariantModel { Name = "The Updated Danish Name", Culture = "da-DK" },
+            ],
+        };
+
+        // Act: update the content as the English only editor.
+        var result = await ContentEditingService.UpdateAsync(content.Key, updateModel, editor.Key);
+        Assert.IsTrue(result.Success);
+
+        // Assert: every segment of the Danish culture keeps its initial value, including the omitted one.
+        VerifyUpdate(result.Result.Content);
+        VerifyUpdate(await ContentEditingService.GetAsync(content.Key));
+
+        void VerifyUpdate(IContent? updatedContent)
+        {
+            Assert.IsNotNull(updatedContent);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual("The initial title in Danish", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: null));
+                Assert.AreEqual("The initial seg-1 title in Danish", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: "seg-1"));
+                Assert.AreEqual("The initial seg-2 title in Danish", updatedContent.GetValue<string>("variantTitle", culture: "da-DK", segment: "seg-2"));
+            });
+        }
+    }
+
+    /// <summary>
     /// A culture invariant property the editing user is not allowed to change is restored from the existing
     /// content for every segment, not only its segment-less value.
     /// </summary>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Validate.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Validate.cs
@@ -349,13 +349,16 @@ public partial class ContentEditingServiceTests
         };
     }
 
-    private async Task<IUser> CreateEnglishLanguageOnlyEditor()
+    private async Task<IUser> CreateEnglishLanguageOnlyEditor() => await CreateSingleLanguageEditor("en-US");
+
+    private async Task<IUser> CreateSingleLanguageEditor(string isoCode)
     {
-        var enUSLanguage = await LanguageService.GetAsync("en-US");
+        var language = await LanguageService.GetAsync(isoCode);
+        var alias = isoCode.Replace("-", string.Empty);
         var userGroup = new UserGroupBuilder()
-            .WithName("English Editors")
-            .WithAlias("englishEditors")
-            .WithAllowedLanguages([enUSLanguage.Id])
+            .WithName($"{isoCode} Editors")
+            .WithAlias($"{alias}Editors")
+            .WithAllowedLanguages([language.Id])
             .Build();
 
         var createUserGroupResult = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
@@ -363,9 +366,9 @@ public partial class ContentEditingServiceTests
 
         var createUserAttempt = await UserService.CreateAsync(Constants.Security.SuperUserKey, new UserCreateModel
         {
-            Email = "english-editor@test.com",
-            Name = "Test English Editor",
-            UserName = "english-editor@test.com",
+            Email = $"{alias}-editor@test.com",
+            Name = $"Test {isoCode} Editor",
+            UserName = $"{alias}-editor@test.com",
             UserGroupKeys = new[] { userGroup.Key }.ToHashSet(),
         });
         Assert.IsTrue(createUserAttempt.Success);


### PR DESCRIPTION
## Description

Publishing a document silently discarded the segment variant values of any Block List, Block Grid, Single Block or Rich Text property, when the **document type varies by culture** and the **property itself varies by segment but not by culture**.

The values were written to the draft correctly and were visible in preview, but never copied into the published version, so the front end rendered the default segment.

Fixes #23553.

_Note for reviewer: please make sure to also read "Additional Issues Resolved" at the bottom of this description._

### The root cause

The routing is in `ContentRepositoryExtensions.PublishPropertyValues`. When the content type varies by culture, a data editor can opt into *partial* property publishing:

```csharp
if (content.ContentType.VariesByCulture()
    && propertyEditorCollection.TryGet(property.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor)
    && dataEditor.CanMergePartialPropertyValues(property.PropertyType))
{
    property.PublishPartialValues(dataEditor, culture);
    return;
}

property.PublishValues(culture);
```

The two branches did not behave alike:

- `PublishValues(culture, segment = "*")` iterates `_vvalues`, so every segment gets published.
- `PublishPartialValues` only ever published `_pvalue` — the neutral value — and never looked at `_vvalues` at all.

The block editors opt in for exactly the configuration described above, since `CanMergePartialPropertyValues(propertyType) => propertyType.VariesByCulture() is false` is satisfied by a segment-only variant property. So those properties took the partial branch and lost every segment value.

  The block editors opt in for any culture invariant property, since `CanMergePartialPropertyValues(propertyType) => propertyType.VariesByCulture()` is `false`. That covers two cases:
 - A fully invariant property. This is the case partial publishing exists for, and it works correctly — there are no varying values, so publishing only `_pvalue` is complete.
 - A segment variant property. Here `_vvalues` holds one entry per segment, and every one of them was dropped.

All three conditions have to hold to hit it, which is why it isn't more widely seen:

1. The document type varies by culture.
2. The property is a Block List, Block Grid, Single Block or Rich Text property.
3. The property varies by segment but **not** by culture.

### The fix

`Property.PublishPartialValues` now publishes the default value *and* each varying value, so the partial branch covers all segments in the same way `PublishValues` already does.

Since the method throws for culture variant properties, everything in `_vvalues` at that point is by definition a segment value — hence the filter mirrors the validity check `PublishValues` uses rather than needing a culture predicate.

The fix is in the shared code path behind all four editors named in the issue, so one change covers Block List, Block Grid, Single Block and Rich Text.

## Testing

### Automated

`BlockListElementLevelVariationTests.Publishing.cs` → `Can_Publish_Segment_Variant_Blocks_On_Culture_Variant_Content_Type`.

It builds exactly the three conditions above — a `CultureAndSegment` content type with a `Segment`-only Block List property — and adds a Textstring of *identical* variation as a control, so the assertion isolates the block editor path rather than segments in general. Both properties get a default-segment and an `s1`-segment value, then the document is saved and published for both cultures.

It asserts on the persisted published values read back through `IContentService` (the equivalent of the SQL check in the issue), and then on a published cache read via `BlockListModel` to cover the front end impact.

Verified to fail before the fix and pass after. Without the fix, only the block assertion fails:

```
Expected: "The segment 1 block value"
But was:  null
```

The test covers Block List only. The defect is in shared code, and the per-editor `MergePartialPropertyValueForCulture` implementations already have their own coverage, so a test per editor would not add much.

### Manual

I've run the following locally to also verify the fix via actual content and custom code.

#### a) Document type and content setup

Two languages are needed. Any second language works — the issue uses Danish, this was run with `en-US` (default) and `it`.

**Element type — `23553 Text Block`** (alias `textBlock23553`)

| Setting | Value |
|---|---|
| Is element type | yes |
| Variation | invariant (neither culture nor segment) |
| Property | `text` — Textstring |

**Data type — `23553 Blocks - Block List`**

A Block List allowing `23553 Text Block` as a content element type. No settings element type.

**Document type — `23553 Page`** (alias `page23553`)

| Setting | Value |
|---|---|
| Allow varying by culture | **ticked** |
| Allow segmentation | **ticked** |
| Allowed at root | yes |

| Property | Editor | Vary by culture | Vary by segments |
|---|---|---|---|
| `title` | Textstring | **no** | **yes** |
| `blocks` | `23553 Blocks - Block List` | **no** | **yes** |

`title` is the control: same variance as `blocks`, but a non-block editor, so it publishes its segment value correctly and makes the contrast obvious.

**Content**

Create one `23553 Page` at root. Fill in `title`, add a single block to `blocks` and set its `text`, then publish all languages. That establishes the default segment values that the controller clones.

**Segments**

To pick the segment in the backoffice UI, an `ISegmentService` has to offer it, registered in a composer alongside `SegmentSettings.Enabled = true`. The controller below sets the segment value programmatically, so this is only needed for driving the repro through the UI:

```csharp
public class MySegmentService : ISegmentService
{
    private readonly Segment[] _segments =
    [
        new() { Alias = "test", Name = "Test" },
        new() { Alias = "other", Name = "Other" }
    ];

    public Task<Attempt<PagedModel<Segment>?, SegmentOperationStatus>> GetPagedSegmentsAsync(int skip = 0, int take = 100)
        => Task.FromResult(
            Attempt.SucceedWithStatus<PagedModel<Segment>?, SegmentOperationStatus>(
                SegmentOperationStatus.Success,
                new PagedModel<Segment> { Total = _segments.Length, Items = _segments.Skip(skip).Take(take) }));
}
```

#### b) Controller used to replicate and verify

Dropped into `Umbraco.Web.UI/Controllers`. Three endpoints, plain text outputs:

| Endpoint | Effect |
|---|---|
| `/debug/segment-block-publish` | Report only, mutates nothing |
| `/debug/segment-block-publish/run` | Writes a segment value to **both** properties, Save + Publish `["*"]`, then reports |
| `/debug/segment-block-publish/reset` | Clears the segment values and republishes, for a clean re-run |

`?key=<guid>` and `?segment=<alias>` override the defaults. Each report prints the resolved variance, draft vs published per property via `IContentService`, a verdict line, the SQL query from the issue over `umbracoPropertyData`, and the `umbracoDocumentCultureVariation` rows.

`/run` follows the issue's repro step 5 exactly: it clones the JSON already saved on the default segment and changes the block's text, rather than authoring fresh JSON.

Set `DefaultDocumentKey` to your own document's key before running.

<details>
<summary>DebugSegmentBlockPublishController.cs</summary>

```csharp
using System.Text;
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Models.Blocks;
using Umbraco.Cms.Core.Serialization;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Infrastructure.Scoping;

namespace Umbraco.Cms.Web.UI.Controllers;

// Local-only diagnostic for issue #23553: publishing silently discards the segment variant values of a
// Block List / Block Grid / Single Block / Rich Text property when the document type varies by culture
// and the property itself varies by segment but NOT by culture.
//
// Usage:
//   /debug/segment-block-publish              - report only, mutates nothing
//   /debug/segment-block-publish/run          - write a segment value to BOTH properties, Save, Publish, report
//   /debug/segment-block-publish/reset        - clear the segment values and republish, for a clean re-run
//
// Optional query string on all three: ?key=<guid> and ?segment=<alias> (defaults below).
//
// Broken (without fix): after /run the "blocks" row for the segment exists in the PUBLISHED version but
//                       its value is EMPTY, while "title" carries its segment value across. The verdict
//                       block reports blocks published = MISSING.
// Expected (with fix):  both "title" and "blocks" hold the segment value in the PUBLISHED version.
public class DebugSegmentBlockPublishController : Controller
{
    private const string DefaultDocumentKey = "decfd36b-3692-4e9c-9000-bbecdda635de";
    private const string DefaultSegment = "test";
    private const string TitleAlias = "title";
    private const string BlocksAlias = "blocks";

    private readonly IContentService _contentService;
    private readonly IJsonSerializer _jsonSerializer;
    private readonly IScopeProvider _scopeProvider;

    public DebugSegmentBlockPublishController(
        IContentService contentService,
        IJsonSerializer jsonSerializer,
        IScopeProvider scopeProvider)
    {
        _contentService = contentService;
        _jsonSerializer = jsonSerializer;
        _scopeProvider = scopeProvider;
    }

    [HttpGet("/debug/segment-block-publish")]
    public IActionResult Report([FromQuery] Guid? key = null, [FromQuery] string? segment = null)
        => Execute(key, segment, Mode.Report);

    [HttpGet("/debug/segment-block-publish/run")]
    public IActionResult Run([FromQuery] Guid? key = null, [FromQuery] string? segment = null)
        => Execute(key, segment, Mode.Populate);

    [HttpGet("/debug/segment-block-publish/reset")]
    public IActionResult Reset([FromQuery] Guid? key = null, [FromQuery] string? segment = null)
        => Execute(key, segment, Mode.Clear);

    private IActionResult Execute(Guid? key, string? segment, Mode mode)
    {
        Guid documentKey = key ?? Guid.Parse(DefaultDocumentKey);
        segment = string.IsNullOrWhiteSpace(segment) ? DefaultSegment : segment;

        var sb = new StringBuilder();
        sb.AppendLine("=== Segment values on block properties, on publish (#23553) ===");
        sb.AppendLine($"Document: {documentKey}");
        sb.AppendLine($"Segment:  {segment}");
        sb.AppendLine($"Mode:     {mode}");
        sb.AppendLine();

        IContent? content = _contentService.GetById(documentKey);
        if (content is null)
        {
            sb.AppendLine("Document not found.");
            return Content(sb.ToString(), "text/plain");
        }

        AppendVariance(sb, content);

        if (mode != Mode.Report)
        {
            if (!TryMutateAndPublish(sb, content, segment, mode))
            {
                return Content(sb.ToString(), "text/plain");
            }

            // re-read so the report reflects what was actually persisted, not the in-memory instance
            content = _contentService.GetById(documentKey)!;
        }

        AppendVerdict(sb, content, segment);
        AppendPropertyDataRows(sb, content.Id);
        AppendCultureVariationRows(sb, content.Id);

        return Content(sb.ToString(), "text/plain");
    }

    private bool TryMutateAndPublish(StringBuilder sb, IContent content, string segment, Mode mode)
    {
        sb.AppendLine($"--- {(mode == Mode.Clear ? "CLEARING" : "WRITING")} segment values ---");

        if (mode == Mode.Clear)
        {
            content.SetValue(TitleAlias, null, null, segment);
            content.SetValue(BlocksAlias, null, null, segment);
            sb.AppendLine($"  {TitleAlias}:  (cleared)");
            sb.AppendLine($"  {BlocksAlias}: (cleared)");
        }
        else
        {
            var titleValue = $"Segment '{segment}' title";
            content.SetValue(TitleAlias, titleValue, null, segment);
            sb.AppendLine($"  {TitleAlias}:  {titleValue}");

            // exactly as the issue's repro step 5 does it: reuse the JSON already saved on the default
            // segment, with the block's text changed so the two segments are visibly different
            var neutralBlocksJson = content.GetValue<string>(BlocksAlias);
            if (neutralBlocksJson is null)
            {
                sb.AppendLine($"  {BlocksAlias}: ABORTED - no default segment value to clone. Set one first.");
                return false;
            }

            BlockListValue? blockListValue = _jsonSerializer.Deserialize<BlockListValue>(neutralBlocksJson);
            BlockPropertyValue? blockText = blockListValue?.ContentData.FirstOrDefault()?.Values
                .FirstOrDefault(x => x.Alias == "text");
            if (blockText is null)
            {
                sb.AppendLine($"  {BlocksAlias}: ABORTED - could not find the block's 'text' value to change.");
                return false;
            }

            blockText.Value = $"Segment '{segment}' block text";
            content.SetValue(BlocksAlias, _jsonSerializer.Serialize(blockListValue), null, segment);
            sb.AppendLine($"  {BlocksAlias}: {blockText.Value}");
        }

        sb.AppendLine();

        _contentService.Save(content);
        PublishResult publishResult = _contentService.Publish(content, ["*"]);
        sb.AppendLine($"Publish result: {publishResult.Result} (success: {publishResult.Success})");
        sb.AppendLine();

        return true;
    }

    private static void AppendVariance(StringBuilder sb, IContent content)
    {
        sb.AppendLine("--- Variance ---");
        sb.AppendLine($"  content type '{content.ContentType.Alias}': {content.ContentType.Variations}");
        foreach (IProperty property in content.Properties.OrderBy(x => x.Alias))
        {
            sb.AppendLine(
                $"  property '{property.Alias}' ({property.PropertyType.PropertyEditorAlias}): {property.PropertyType.Variations}");
        }

        sb.AppendLine();
    }

    private static void AppendVerdict(StringBuilder sb, IContent content, string segment)
    {
        sb.AppendLine("--- Draft vs published, via IContentService ---");

        (var titleDraft, var titlePublished) = Describe(TitleAlias);
        (var blocksDraft, var blocksPublished) = Describe(BlocksAlias);

        sb.AppendLine();
        sb.AppendLine(DescribeVerdict());
        sb.AppendLine();

        string DescribeVerdict()
        {
            if (!titleDraft && !blocksDraft)
            {
                return $"VERDICT: nothing to assess - no segment '{segment}' value on the draft yet. Run /debug/segment-block-publish/run first.";
            }

            if (titlePublished && blocksPublished)
            {
                return "VERDICT: both properties published their segment value - behaving as expected (fixed).";
            }

            if (blocksDraft && !blocksPublished && titlePublished)
            {
                return $"VERDICT: '{BlocksAlias}' did NOT publish its segment value while '{TitleAlias}' did - this is #23553 (unfixed).";
            }

            return "VERDICT: unexpected combination - inspect the rows below.";
        }

        (bool Draft, bool Published) Describe(string alias)
        {
            var draft = content.GetValue<string>(alias, segment: segment);
            var published = content.GetValue<string>(alias, segment: segment, published: true);
            sb.AppendLine($"  {alias}");
            sb.AppendLine($"    draft:     {Summarise(draft)}");
            sb.AppendLine($"    published: {Summarise(published)}");
            return (!string.IsNullOrEmpty(draft), !string.IsNullOrEmpty(published));
        }

        static string Summarise(string? value) => value is null
            ? "MISSING (null)"
            : value.Length == 0
                ? "MISSING (empty)"
                : value.Length <= 120
                    ? value
                    : value[..120] + "...";
    }

    // The query from the issue, plus a truncated value so the EMPTY rows are unambiguous.
    // SQL Server only (this dev site runs SQL Express).
    private void AppendPropertyDataRows(StringBuilder sb, int nodeId)
    {
        const string sql = """
                           SELECT pt.alias                                        AS PropertyAlias,
                                  pd.segment                                      AS Segment,
                                  CASE WHEN pd.textValue IS NULL AND pd.varcharValue IS NULL
                                       THEN 'EMPTY' ELSE 'has value' END          AS State,
                                  CASE WHEN dv.published = 1
                                       THEN 'PUBLISHED' ELSE 'draft' END          AS VersionState,
                                  LEFT(COALESCE(CAST(pd.textValue AS nvarchar(4000)), pd.varcharValue), 80) AS ValueSnippet
                           FROM   umbracoContentVersion cv
                                  LEFT JOIN umbracoDocumentVersion dv ON dv.id = cv.id
                                  JOIN umbracoPropertyData pd ON pd.versionId = cv.id
                                  JOIN cmsPropertyType pt ON pt.id = pd.propertyTypeId
                           WHERE  cv.nodeId = @0
                             AND  pd.segment IS NOT NULL
                             AND  (cv.[current] = 1 OR dv.published = 1)
                           ORDER BY VersionState, pt.alias, pd.segment
                           """;

        sb.AppendLine("--- umbracoPropertyData, segment rows only ---");

        using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
        List<PropertyDataRow> rows = scope.Database.Fetch<PropertyDataRow>(sql, nodeId);

        if (rows.Count == 0)
        {
            sb.AppendLine("  (no segment rows at all - run /debug/segment-block-publish/run first)");
            sb.AppendLine();
            return;
        }

        sb.AppendLine($"  {"version",-10} {"property",-10} {"segment",-12} {"state",-10} value");
        foreach (PropertyDataRow row in rows)
        {
            sb.AppendLine(
                $"  {row.VersionState,-10} {row.PropertyAlias,-10} {row.Segment,-12} {row.State,-10} {row.ValueSnippet}");
        }

        sb.AppendLine();
    }

    // The issue also notes edited = 0 for every language after the save, so the backoffice shows no
    // pending changes and the editor gets no hint that anything was dropped.
    private void AppendCultureVariationRows(StringBuilder sb, int nodeId)
    {
        const string sql = """
                           SELECT l.languageISOCode AS Culture,
                                  dcv.edited       AS Edited,
                                  dcv.available    AS Available
                           FROM   umbracoDocumentCultureVariation dcv
                                  JOIN umbracoLanguage l ON l.id = dcv.languageId
                           WHERE  dcv.nodeId = @0
                           ORDER BY l.languageISOCode
                           """;

        sb.AppendLine("--- umbracoDocumentCultureVariation ---");

        using IScope scope = _scopeProvider.CreateScope(autoComplete: true);
        List<CultureVariationRow> rows = scope.Database.Fetch<CultureVariationRow>(sql, nodeId);

        foreach (CultureVariationRow row in rows)
        {
            sb.AppendLine($"  {row.Culture,-8} edited: {row.Edited,-6} available: {row.Available}");
        }

        sb.AppendLine();
    }

    private enum Mode
    {
        Report,
        Populate,
        Clear
    }

    private class PropertyDataRow
    {
        public string PropertyAlias { get; set; } = string.Empty;

        public string? Segment { get; set; }

        public string State { get; set; } = string.Empty;

        public string VersionState { get; set; } = string.Empty;

        public string? ValueSnippet { get; set; }
    }

    private class CultureVariationRow
    {
        public string Culture { get; set; } = string.Empty;

        public bool Edited { get; set; }

        public bool Available { get; set; }
    }
}
```

</details>

### Observed results

Run against the **unfixed** build, `/debug/segment-block-publish/run`:

```
--- Draft vs published, via IContentService ---
  title
    draft:     Segment 'test' title
    published: Segment 'test' title
  blocks
    draft:     {"contentData":[{"contentTypeKey":"c8aac633-...","key":"2c9f1a30-...","v...
    published: MISSING (null)

VERDICT: 'blocks' did NOT publish its segment value while 'title' did - this is #23553 (unfixed).

--- umbracoPropertyData, segment rows only ---
  version    property   segment      state      value
  draft      blocks     test         has value  {"contentData":[{"contentTypeKey":"c8aac633-...
  draft      title      test         has value  Segment 'test' title
  PUBLISHED  blocks     test         EMPTY
  PUBLISHED  title      test         has value  Segment 'test' title

--- umbracoDocumentCultureVariation ---
  en-US    edited: False  available: True
  it       edited: False  available: True
```

The published `blocks` row for the segment exists but is `EMPTY`, while `title` carries its segment value across — and `edited` is `False` for every language, which is why the backoffice shows no pending changes.

Same request against the **fixed** build, after a `/reset`:

```
--- Draft vs published, via IContentService ---
  title
    draft:     Segment 'test' title
    published: Segment 'test' title
  blocks
    draft:     {"contentData":[{"contentTypeKey":"c8aac633-...","key":"2c9f1a30-...","v...
    published: {"contentData":[{"contentTypeKey":"c8aac633-...","key":"2c9f1a30-...","v...

VERDICT: both properties published their segment value - behaving as expected (fixed).

--- umbracoPropertyData, segment rows only ---
  version    property   segment      state      value
  draft      blocks     test         has value  {"contentData":[{"contentTypeKey":"c8aac633-...
  draft      title      test         has value  Segment 'test' title
  PUBLISHED  blocks     test         has value  {"contentData":[{"contentTypeKey":"c8aac633-...
  PUBLISHED  title      test         has value  Segment 'test' title
```

## Additional Issues Resolved

In review, I found the following additional issues where a similar situation was in place, with segments either not being restored, or being restored from the wrong segment.

All of these sit in the *editing* path rather than the publishing path this issue reports. When a user edits content in a language they have no access to, `ContentEditingService.EnsureOnlyAllowedFieldsAreUpdated` overwrites the values they were not allowed to change with the values already held by the existing content. Every place that did so considered only the segment-less value, so a segment variant property kept whatever the request supplied for its segments.

- **A culture the user has no access to** — only the segment-less value of that culture was restored, so its segment values were left as submitted. (`Can_Retain_Existing_Segment_Values_For_Culture_Without_Access`, and `Can_Retain_Omitted_Segment_Value_For_Culture_Without_Access` for a segment the request omits entirely.)
- **A culture invariant property the user is not allowed to change** — the same, for the case where `AllowEditInvariantFromNonDefault` is false and the user has no access to the default language. (`Can_Retain_Existing_Segment_Values_For_Invariant_Property_Without_Access`.)
- **A block property that varies by segment** — only the segment-less value was handed to the block editor's merge, so every other segment bypassed the permission merge altogether and unauthorised culture data was persisted unchecked. (`Can_Handle_Limited_User_Access_To_Languages_With_Segment_Variant_Block_Property`.)
- **A block whose element type varies by culture and segment** — `BlockValuePropertyValueEditorBase.CleanupVariantValues` matched a block property value back to its source on alias and culture only, so a segmented value was restored from the segment-less value of the same culture and ended up holding the wrong content. `RestoreMissingValues` in the same class already matched on the segment too. (`Can_Handle_Limited_User_Access_To_Languages_With_Segment_Variant_Elements`.)

Each of these has been resolved via firstly writing an integration test that replicates the concern and fails, providing a production fix and verifying that the test now passes. In each case the segment-less value acts as a control within the test - it was already handled correctly, so only the segment assertions fail beforehand.


---
_This item has been added to our backlog AB#71559_