### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,8 +46,8 @@
   </ItemGroup>
   <!-- Third-party packages -->
   <ItemGroup>
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.1" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
     <PackageVersion Include="BitFaster.Caching" Version="2.6.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
     <PackageVersion Include="Examine" Version="3.9.0" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Routine dependency maintenance for the **18.2.0-rc** release. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

#### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Asp.Versioning.Mvc | 10.0.0 | 10.0.1 |
| Asp.Versioning.Mvc.ApiExplorer | 10.0.0 | 10.0.1 |

#### Test packages (`tests/Directory.Packages.props`)

No changes.

#### Inline / template versions

- `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: no changes.
- `templates/UmbracoExtension`: no changes (does not reference the updated packages).

#### Deliberately left unchanged

- `Microsoft.OpenApi` — held at `2.9.0` per the existing `HOLD` comment in `Directory.Packages.props` (2.10.0+ has a confirmed OpenAPI 3.0 nullability serialization regression that corrupts the Delivery API contract; 2.9.0 is already CVE-patched). Not bumped despite 2.11.0 being available.
- Any package where only a **major** update is available (out of scope for this PR).

#### Testing

Solution builds (`dotnet build umbraco.sln -c Release`) and the full unit test suite (6467 passed, 6 skipped, 0 failed) passes locally. CI checks are the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159wdQ7vZELvnhXReAXEPtK


---
_Generated by [Claude Code](https://claude.ai/code/session_0159wdQ7vZELvnhXReAXEPtK)_