### PR TITLE
Code Block: style update

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -63,7 +63,6 @@ export class UmbCodeBlockElement extends UmbLitElement {
 					this.copy,
 					() => html`
 						<uui-button
-							color=${this._copyState === 'idle' ? 'default' : 'positive'}
 							.label=${this._copyState === 'idle'
 								? this.localize.term('general_copy')
 								: this.localize.term('general_copied')}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -66,7 +66,8 @@ export class UmbCodeBlockElement extends UmbLitElement {
 							.label=${this._copyState === 'idle'
 								? this.localize.term('general_copy')
 								: this.localize.term('general_copied')}
-							@click=${this.copyCode}>
+							@click=${this.copyCode}
+							compact>
 							${when(
 								this._copyState === 'idle',
 								() => html`<uui-icon name="copy"></uui-icon> <umb-localize key="general_copy">Copy</umb-localize>`,
@@ -101,7 +102,7 @@ export class UmbCodeBlockElement extends UmbLitElement {
 				display: block;
 				margin: 0;
 				overflow-x: auto;
-				padding: 9.5px;
+				padding: var(--uui-size-space-3);
 			}
 
 			pre,
@@ -118,9 +119,12 @@ export class UmbCodeBlockElement extends UmbLitElement {
 				border-bottom: 1px solid var(--uui-color-border);
 			}
 
+			#header uui-button {
+				margin-right: var(--uui-size-space-1);
+			}
+
 			#lang {
-				margin-left: 16px;
-				font-weight: bold;
+				margin-left: var(--uui-size-space-3);
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -85,6 +85,7 @@ export class UmbCodeBlockElement extends UmbLitElement {
 		css`
 			:host {
 				display: block;
+				background-color: var(--uui-color-surface);
 				border: 1px solid var(--uui-color-border);
 				border-radius: var(--uui-border-radius);
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -62,7 +62,12 @@ export class UmbCodeBlockElement extends UmbLitElement {
 				${when(
 					this.copy,
 					() => html`
-						<uui-button color=${this._copyState === 'idle' ? 'default' : 'positive'} .label=${this._copyState === 'idle' ? this.localize.term('general_copy') : this.localize.term('general_copied')} @click=${this.copyCode}>
+						<uui-button
+							color=${this._copyState === 'idle' ? 'default' : 'positive'}
+							.label=${this._copyState === 'idle'
+								? this.localize.term('general_copy')
+								: this.localize.term('general_copied')}
+							@click=${this.copyCode}>
 							${when(
 								this._copyState === 'idle',
 								() => html`<uui-icon name="copy"></uui-icon> <umb-localize key="general_copy">Copy</umb-localize>`,
@@ -81,7 +86,7 @@ export class UmbCodeBlockElement extends UmbLitElement {
 		css`
 			:host {
 				display: block;
-				border: 1px solid var(--uui-color-divider-emphasis);
+				border: 1px solid var(--uui-color-border);
 				border-radius: var(--uui-border-radius);
 			}
 
@@ -92,7 +97,6 @@ export class UmbCodeBlockElement extends UmbLitElement {
 
 			pre {
 				font-family: monospace;
-				background-color: var(--uui-color-surface-alt);
 				color: #303033;
 				display: block;
 				margin: 0;
@@ -111,30 +115,12 @@ export class UmbCodeBlockElement extends UmbLitElement {
 				display: flex;
 				justify-content: space-between;
 				align-items: center;
-				background-color: var(--uui-color-surface-alt);
-				border-bottom: 1px solid var(--uui-color-divider-emphasis);
+				border-bottom: 1px solid var(--uui-color-border);
 			}
 
 			#lang {
 				margin-left: 16px;
 				font-weight: bold;
-			}
-
-			button {
-				font-family: inherit;
-				padding: 6px 16px;
-				background-color: transparent;
-				border: none;
-				border-left: 1px solid var(--uui-color-divider-emphasis);
-				border-radius: 0;
-				color: #000;
-				display: flex;
-				align-items: center;
-				gap: 8px;
-			}
-
-			button:hover {
-				background-color: var(--uui-color-surface-emphasis);
 			}
 		`,
 	];


### PR DESCRIPTION
Update the look of Code Block, a web component inside the backoffice project. It is used in a few places.

Instead of having a gray background, it is now white, and a few other tweaks:

<img width="528" height="212" alt="image" src="https://github.com/user-attachments/assets/e0050df2-c7c9-4639-a476-adcbcb5bb333" />
