### PR TITLE
Array State: support value to be undefined

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/array-state.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/array-state.test.ts
@@ -238,3 +238,97 @@ describe('ArrayState', () => {
 		});
 	});
 });
+
+describe('ArrayState with a nullable (undefined) value', () => {
+	type ObjectType = { key: string; another: string };
+
+	let nullableState: UmbArrayState<ObjectType, string, undefined>;
+
+	beforeEach(() => {
+		nullableState = new UmbArrayState<ObjectType, string, undefined>(undefined, (x) => x.key);
+	});
+
+	it('getValue returns undefined when constructed with undefined', () => {
+		expect(nullableState.getValue()).to.be.undefined;
+	});
+
+	it('asObservable emits undefined when constructed with undefined', (done) => {
+		nullableState.asObservable().subscribe((value) => {
+			expect(value).to.be.undefined;
+			done();
+		});
+	});
+
+	it('getHasOne returns false when the value is undefined', () => {
+		expect(nullableState.getHasOne('1')).to.be.false;
+	});
+
+	it('appendOne creates a new array from an undefined value', () => {
+		const newItem = { key: '1', another: 'myValue1' };
+		nullableState.appendOne(newItem);
+		expect(nullableState.getValue()).to.deep.equal([newItem]);
+	});
+
+	it('appendOneAt creates a new array from an undefined value', () => {
+		const newItem = { key: '1', another: 'myValue1' };
+		nullableState.appendOneAt(newItem, 0);
+		expect(nullableState.getValue()).to.deep.equal([newItem]);
+	});
+
+	it('append creates a new array from an undefined value', () => {
+		const newItems = [
+			{ key: '1', another: 'myValue1' },
+			{ key: '2', another: 'myValue2' },
+		];
+		nullableState.append(newItems);
+		expect(nullableState.getValue()).to.deep.equal(newItems);
+	});
+
+	it('prepend creates a new array from an undefined value', () => {
+		const newItems = [
+			{ key: '1', another: 'myValue1' },
+			{ key: '2', another: 'myValue2' },
+		];
+		nullableState.prepend(newItems);
+		// Each entry is unshifted individually, so the resulting order is the reverse of the input.
+		expect(nullableState.getValue()).to.deep.equal([...newItems].reverse());
+	});
+
+	it('remove leaves the value undefined when it is already undefined', () => {
+		nullableState.remove(['1']);
+		expect(nullableState.getValue()).to.be.undefined;
+	});
+
+	it('removeOne leaves the value undefined when it is already undefined', () => {
+		nullableState.removeOne('1');
+		expect(nullableState.getValue()).to.be.undefined;
+	});
+
+	it('filter leaves the value undefined when it is already undefined', () => {
+		nullableState.filter((x) => x.key !== '1');
+		expect(nullableState.getValue()).to.be.undefined;
+	});
+
+	it('replace leaves the value undefined when it is already undefined', () => {
+		nullableState.replace([{ key: '1', another: 'myValue1' }]);
+		expect(nullableState.getValue()).to.be.undefined;
+	});
+
+	it('updateOne leaves the value undefined when it is already undefined', () => {
+		nullableState.updateOne('1', { another: 'updated' });
+		expect(nullableState.getValue()).to.be.undefined;
+	});
+
+	it('setValue(undefined) resets an already-populated value back to undefined', () => {
+		nullableState.setValue([{ key: '1', another: 'myValue1' }]);
+		expect(nullableState.getValue()).to.not.be.undefined;
+
+		nullableState.setValue(undefined);
+		expect(nullableState.getValue()).to.be.undefined;
+	});
+
+	it('clear sets the value to an empty array, not undefined', () => {
+		nullableState.clear();
+		expect(nullableState.getValue()).to.deep.equal([]);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/array-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/array-state.ts
@@ -210,7 +210,8 @@ export class UmbArrayState<T, U = unknown, D extends T[] | undefined = T[]> exte
 	 * myState.append({ key: 1, value: 'replaced-foo'});
 	 */
 	appendOne(entry: T) {
-		const next = this.getValue() ? [...this.getValue()!] : [];
+		const value = this.getValue();
+		const next = value ? [...value] : [];
 		if (this.getUniqueMethod) {
 			pushToUniqueArray(next, entry, this.getUniqueMethod);
 		} else {

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/array-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/array-state.ts
@@ -6,19 +6,31 @@ import { replaceInUniqueArray } from '../utils/replace-in-unique-array.function.
 import { UmbDeepState } from './deep-state.js';
 
 /**
+ * @description - The value held by a {@link UmbArrayState}. Nullable when constructed with `undefined` (or with a value typed to include `undefined`), otherwise a plain array.
+ */
+type UmbArrayStateValue<T, D extends T[] | undefined> = undefined extends D ? T[] | undefined : T[];
+
+/**
  * @class UmbArrayState
  * @augments {UmbDeepState<T>}
  * @description - A RxJS BehaviorSubject which deepFreezes the object-data to ensure its not manipulated from any implementations.
  * Additionally the Subject ensures the data is unique, not updating any Observes unless there is an actual change of the content.
  *
  * The ArrayState provides methods to append data when the data is an Object.
+ *
+ * Constructing with an actual array keeps the classic, non-nullable behaviour (`getValue()` returns `T[]`). Constructing with
+ * `undefined` — or a value typed to include `undefined` — makes the state nullable (`getValue()` returns `T[] | undefined`).
+ * Note this detection only works when the generic parameters aren't pinned explicitly to just `T`; to opt into the nullable
+ * behaviour while still naming `T`, provide all three generics: `new UmbArrayState<Item, unknown, undefined>(undefined, ...)`.
  */
-export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
+export class UmbArrayState<T, U = unknown, D extends T[] | undefined = T[]> extends UmbDeepState<
+	UmbArrayStateValue<T, D>
+> {
 	readonly getUniqueMethod: (entry: T) => U;
 	#sortMethod?: (a: T, b: T) => number;
 
-	constructor(initialData: T[], getUniqueOfEntryMethod: (entry: T) => U) {
-		super(initialData);
+	constructor(initialData: T[] | (T[] | undefined) | D, getUniqueOfEntryMethod: (entry: T) => U) {
+		super(initialData as UmbArrayStateValue<T, D>);
 		this.getUniqueMethod = getUniqueOfEntryMethod;
 	}
 
@@ -55,7 +67,7 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 	 * myState.setValue(['Goodnight'])
 	 * // myState.value is equal ['Goodnight'].
 	 */
-	override setValue(value: T[]) {
+	override setValue(value: UmbArrayStateValue<T, D>) {
 		if (value && this.#sortMethod) {
 			super.setValue([...value].sort(this.#sortMethod));
 		} else {
@@ -91,7 +103,7 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 	 */
 	getHasOne(unique: U): boolean {
 		if (this.getUniqueMethod) {
-			return this.getValue().some((x) => this.getUniqueMethod(x) === unique);
+			return this.getValue()?.some((x) => this.getUniqueMethod(x) === unique) ?? false;
 		} else {
 			throw new Error('Cannot use hasOne when no unique method provided to check for uniqueness');
 		}
@@ -115,7 +127,7 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 			let next = this.getValue();
 			if (!next) return this;
 			uniques.forEach((unique) => {
-				next = next.filter((x) => {
+				next = next!.filter((x) => {
 					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 					// @ts-ignore
 					return this.getUniqueMethod(x) !== unique;
@@ -198,7 +210,7 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 	 * myState.append({ key: 1, value: 'replaced-foo'});
 	 */
 	appendOne(entry: T) {
-		const next = [...this.getValue()];
+		const next = this.getValue() ? [...this.getValue()!] : [];
 		if (this.getUniqueMethod) {
 			pushToUniqueArray(next, entry, this.getUniqueMethod);
 		} else {
@@ -223,7 +235,7 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 	 * myState.appendOneAt({ key: 2, value: 'in-between'}, 1);
 	 */
 	appendOneAt(entry: T, index: number) {
-		const next = [...this.getValue()];
+		const next = this.getValue() ? [...this.getValue()!] : [];
 		if (this.getUniqueMethod) {
 			pushAtToUniqueArray(next, entry, this.getUniqueMethod, index);
 		} else if (index === -1 || index >= next.length) {
@@ -252,14 +264,14 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 	 * ]);
 	 */
 	append(entries: T[]) {
+		const current = this.getValue() ? [...this.getValue()!] : [];
 		if (this.getUniqueMethod) {
-			const next = [...this.getValue()];
 			entries.forEach((entry) => {
-				pushToUniqueArray(next, entry, this.getUniqueMethod!);
+				pushToUniqueArray(current, entry, this.getUniqueMethod!);
 			});
-			this.setValue(next);
+			this.setValue(current);
 		} else {
-			this.setValue([...this.getValue(), ...entries]);
+			this.setValue([...current, ...entries]);
 		}
 		return this;
 	}
@@ -284,9 +296,11 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 	 * // Only the existing item gets replaced:
 	 * myState.getValue(); // -> [{ key: 1, value: 'foo2'}, { key: 2, value: 'bar'}]
 	 */
-	replace(entries: Array<T>): UmbArrayState<T> {
+	replace(entries: Array<T>): this {
 		if (this.getUniqueMethod) {
-			const next = [...this.getValue()];
+			const current = this.getValue();
+			if (!current) return this;
+			const next = [...current];
 			entries.forEach((entry) => {
 				replaceInUniqueArray(next, entry as T, this.getUniqueMethod!);
 			});
@@ -315,7 +329,11 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 		if (!this.getUniqueMethod) {
 			throw new Error("Can't partial update an ArrayState without a getUnique method provided when constructed.");
 		}
-		this.setValue(partialUpdateFrozenArray(this.getValue(), entry, (x) => unique === this.getUniqueMethod!(x)));
+		const current = this.getValue();
+		if (!current) return this;
+		this.setValue(
+			partialUpdateFrozenArray(current, entry, (x) => unique === this.getUniqueMethod!(x)) as UmbArrayStateValue<T, D>,
+		);
 		return this;
 	}
 
@@ -336,14 +354,14 @@ export class UmbArrayState<T, U = unknown> extends UmbDeepState<T[]> {
 	 * ]);
 	 */
 	prepend(entries: T[]) {
+		const current = this.getValue() ? [...this.getValue()!] : [];
 		if (this.getUniqueMethod) {
-			const next = [...this.getValue()];
 			entries.forEach((entry) => {
-				prependToUniqueArray(next, entry, this.getUniqueMethod!);
+				prependToUniqueArray(current, entry, this.getUniqueMethod!);
 			});
-			this.setValue(next);
+			this.setValue(current);
 		} else {
-			this.setValue([...entries, ...this.getValue()]);
+			this.setValue([...entries, ...current]);
 		}
 
 		return this;


### PR DESCRIPTION
Enables the ArrayState class to optionally hold an undefined value.

Note: Clear will still set the value to an empty array, but I think this is fine for now. As we typically use undefined for the not-yet-defined state. Whereas Clear could still be interpreted as clearing the data, but still defined data.