### PR TITLE
Published cache: Populate the ID/key map from seeded and cached content (closes #23583)

### DIFF
--- a/src/Umbraco.Core/Services/IIdKeyMap.cs
+++ b/src/Umbraco.Core/Services/IIdKeyMap.cs
@@ -42,6 +42,28 @@ public interface IIdKeyMap
     Attempt<Guid> GetKeyForId(int id, UmbracoObjectTypes umbracoObjectType);
 
     /// <summary>
+    /// Adds known ID/key pairs to the cache, so subsequent lookups do not need to hit the database.
+    /// </summary>
+    /// <param name="pairs">The ID/key pairs to cache. Must be a materialized collection.</param>
+    /// <param name="umbracoObjectType">The type of the Umbraco objects the pairs belong to.</param>
+    /// <remarks>
+    /// Only supply pairs read from persisted entities: the mapping is assumed to be unique and permanent.
+    /// </remarks>
+    // TODO (V19): Remove the default implementation.
+    void PopulateCache(IReadOnlyCollection<(int Id, Guid Key)> pairs, UmbracoObjectTypes umbracoObjectType)
+    {
+    }
+
+    /// <summary>
+    /// Adds a known ID/key pair to the cache, so subsequent lookups do not need to hit the database.
+    /// </summary>
+    /// <param name="id">The integer identifier of the entity.</param>
+    /// <param name="key">The unique GUID key of the entity.</param>
+    /// <param name="umbracoObjectType">The type of the Umbraco object.</param>
+    void PopulateCache(int id, Guid key, UmbracoObjectTypes umbracoObjectType)
+        => PopulateCache([(id, key)], umbracoObjectType);
+
+    /// <summary>
     /// Clears the entire ID/key mapping cache.
     /// </summary>
     void ClearCache();

--- a/src/Umbraco.Core/Services/IdKeyMap.cs
+++ b/src/Umbraco.Core/Services/IdKeyMap.cs
@@ -30,8 +30,11 @@ public class IdKeyMap : IIdKeyMap, IDisposable
     private readonly IIdKeyMapRepository _idKeyMapRepository;
     private readonly ReaderWriterLockSlim _locker = new();
 
-    private readonly Dictionary<int, TypedId<Guid>> _id2Key = new();
-    private readonly Dictionary<Guid, TypedId<int>> _key2Id = new();
+    // Both dictionaries are keyed by the identifier alone, with the object type carried on the value only as a
+    // discriminator. That is safe because umbracoNode.id is unique across all object types, so an id can never
+    // belong to two entries at once.
+    private readonly Dictionary<int, TypedId<Guid>> _id2Key = [];
+    private readonly Dictionary<Guid, TypedId<int>> _key2Id = [];
 
     // note - for pure read-only we might want to *not* enforce a transaction?
 
@@ -73,7 +76,16 @@ public class IdKeyMap : IIdKeyMap, IDisposable
 
     private bool _disposedValue;
 
-    /// <inheritdoc />
+    /// <summary>
+    ///     Registers an external source of ID/key mappings, consulted before falling back to the database.
+    /// </summary>
+    /// <param name="umbracoObjectType">The Umbraco object type the mappers apply to.</param>
+    /// <param name="id2key">Maps an integer identifier to a key.</param>
+    /// <param name="key2id">Maps a key to an integer identifier.</param>
+    /// <remarks>
+    ///     Prefer <see cref="PopulateCache(int, Guid, UmbracoObjectTypes)" />. A mapper is invoked on every miss,
+    ///     and one backed by the published cache re-enters this map when resolving by identifier.
+    /// </remarks>
     public void SetMapper(UmbracoObjectTypes umbracoObjectType, Func<int, Guid> id2key, Func<Guid, int> key2id) =>
         _dictionary[umbracoObjectType] = (id2key, key2id);
 
@@ -224,13 +236,18 @@ public class IdKeyMap : IIdKeyMap, IDisposable
         return Attempt.Succeed(val.Value);
     }
 
-    /// <summary>
-    ///     Populates the cache with multiple ID/Key pairs for a specific object type.
-    /// </summary>
-    /// <param name="pairs">The collection of ID/Key pairs to cache.</param>
-    /// <param name="umbracoObjectType">The Umbraco object type for the pairs.</param>
-    internal void Populate(IEnumerable<(int id, Guid key)> pairs, UmbracoObjectTypes umbracoObjectType)
+    /// <inheritdoc />
+    /// <remarks>
+    ///     The write lock is held for the whole enumeration, hence the materialized collection: passing a lazy
+    ///     sequence would block every reader for as long as it takes to produce the pairs.
+    /// </remarks>
+    public void PopulateCache(IReadOnlyCollection<(int Id, Guid Key)> pairs, UmbracoObjectTypes umbracoObjectType)
     {
+        if (pairs.Count == 0)
+        {
+            return;
+        }
+
         try
         {
             _locker.EnterWriteLock();
@@ -239,6 +256,48 @@ public class IdKeyMap : IIdKeyMap, IDisposable
                 _id2Key[id] = new TypedId<Guid>(key, umbracoObjectType);
                 _key2Id[key] = new TypedId<int>(id, umbracoObjectType);
             }
+        }
+        finally
+        {
+            if (_locker.IsWriteLockHeld)
+            {
+                _locker.ExitWriteLock();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void PopulateCache(int id, Guid key, UmbracoObjectTypes umbracoObjectType)
+    {
+        // Callers on the published cache read path re-supply pairs that are already mapped (content is
+        // re-converted after every publish and on every preview request), so check under the read lock
+        // first and only take the write lock when there is something to write.
+        try
+        {
+            _locker.EnterReadLock();
+            if (_id2Key.TryGetValue(id, out TypedId<Guid> existing)
+                && existing.Id == key
+                && existing.UmbracoObjectType == umbracoObjectType)
+            {
+                return;
+            }
+        }
+        finally
+        {
+            if (_locker.IsReadLockHeld)
+            {
+                _locker.ExitReadLock();
+            }
+        }
+
+        // The lock does not support recursion, so the read lock above must be released before taking the
+        // write lock - which means another thread may have written the same pair in between. That is
+        // harmless: the id/key mapping is unique, so both threads write the same values.
+        try
+        {
+            _locker.EnterWriteLock();
+            _id2Key[id] = new TypedId<Guid>(key, umbracoObjectType);
+            _key2Id[key] = new TypedId<int>(id, umbracoObjectType);
         }
         finally
         {

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -192,9 +192,9 @@ internal sealed class DocumentCacheService : IDocumentCacheService, IMemoryCache
 
         // The node carries both identifiers, so the id/key map can be warmed without a lookup of its own.
         // Unlike the content itself the mapping is permanent, so this is done regardless of snapshotIsCurrent.
-        // The L0 fast path above returns before reaching here, which only matters for a key that was mapped
-        // by an earlier pass - and the map is only ever evicted per entity, alongside that entity's L0 entry.
+        // Deliberately outside the read-through branch above, so that backing store hits populate the map too.
         _idKeyMap.PopulateCache(contentCacheNode.Id, contentCacheNode.Key, UmbracoObjectTypes.Document);
+
 
         IPublishedContent? result = _publishedContentFactory.ToIPublishedContent(contentCacheNode, preview).CreateModel(_publishedModelFactory);
 
@@ -354,7 +354,13 @@ internal sealed class DocumentCacheService : IDocumentCacheService, IMemoryCache
 
             scope.Complete();
 
-            _logger.LogDebug("Document nodes to cache {NodeCount}", cacheNodes.Count);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Document nodes to cache {NodeCount}", cacheNodes.Count);
+            }
+
+            // The seeded nodes carry both identifiers, so the id/key map is warmed without any lookups of its own.
+            var idKeyPairs = new List<(int Id, Guid Key)>(cacheNodes.Count);
 
             foreach (ContentCacheNode cacheNode in cacheNodes)
             {
@@ -365,12 +371,11 @@ internal sealed class DocumentCacheService : IDocumentCacheService, IMemoryCache
                     GetSeedEntryOptions(),
                     GenerateTags(cacheNode),
                     cancellationToken: cancellationToken);
+
+                idKeyPairs.Add((cacheNode.Id, cacheNode.Key));
             }
 
-            // The seeded nodes carry both identifiers, so the id/key map is warmed without any lookups of its own.
-            _idKeyMap.PopulateCache(
-                cacheNodes.Select(x => (x.Id, x.Key)).ToList(),
-                UmbracoObjectTypes.Document);
+            _idKeyMap.PopulateCache(idKeyPairs, UmbracoObjectTypes.Document);
         }
 
 #if DEBUG

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -190,6 +190,12 @@ internal sealed class DocumentCacheService : IDocumentCacheService, IMemoryCache
             return null;
         }
 
+        // The node carries both identifiers, so the id/key map can be warmed without a lookup of its own.
+        // Unlike the content itself the mapping is permanent, so this is done regardless of snapshotIsCurrent.
+        // The L0 fast path above returns before reaching here, which only matters for a key that was mapped
+        // by an earlier pass - and the map is only ever evicted per entity, alongside that entity's L0 entry.
+        _idKeyMap.PopulateCache(contentCacheNode.Id, contentCacheNode.Key, UmbracoObjectTypes.Document);
+
         IPublishedContent? result = _publishedContentFactory.ToIPublishedContent(contentCacheNode, preview).CreateModel(_publishedModelFactory);
 
         // Only published content is stored in L0: the read fast path above is guarded by preview is false, so a
@@ -342,11 +348,13 @@ internal sealed class DocumentCacheService : IDocumentCacheService, IMemoryCache
 
             using ICoreScope scope = _scopeProvider.CreateCoreScope();
 
-            IEnumerable<ContentCacheNode> cacheNodes = await _databaseCacheRepository.GetContentSourcesAsync(uncachedKeys);
+            // Materialized because the repository defers deserialization of each node until it is enumerated,
+            // and the sequence is walked more than once below.
+            var cacheNodes = (await _databaseCacheRepository.GetContentSourcesAsync(uncachedKeys)).ToList();
 
             scope.Complete();
 
-            _logger.LogDebug("Document nodes to cache {NodeCount}", cacheNodes.Count());
+            _logger.LogDebug("Document nodes to cache {NodeCount}", cacheNodes.Count);
 
             foreach (ContentCacheNode cacheNode in cacheNodes)
             {
@@ -358,6 +366,11 @@ internal sealed class DocumentCacheService : IDocumentCacheService, IMemoryCache
                     GenerateTags(cacheNode),
                     cancellationToken: cancellationToken);
             }
+
+            // The seeded nodes carry both identifiers, so the id/key map is warmed without any lookups of its own.
+            _idKeyMap.PopulateCache(
+                cacheNodes.Select(x => (x.Id, x.Key)).ToList(),
+                UmbracoObjectTypes.Document);
         }
 
 #if DEBUG

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -172,6 +172,10 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
             return null;
         }
 
+        // The node carries both identifiers, so the id/key map can be warmed without a lookup of its own.
+        // Unlike the content itself the mapping is permanent, so this is done regardless of snapshotIsCurrent.
+        _idKeyMap.PopulateCache(contentCacheNode.Id, contentCacheNode.Key, UmbracoObjectTypes.Media);
+
         IPublishedContent? result = _publishedContentFactory.ToIPublishedMedia(contentCacheNode).CreateModel(_publishedModelFactory);
 
         // Only populate the L0 cache when our snapshot is still current; otherwise a concurrent
@@ -272,11 +276,13 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
 
             using ICoreScope scope = _scopeProvider.CreateCoreScope();
 
-            IEnumerable<ContentCacheNode> cacheNodes = await _databaseCacheRepository.GetMediaSourcesAsync(uncachedKeys);
+            // Materialized because the repository defers deserialization of each node until it is enumerated,
+            // and the sequence is walked more than once below.
+            var cacheNodes = (await _databaseCacheRepository.GetMediaSourcesAsync(uncachedKeys)).ToList();
 
             scope.Complete();
 
-            _logger.LogDebug("Media nodes to cache {NodeCount}", cacheNodes.Count());
+            _logger.LogDebug("Media nodes to cache {NodeCount}", cacheNodes.Count);
 
             foreach (ContentCacheNode cacheNode in cacheNodes)
             {
@@ -287,6 +293,11 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
                     GenerateTags(cacheNode),
                     cancellationToken: cancellationToken);
             }
+
+            // The seeded nodes carry both identifiers, so the id/key map is warmed without any lookups of its own.
+            _idKeyMap.PopulateCache(
+                cacheNodes.Select(x => (x.Id, x.Key)).ToList(),
+                UmbracoObjectTypes.Media);
         }
 
 #if DEBUG
@@ -296,6 +307,9 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
         _logger.LogInformation("Media cache seeding completed with {SeedCount} seed keys.", SeedKeys.Count);
 #endif
     }
+
+    // Internal for test purposes.
+    internal void ResetSeedKeys() => _seedKeys = null;
 
     public async Task RefreshMemoryCacheAsync(Guid key)
     {

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -174,7 +174,9 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
 
         // The node carries both identifiers, so the id/key map can be warmed without a lookup of its own.
         // Unlike the content itself the mapping is permanent, so this is done regardless of snapshotIsCurrent.
+        // Deliberately outside the read-through branch above, so that backing store hits populate the map too.
         _idKeyMap.PopulateCache(contentCacheNode.Id, contentCacheNode.Key, UmbracoObjectTypes.Media);
+
 
         IPublishedContent? result = _publishedContentFactory.ToIPublishedMedia(contentCacheNode).CreateModel(_publishedModelFactory);
 
@@ -282,7 +284,13 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
 
             scope.Complete();
 
-            _logger.LogDebug("Media nodes to cache {NodeCount}", cacheNodes.Count);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Media nodes to cache {NodeCount}", cacheNodes.Count);
+            }
+
+            // The seeded nodes carry both identifiers, so the id/key map is warmed without any lookups of its own.
+            var idKeyPairs = new List<(int Id, Guid Key)>(cacheNodes.Count);
 
             foreach (ContentCacheNode cacheNode in cacheNodes)
             {
@@ -292,12 +300,11 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
                     GetSeedEntryOptions(),
                     GenerateTags(cacheNode),
                     cancellationToken: cancellationToken);
+
+                idKeyPairs.Add((cacheNode.Id, cacheNode.Key));
             }
 
-            // The seeded nodes carry both identifiers, so the id/key map is warmed without any lookups of its own.
-            _idKeyMap.PopulateCache(
-                cacheNodes.Select(x => (x.Id, x.Key)).ToList(),
-                UmbracoObjectTypes.Media);
+            _idKeyMap.PopulateCache(idKeyPairs, UmbracoObjectTypes.Media);
         }
 
 #if DEBUG
@@ -307,9 +314,6 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
         _logger.LogInformation("Media cache seeding completed with {SeedCount} seed keys.", SeedKeys.Count);
 #endif
     }
-
-    // Internal for test purposes.
-    internal void ResetSeedKeys() => _seedKeys = null;
 
     public async Task RefreshMemoryCacheAsync(Guid key)
     {
@@ -394,6 +398,14 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
             .Select(x => _publishedContentFactory.ToIPublishedContent(x, x.IsDraft).CreateModel(_publishedModelFactory))
             .WhereNotNull();
     }
+
+    /// <summary>
+    ///     Discards the memoized seed keys so that they are recalculated on the next seeding run.
+    /// </summary>
+    /// <remarks>
+    ///     Internal for test purposes, so that media created after the keys were first resolved is seeded.
+    /// </remarks>
+    internal void ResetSeedKeys() => _seedKeys = null;
 
     private HybridCacheEntryOptions GetEntryOptions(Guid key)
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheIdKeyMapTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheIdKeyMapTests.cs
@@ -42,8 +42,6 @@ internal sealed class DocumentHybridCacheIdKeyMapTests : UmbracoIntegrationTestW
 
     private IDocumentCacheService DocumentCacheService => GetRequiredService<IDocumentCacheService>();
 
-    private IIdKeyMap IdKeyMap => GetRequiredService<IIdKeyMap>();
-
     private CountingIdKeyMapRepository IdKeyMapRepository
         => (CountingIdKeyMapRepository)GetRequiredService<IIdKeyMapRepository>();
 
@@ -85,19 +83,22 @@ internal sealed class DocumentHybridCacheIdKeyMapTests : UmbracoIntegrationTestW
     }
 
     [Test]
-    public async Task Loading_A_Document_Keeps_The_Id_Key_Map_Populated_Across_Repeated_Reads()
+    public async Task Loading_A_Document_From_The_Backing_Store_Populates_The_Id_Key_Map()
     {
         Guid key = PublishedTextPage.Key!.Value;
 
-        await DocumentCacheService.RemoveFromMemoryCacheAsync(key);
+        // Arrange - warm the hybrid cache, then drop only the converted content cache. The read below is
+        // therefore served from the backing store rather than the database, which is the common case and
+        // the reason the map is populated outside the branch that reads through to the repository.
+        Assert.IsNotNull(await PublishedContentHybridCache.GetByIdAsync(key));
+        DocumentCacheService.ClearConvertedContentCache();
         IdKeyMap.ClearCache();
         IdKeyMapRepository.Reset();
 
-        // The first read is a cache miss and warms the map; subsequent reads are served from the converted
-        // content cache and return before the map is consulted, which is why the map has to stay warm.
-        Assert.IsNotNull(await PublishedContentHybridCache.GetByIdAsync(key));
+        // Act
         Assert.IsNotNull(await PublishedContentHybridCache.GetByIdAsync(key));
 
+        // Assert
         AssertResolvesWithoutQuerying(PublishedTextPageId, key);
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheIdKeyMapTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheIdKeyMapTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.HybridCache.Services;
+using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.PublishedCache.HybridCache;
+
+/// <summary>
+///     Verifies that content passing through the published cache warms <see cref="IIdKeyMap" />, so that
+///     consumers resolving between integer IDs and keys do not fall through to the database one item at a
+///     time (see issue #23583).
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class DocumentHybridCacheIdKeyMapTests : UmbracoIntegrationTestWithContentEditing
+{
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();
+        builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
+
+        // Wrap the real repository so the tests can assert that ID/key lookups never reach the database.
+        builder.Services.AddUnique<IIdKeyMapRepository>(factory =>
+            new CountingIdKeyMapRepository(
+                new IdKeyMapRepository(
+                    factory.GetRequiredService<global::Umbraco.Cms.Infrastructure.Scoping.IScopeAccessor>())));
+    }
+
+    private IPublishedContentCache PublishedContentHybridCache => GetRequiredService<IPublishedContentCache>();
+
+    private IDocumentCacheService DocumentCacheService => GetRequiredService<IDocumentCacheService>();
+
+    private IIdKeyMap IdKeyMap => GetRequiredService<IIdKeyMap>();
+
+    private CountingIdKeyMapRepository IdKeyMapRepository
+        => (CountingIdKeyMapRepository)GetRequiredService<IIdKeyMapRepository>();
+
+    [Test]
+    public async Task Seeding_Populates_The_Id_Key_Map()
+    {
+        Guid key = PublishedTextPage.Key!.Value;
+
+        // Arrange - evict the page so that seeding has something to fetch, then start from a cold map so
+        // that we are observing seeding rather than an entry left behind by the test setup.
+        await DocumentCacheService.RemoveFromMemoryCacheAsync(key);
+        ((DocumentCacheService)DocumentCacheService).ResetSeedKeys();
+        IdKeyMap.ClearCache();
+        IdKeyMapRepository.Reset();
+
+        // Act
+        await DocumentCacheService.SeedAsync(CancellationToken.None);
+
+        // Assert - the seeded node carried both identifiers, so both directions resolve from memory.
+        AssertResolvesWithoutQuerying(PublishedTextPageId, key);
+    }
+
+    [Test]
+    public async Task Loading_A_Document_Populates_The_Id_Key_Map()
+    {
+        Guid key = PublishedTextPage.Key!.Value;
+
+        // Arrange - evict the page so the read below is a genuine cache miss, then start from a cold map.
+        await DocumentCacheService.RemoveFromMemoryCacheAsync(key);
+        IdKeyMap.ClearCache();
+        IdKeyMapRepository.Reset();
+
+        // Act - fetch by key, so resolving the document itself never consults the map.
+        IPublishedContent? content = await PublishedContentHybridCache.GetByIdAsync(key);
+        Assert.IsNotNull(content);
+
+        // Assert
+        AssertResolvesWithoutQuerying(PublishedTextPageId, key);
+    }
+
+    [Test]
+    public async Task Loading_A_Document_Keeps_The_Id_Key_Map_Populated_Across_Repeated_Reads()
+    {
+        Guid key = PublishedTextPage.Key!.Value;
+
+        await DocumentCacheService.RemoveFromMemoryCacheAsync(key);
+        IdKeyMap.ClearCache();
+        IdKeyMapRepository.Reset();
+
+        // The first read is a cache miss and warms the map; subsequent reads are served from the converted
+        // content cache and return before the map is consulted, which is why the map has to stay warm.
+        Assert.IsNotNull(await PublishedContentHybridCache.GetByIdAsync(key));
+        Assert.IsNotNull(await PublishedContentHybridCache.GetByIdAsync(key));
+
+        AssertResolvesWithoutQuerying(PublishedTextPageId, key);
+    }
+
+    private void AssertResolvesWithoutQuerying(int expectedId, Guid expectedKey)
+    {
+        Attempt<int> idAttempt = IdKeyMap.GetIdForKey(expectedKey, UmbracoObjectTypes.Document);
+        Attempt<Guid> keyAttempt = IdKeyMap.GetKeyForId(expectedId, UmbracoObjectTypes.Document);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(idAttempt.Success);
+            Assert.AreEqual(expectedId, idAttempt.Result);
+            Assert.IsTrue(keyAttempt.Success);
+            Assert.AreEqual(expectedKey, keyAttempt.Result);
+            Assert.AreEqual(0, IdKeyMapRepository.Count, "Expected no ID/key lookups against the database.");
+        });
+    }
+
+    /// <summary>
+    ///     Counts the ID/key lookups that fall all the way through to the database.
+    /// </summary>
+    private sealed class CountingIdKeyMapRepository : IIdKeyMapRepository
+    {
+        private readonly IIdKeyMapRepository _inner;
+        private int _count;
+
+        public CountingIdKeyMapRepository(IIdKeyMapRepository inner) => _inner = inner;
+
+        public int Count => Volatile.Read(ref _count);
+
+        public void Reset() => Interlocked.Exchange(ref _count, 0);
+
+        public int? GetIdForKey(Guid key, UmbracoObjectTypes umbracoObjectType)
+        {
+            Interlocked.Increment(ref _count);
+            return _inner.GetIdForKey(key, umbracoObjectType);
+        }
+
+        public Guid? GetIdForKey(int id, UmbracoObjectTypes umbracoObjectType)
+        {
+            Interlocked.Increment(ref _count);
+            return _inner.GetIdForKey(id, umbracoObjectType);
+        }
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MediaHybridCacheIdKeyMapTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MediaHybridCacheIdKeyMapTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.HybridCache.Services;
+using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.PublishedCache.HybridCache;
+
+/// <summary>
+///     Verifies that media passing through the published cache warms <see cref="IIdKeyMap" />, so that
+///     consumers resolving between integer IDs and keys do not fall through to the database one item at a
+///     time (see issue #23583).
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MediaHybridCacheIdKeyMapTests : UmbracoIntegrationTestWithMediaEditing
+{
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<MediaTreeChangeNotification, MediaTreeChangeDistributedCacheNotificationHandler>();
+        builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
+
+        // Wrap the real repository so the tests can assert that ID/key lookups never reach the database.
+        builder.Services.AddUnique<IIdKeyMapRepository>(factory =>
+            new CountingIdKeyMapRepository(
+                new IdKeyMapRepository(
+                    factory.GetRequiredService<global::Umbraco.Cms.Infrastructure.Scoping.IScopeAccessor>())));
+    }
+
+    private IPublishedMediaCache PublishedMediaHybridCache => GetRequiredService<IPublishedMediaCache>();
+
+    private IMediaCacheService MediaCacheService => GetRequiredService<IMediaCacheService>();
+
+    private IIdKeyMap IdKeyMap => GetRequiredService<IIdKeyMap>();
+
+    private CountingIdKeyMapRepository IdKeyMapRepository
+        => (CountingIdKeyMapRepository)GetRequiredService<IIdKeyMapRepository>();
+
+    [Test]
+    public async Task Seeding_Populates_The_Id_Key_Map()
+    {
+        Guid key = RootFolder.Key!.Value;
+
+        // Arrange - evict the item so that seeding has something to fetch, then start from a cold map so
+        // that we are observing seeding rather than an entry left behind by the test setup.
+        await MediaCacheService.RemoveFromMemoryCacheAsync(key);
+
+        // The seed keys are memoized on first use, and startup seeding ran before this media existed.
+        ((MediaCacheService)MediaCacheService).ResetSeedKeys();
+        IdKeyMap.ClearCache();
+        IdKeyMapRepository.Reset();
+
+        // Act
+        await MediaCacheService.SeedAsync(CancellationToken.None);
+
+        // Assert - the seeded node carried both identifiers, so both directions resolve from memory.
+        AssertResolvesWithoutQuerying(RootFolderId, key);
+    }
+
+    [Test]
+    public async Task Loading_Media_Populates_The_Id_Key_Map()
+    {
+        Guid key = RootFolder.Key!.Value;
+
+        // Arrange - evict the item so the read below is a genuine cache miss, then start from a cold map.
+        await MediaCacheService.RemoveFromMemoryCacheAsync(key);
+        IdKeyMap.ClearCache();
+        IdKeyMapRepository.Reset();
+
+        // Act - fetch by key, so resolving the media item itself never consults the map.
+        Assert.IsNotNull(await PublishedMediaHybridCache.GetByIdAsync(key));
+
+        // Assert
+        AssertResolvesWithoutQuerying(RootFolderId, key);
+    }
+
+    private void AssertResolvesWithoutQuerying(int expectedId, Guid expectedKey)
+    {
+        Attempt<int> idAttempt = IdKeyMap.GetIdForKey(expectedKey, UmbracoObjectTypes.Media);
+        Attempt<Guid> keyAttempt = IdKeyMap.GetKeyForId(expectedId, UmbracoObjectTypes.Media);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(idAttempt.Success);
+            Assert.AreEqual(expectedId, idAttempt.Result);
+            Assert.IsTrue(keyAttempt.Success);
+            Assert.AreEqual(expectedKey, keyAttempt.Result);
+            Assert.AreEqual(0, IdKeyMapRepository.Count, "Expected no ID/key lookups against the database.");
+        });
+    }
+
+    /// <summary>
+    ///     Counts the ID/key lookups that fall all the way through to the database.
+    /// </summary>
+    private sealed class CountingIdKeyMapRepository : IIdKeyMapRepository
+    {
+        private readonly IIdKeyMapRepository _inner;
+        private int _count;
+
+        public CountingIdKeyMapRepository(IIdKeyMapRepository inner) => _inner = inner;
+
+        public int Count => Volatile.Read(ref _count);
+
+        public void Reset() => Interlocked.Exchange(ref _count, 0);
+
+        public int? GetIdForKey(Guid key, UmbracoObjectTypes umbracoObjectType)
+        {
+            Interlocked.Increment(ref _count);
+            return _inner.GetIdForKey(key, umbracoObjectType);
+        }
+
+        public Guid? GetIdForKey(int id, UmbracoObjectTypes umbracoObjectType)
+        {
+            Interlocked.Increment(ref _count);
+            return _inner.GetIdForKey(id, umbracoObjectType);
+        }
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MediaHybridCacheIdKeyMapTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MediaHybridCacheIdKeyMapTests.cs
@@ -41,8 +41,6 @@ internal sealed class MediaHybridCacheIdKeyMapTests : UmbracoIntegrationTestWith
 
     private IMediaCacheService MediaCacheService => GetRequiredService<IMediaCacheService>();
 
-    private IIdKeyMap IdKeyMap => GetRequiredService<IIdKeyMap>();
-
     private CountingIdKeyMapRepository IdKeyMapRepository
         => (CountingIdKeyMapRepository)GetRequiredService<IIdKeyMapRepository>();
 
@@ -78,6 +76,26 @@ internal sealed class MediaHybridCacheIdKeyMapTests : UmbracoIntegrationTestWith
         IdKeyMapRepository.Reset();
 
         // Act - fetch by key, so resolving the media item itself never consults the map.
+        Assert.IsNotNull(await PublishedMediaHybridCache.GetByIdAsync(key));
+
+        // Assert
+        AssertResolvesWithoutQuerying(RootFolderId, key);
+    }
+
+    [Test]
+    public async Task Loading_Media_From_The_Backing_Store_Populates_The_Id_Key_Map()
+    {
+        Guid key = RootFolder.Key!.Value;
+
+        // Arrange - warm the hybrid cache, then drop only the converted content cache. The read below is
+        // therefore served from the backing store rather than the database, which is the common case and
+        // the reason the map is populated outside the branch that reads through to the repository.
+        Assert.IsNotNull(await PublishedMediaHybridCache.GetByIdAsync(key));
+        MediaCacheService.ClearConvertedContentCache();
+        IdKeyMap.ClearCache();
+        IdKeyMapRepository.Reset();
+
+        // Act
         Assert.IsNotNull(await PublishedMediaHybridCache.GetByIdAsync(key));
 
         // Assert

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/IdKeyMapTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/IdKeyMapTests.cs
@@ -1,6 +1,8 @@
-﻿using Moq;
+using System.Data;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
@@ -11,38 +13,161 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
 [TestFixture]
 public class IdKeyMapTests
 {
-    private IdKeyMap GetSubject()
+    private IdKeyMap GetIdKeyMap()
         => new IdKeyMap(Mock.Of<ICoreScopeProvider>(), Mock.Of<IIdKeyMapRepository>());
 
-    [Test]
-    public void CanResolveContentRecycleBinIdFromKey()
+    private IdKeyMap GetIdKeyMap(out Mock<IIdKeyMapRepository> repository)
     {
-        var result = GetSubject().GetIdForKey(Constants.System.RecycleBinContentKey, UmbracoObjectTypes.Document);
+        repository = new Mock<IIdKeyMapRepository>();
+
+        var scopeProvider = new Mock<ICoreScopeProvider>();
+        scopeProvider
+            .Setup(x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher>(),
+                It.IsAny<IScopedNotificationPublisher>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(Mock.Of<ICoreScope>());
+
+        return new IdKeyMap(scopeProvider.Object, repository.Object);
+    }
+
+    [Test]
+    public void Can_Resolve_Content_Recycle_Bin_Id_From_Key()
+    {
+        var result = GetIdKeyMap().GetIdForKey(Constants.System.RecycleBinContentKey, UmbracoObjectTypes.Document);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(Constants.System.RecycleBinContent, result.Result);
     }
 
     [Test]
-    public void CanResolveMediaRecycleBinIdFromKey()
+    public void Can_Resolve_Media_Recycle_Bin_Id_From_Key()
     {
-        var result = GetSubject().GetIdForKey(Constants.System.RecycleBinMediaKey, UmbracoObjectTypes.Media);
+        var result = GetIdKeyMap().GetIdForKey(Constants.System.RecycleBinMediaKey, UmbracoObjectTypes.Media);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(Constants.System.RecycleBinMedia, result.Result);
     }
 
     [Test]
-    public void CanResolveContentRecycleBinKeyFromId()
+    public void Can_Resolve_Content_Recycle_Bin_Key_From_Id()
     {
-        var result = GetSubject().GetKeyForId(Constants.System.RecycleBinContent, UmbracoObjectTypes.Document);
+        var result = GetIdKeyMap().GetKeyForId(Constants.System.RecycleBinContent, UmbracoObjectTypes.Document);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(Constants.System.RecycleBinContentKey, result.Result);
     }
 
     [Test]
-    public void CanResolveMediaRecycleBinKeyFromId()
+    public void Can_Resolve_Media_Recycle_Bin_Key_From_Id()
     {
-        var result = GetSubject().GetKeyForId(Constants.System.RecycleBinMedia, UmbracoObjectTypes.Media);
+        var result = GetIdKeyMap().GetKeyForId(Constants.System.RecycleBinMedia, UmbracoObjectTypes.Media);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(Constants.System.RecycleBinMediaKey, result.Result);
+    }
+
+    [Test]
+    public void Can_Resolve_Both_Directions_From_Populated_Pairs_Without_Hitting_The_Repository()
+    {
+        var key = Guid.NewGuid();
+        IdKeyMap idKeyMap = GetIdKeyMap(out Mock<IIdKeyMapRepository> repository);
+
+        idKeyMap.PopulateCache([(1234, key)], UmbracoObjectTypes.Document);
+
+        Assert.Multiple(() =>
+        {
+            Attempt<int> idAttempt = idKeyMap.GetIdForKey(key, UmbracoObjectTypes.Document);
+            Assert.IsTrue(idAttempt.Success);
+            Assert.AreEqual(1234, idAttempt.Result);
+
+            Attempt<Guid> keyAttempt = idKeyMap.GetKeyForId(1234, UmbracoObjectTypes.Document);
+            Assert.IsTrue(keyAttempt.Success);
+            Assert.AreEqual(key, keyAttempt.Result);
+        });
+
+        repository.Verify(
+            x => x.GetIdForKey(It.IsAny<Guid>(), It.IsAny<UmbracoObjectTypes>()),
+            Times.Never);
+        repository.Verify(
+            x => x.GetIdForKey(It.IsAny<int>(), It.IsAny<UmbracoObjectTypes>()),
+            Times.Never);
+    }
+
+    [Test]
+    public void Can_Resolve_Both_Directions_From_A_Single_Populated_Pair_Without_Hitting_The_Repository()
+    {
+        var key = Guid.NewGuid();
+        IdKeyMap idKeyMap = GetIdKeyMap(out Mock<IIdKeyMapRepository> repository);
+
+        idKeyMap.PopulateCache(4321, key, UmbracoObjectTypes.Media);
+
+        Assert.Multiple(() =>
+        {
+            Attempt<int> idAttempt = idKeyMap.GetIdForKey(key, UmbracoObjectTypes.Media);
+            Assert.IsTrue(idAttempt.Success);
+            Assert.AreEqual(4321, idAttempt.Result);
+
+            Attempt<Guid> keyAttempt = idKeyMap.GetKeyForId(4321, UmbracoObjectTypes.Media);
+            Assert.IsTrue(keyAttempt.Success);
+            Assert.AreEqual(key, keyAttempt.Result);
+        });
+
+        repository.Verify(
+            x => x.GetIdForKey(It.IsAny<Guid>(), It.IsAny<UmbracoObjectTypes>()),
+            Times.Never);
+        repository.Verify(
+            x => x.GetIdForKey(It.IsAny<int>(), It.IsAny<UmbracoObjectTypes>()),
+            Times.Never);
+    }
+
+    [Test]
+    public void Cannot_Resolve_Populated_Pair_Under_A_Different_Object_Type()
+    {
+        var key = Guid.NewGuid();
+        IdKeyMap idKeyMap = GetIdKeyMap(out Mock<IIdKeyMapRepository> repository);
+
+        idKeyMap.PopulateCache(1234, key, UmbracoObjectTypes.Document);
+
+        // The entries are keyed by identifier alone, so the object type on the value has to be what rejects
+        // the mismatch and sends the lookup on to the repository.
+        Assert.IsFalse(idKeyMap.GetIdForKey(key, UmbracoObjectTypes.Media).Success);
+        Assert.IsFalse(idKeyMap.GetKeyForId(1234, UmbracoObjectTypes.Media).Success);
+
+        repository.Verify(x => x.GetIdForKey(key, UmbracoObjectTypes.Media), Times.Once);
+        repository.Verify(x => x.GetIdForKey(1234, UmbracoObjectTypes.Media), Times.Once);
+    }
+
+    [Test]
+    public void Can_Populate_Cache_Without_Overriding_Recycle_Bin_Identifiers()
+    {
+        IdKeyMap idKeyMap = GetIdKeyMap(out _);
+
+        idKeyMap.PopulateCache(Constants.System.RecycleBinContent, Guid.NewGuid(), UmbracoObjectTypes.Document);
+
+        Attempt<Guid> keyAttempt = idKeyMap.GetKeyForId(Constants.System.RecycleBinContent, UmbracoObjectTypes.Document);
+        Assert.IsTrue(keyAttempt.Success);
+        Assert.AreEqual(Constants.System.RecycleBinContentKey, keyAttempt.Result);
+    }
+
+    [Test]
+    public void Can_Populate_Cache_Concurrently_While_Reading()
+    {
+        const int Count = 500;
+        IdKeyMap idKeyMap = GetIdKeyMap(out _);
+        var pairs = Enumerable.Range(1, Count).Select(id => (Id: id, Key: Guid.NewGuid())).ToArray();
+
+        Assert.DoesNotThrow(() => Parallel.ForEach(pairs, pair =>
+        {
+            idKeyMap.PopulateCache(pair.Id, pair.Key, UmbracoObjectTypes.Document);
+            idKeyMap.GetIdForKey(pair.Key, UmbracoObjectTypes.Document);
+            idKeyMap.PopulateCache(pair.Id, pair.Key, UmbracoObjectTypes.Document);
+        }));
+
+        foreach ((int id, Guid key) in pairs)
+        {
+            Assert.AreEqual(id, idKeyMap.GetIdForKey(key, UmbracoObjectTypes.Document).Result);
+            Assert.AreEqual(key, idKeyMap.GetKeyForId(id, UmbracoObjectTypes.Document).Result);
+        }
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/IdKeyMapTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/IdKeyMapTests.cs
@@ -13,10 +13,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
 [TestFixture]
 public class IdKeyMapTests
 {
-    private IdKeyMap GetIdKeyMap()
+    private static IdKeyMap GetIdKeyMap()
         => new IdKeyMap(Mock.Of<ICoreScopeProvider>(), Mock.Of<IIdKeyMapRepository>());
 
-    private IdKeyMap GetIdKeyMap(out Mock<IIdKeyMapRepository> repository)
+    private static IdKeyMap GetIdKeyMap(out Mock<IIdKeyMapRepository> repository)
     {
         repository = new Mock<IIdKeyMapRepository>();
 


### PR DESCRIPTION
## Description

Umbraco stores two IDs for most entities - the `Id` (an integer) and the `Key` (a GUID).  The management API uses the latter, but the database is mostly primary keyed by the former.  As such there's often a need to convert from one to the other which is done via `IdKeyMap` (implementing `IIdKeyMap`).  This involves a database lookup, which once done, is cached for the lifetime of the application.

`IdKeyMap` is a lazy cache: it prefetches nothing, so every miss costs a fresh `ICoreScope` plus a single-row query against `umbracoNode`. On a cold map that can turn into an N+1 — the issue reports looping over a `List<IPublishedContent>` calling `.Url()` and seeing one ...

```sql
SELECT [umbracoNode].[id] FROM [umbracoNode] WHERE [umbracoNode].[uniqueId] = @0 AND (...)
```

... per item.

The observation behind this PR is that we already have the data when rendering documents and media. Every `ContentCacheNode` the published cache materialises carries **both** the integer `Id` and the `Guid` `Key` — at seed time and on every cache load. Feeding those pairs into the map costs no extra queries, and benefits every consumer of `IIdKeyMap`.

Fixes #23583.

### What's changed

**`IIdKeyMap` gains `PopulateCache`**, in two overloads:

- `PopulateCache(IReadOnlyCollection<(int Id, Guid Key)> pairs, UmbracoObjectTypes)` — for bulk warming.
- `PopulateCache(int id, Guid key, UmbracoObjectTypes)` — for the single-item path.

Both have default implementations, so this is not a breaking change for anyone implementing the interface. The single-pair overload's default delegates to the collection overload, so an implementer only needs to provide one.

**`IdKeyMap` implements them.** 

**`DocumentCacheService` and `MediaCacheService` populate the map** in two places each:

- once per batch in `SeedAsync`, and
- once per cache load in `GetNodeAsync`, positioned so that L1/L2 hits populate too, not just database reads.

Both directions are written, so mapping an item on load also satisfies a later lookup in the opposite direction.

## Testing

### Automated

Unit and integration tests are included; solution should build and CI checks pass.

### Manual

There is no UI-visible change — the effect is the absence of database round-trips — so verification means counting those round-trips.

#### 1. Add temporary logging

In `src/Umbraco.Core/Services/IdKeyMap.cs`, add:

```csharp
private static int _databaseLookupCount;
private static ILogger<IdKeyMap>? _temporaryLogger;

private static void LogDatabaseLookup(string method, object identifier, UmbracoObjectTypes umbracoObjectType)
{
    // Unit tests construct this type directly, with no service provider behind StaticServiceProvider.
    _temporaryLogger ??= StaticServiceProvider.Instance?.GetService<ILogger<IdKeyMap>>();
    if (_temporaryLogger is null)
    {
        return;
    }

    var count = Interlocked.Increment(ref _databaseLookupCount);
    _temporaryLogger.LogInformation(
        "IdKeyMap database lookup #{LookupCount}: {Method}({Identifier}, {UmbracoObjectType})",
        count,
        method,
        identifier,
        umbracoObjectType);
}
```

Then call it in `GetIdForKey` and `GetKeyForId`, immediately before each falls through to `_idKeyMapRepository`:

```csharp
if (val == null)
{
    LogDatabaseLookup("GetIdForKey", key, umbracoObjectType);   // "GetKeyForId", id — in the other method
    using (ICoreScope scope = _scopeProvider.CreateCoreScope())
    {
        ...
```

#### 2. Add a test page

Against a site with a several published nodes:

```csharp
@foreach (var item in Umbraco.ContentAtRoot().First().Descendants())
{
    <li>@item.Name — @item.Url()</li>
}
```

#### 3. Without seeding

Set `Umbraco:CMS:Cache:DocumentBreadthFirstSeedCount` at `0`. Restart, then request the page twice.

- **Expected:** a handful of lookups on the first request only and **none** on any subsequent refresh.

#### 4. With seeding

Set `Umbraco:CMS:Cache:DocumentBreadthFirstSeedCount` high enough to cover the tree. Restart, then request the page.

- **Expected:** **no** lookups at all, including on the first request, because seeding mapped the documents before anything asked for them. This exercises the seed hooks rather than the load hooks, so it is worth running as well as step 3, not instead of it.

#### 5. Before and after

To see the behaviour this PR removes, comment out the single population call in `DocumentCacheService.GetNodeAsync`:

```csharp
//_idKeyMap.PopulateCache(contentCacheNode.Id, contentCacheNode.Key, UmbracoObjectTypes.Document);
```

Rebuild and repeat step 3.

- **Expected:** one lookup per rendered descendant instead of a handful, and the counter keeps climbing on **every** refresh, because nothing warms the map except the lookups themselves.

Restore the line, and the counter goes flat again after the first request.

For the seeding half, comment out the `_idKeyMap.PopulateCache(idKeyPairs, …)` call at the end of the batch loop in `SeedAsync` and repeat step 4.
