### PR TITLE
Segments: Fix mandatory segment property validation (closes #23576)

### DIFF
--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -89,7 +89,8 @@ public class PropertyValidationService : IPropertyValidationService
             return [];
         }
 
-        return ValidatePropertyValue(dataEditor, dataType, postedValue, propertyType.Mandatory, propertyType.ValidationRegExp, propertyType.MandatoryMessage, propertyType.ValidationRegExpMessage, validationContext);
+        var isRequired = propertyType.Mandatory && validationContext.Segment.IsNullOrWhiteSpace();
+        return ValidatePropertyValue(dataEditor, dataType, postedValue, isRequired, propertyType.ValidationRegExp, propertyType.MandatoryMessage, propertyType.ValidationRegExpMessage, validationContext);
     }
 
     /// <inheritdoc />

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Validate.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Validate.cs
@@ -156,7 +156,6 @@ public partial class ContentEditingServiceTests
             [
                 new PropertyValueModel { Alias = "invariantTitle", Value = "The updated invariant title" },
                 new PropertyValueModel { Alias = "variantTitle", Value = "The updated English default segment title", Culture = "en-US" },
-                new PropertyValueModel { Alias = "variantTitle", Value = "The updated Danish default segment title", Culture = "da-DK" },
                 new PropertyValueModel { Alias = "variantTitle", Value = "The updated English segment 1 title", Culture = "en-US", Segment = "seg-1" },
                 new PropertyValueModel { Alias = "variantTitle", Value = "The updated Danish segment 1 title", Culture = "da-DK", Segment = "seg-1" },
                 new PropertyValueModel { Alias = "variantTitle", Value = "The updated English segment 2 title", Culture = "en-US", Segment = "seg-2" },
@@ -175,7 +174,7 @@ public partial class ContentEditingServiceTests
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentEditingOperationStatus.PropertyValidationError, result.Status);
         Assert.AreEqual(1, result.Result.ValidationErrors.Count());
-        Assert.AreEqual("#validation_invalidNull", result.Result.ValidationErrors.Single(x => x.Alias == "variantTitle" && x.Culture == "da-DK" && x.Segment == "seg-2").ErrorMessages[0]);
+        Assert.AreEqual("#validation_invalidNull", result.Result.ValidationErrors.Single(x => x.Alias == "variantTitle" && x.Culture == "da-DK" && x.Segment == null).ErrorMessages[0]);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentValidationServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentValidationServiceTests.cs
@@ -573,7 +573,7 @@ internal sealed class ContentValidationServiceTests : UmbracoIntegrationTestWith
     }
 
     [Test]
-    public async Task Does_Not_Flag_Segment_As_Mandatory_When_Default_Has_Value()
+    public async Task Does_Not_Flag_Mandatory_Property_For_Segment_When_Default_Has_Value()
     {
         var contentType = await SetupSegmentTest(ContentVariation.Segment, titleIsMandatory: true);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentValidationServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentValidationServiceTests.cs
@@ -527,6 +527,80 @@ internal sealed class ContentValidationServiceTests : UmbracoIntegrationTestWith
         });
     }
 
+    [Test]
+    public async Task Can_Validate_Mandatory_Segment()
+    {
+        var contentType = await SetupSegmentTest(ContentVariation.Segment, titleIsMandatory: true);
+
+        var validationResult = await ContentValidationService.ValidatePropertiesAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                Properties =
+                [
+                    new()
+                    {
+                        Alias = "title",
+                        Value = null,
+                        Segment = null
+                    },
+                    new()
+                    {
+                        Alias = "title",
+                        Value = "Valid seg-1 value",
+                        Segment = "seg-1"
+                    }
+                ],
+                Variants = [
+                    new() { Name = "Test Document" },
+                    new() { Name = "Test Document", Segment = "seg-1" },
+                    new() { Name = "Test Document", Segment = "seg-2" }
+                ]
+            },
+            contentType);
+
+        Assert.AreEqual(1, validationResult.ValidationErrors.Count());
+        Assert.Multiple(() =>
+        {
+            var validationError = validationResult.ValidationErrors.First();
+            Assert.AreEqual("title", validationError.Alias);
+            Assert.AreEqual(null, validationError.Segment);
+            Assert.IsEmpty(validationError.JsonPath);
+
+            Assert.AreEqual(1, validationError.ErrorMessages.Length);
+            Assert.AreEqual(Constants.Validation.ErrorMessages.Properties.Missing, validationError.ErrorMessages.Single());
+        });
+    }
+
+    [Test]
+    public async Task Does_Not_Flag_Segment_As_Mandatory_When_Default_Has_Value()
+    {
+        var contentType = await SetupSegmentTest(ContentVariation.Segment, titleIsMandatory: true);
+
+        var validationResult = await ContentValidationService.ValidatePropertiesAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                Properties =
+                [
+                    new()
+                    {
+                        Alias = "title",
+                        Value = "Valid default value",
+                        Segment = null
+                    }
+                ],
+                Variants = [
+                    new() { Name = "Test Document" },
+                    new() { Name = "Test Document", Segment = "seg-1" },
+                    new() { Name = "Test Document", Segment = "seg-2" }
+                ]
+            },
+            contentType);
+
+        Assert.AreEqual(0, validationResult.ValidationErrors.Count());
+    }
+
     private async Task<(IContentType DocumentType, IContentType ElementType)> SetupBlockListTest()
     {
         var propertyEditorCollection = GetRequiredService<PropertyEditorCollection>();
@@ -631,7 +705,7 @@ internal sealed class ContentValidationServiceTests : UmbracoIntegrationTestWith
         return contentType;
     }
 
-    private async Task<IContentType> SetupSegmentTest(ContentVariation variation)
+    private async Task<IContentType> SetupSegmentTest(ContentVariation variation, bool titleIsMandatory = false)
     {
         var language = new LanguageBuilder()
             .WithCultureInfo("da-DK")
@@ -643,6 +717,7 @@ internal sealed class ContentValidationServiceTests : UmbracoIntegrationTestWith
         var titlePropertyType = contentType.PropertyTypes.First(pt => pt.Alias == "title");
         titlePropertyType.Variations = variation;
         titlePropertyType.ValidationRegExp = "^Valid.*$";
+        titlePropertyType.Mandatory = titleIsMandatory;
         contentType.AllowedAsRoot = true;
         await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentValidationServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentValidationServiceTests.cs
@@ -528,7 +528,7 @@ internal sealed class ContentValidationServiceTests : UmbracoIntegrationTestWith
     }
 
     [Test]
-    public async Task Can_Validate_Mandatory_Segment()
+    public async Task Can_Validate_Mandatory_Property_For_Default_Segment()
     {
         var contentType = await SetupSegmentTest(ContentVariation.Segment, titleIsMandatory: true);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23576

### Description

As described in #23576, mandatory validation is performed explicitly on any property value. However, segment values are always considered as _optional overrides_ of the default (`null`) segment value. So in reality, mandatory validation should only ever be performed on the default segment value.

This PR fixes it.

### Testing this PR

First and foremost, enable segmentation with something along these lines:

```cs
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Configuration.Models;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Services.OperationStatus;

namespace My.Site;

public class MySegmentService : ISegmentService
{
    public Task<Attempt<PagedModel<Segment>?, SegmentOperationStatus>> GetPagedSegmentsAsync(int skip = 0, int take = 100)
        => Task.FromResult
        (
            Attempt.SucceedWithStatus<PagedModel<Segment>?, SegmentOperationStatus>
            (
                SegmentOperationStatus.Success,
                new PagedModel<Segment>
                {
                    Total = 2,
                    Items = [
                        new Segment { Alias = "s1", Name = "Segment 1" },
                        new Segment { Alias = "s2", Name = "Segment 2" },
                    ],
                }
            )
        );
}

public class MySegmentComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        // register the custom segment service in place of the Umbraco core implementation
        builder.Services.AddUnique<ISegmentService, MySegmentService>();

        // update segment configuration so segments are enabled (in the client)
        builder.Services.Configure<SegmentSettings>(settings => settings.Enabled = true);
    }
}
```

Next, create segmented content with mandatory, segment-enabled properties, and verify, that you can indeed publish content _without_ filling out the mandatory properties for one or more segments, as long as they're filled out for the default segment.