### PR TITLE
Switch docs upload to umbraco-storage-wif service connection

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -902,7 +902,7 @@ stages:
             displayName: 'Copy C# Docs to blob storage'
             inputs:
               SourcePath: '$(Build.ArtifactStagingDirectory)/csharp-docs/*'
-              azureSubscription: umbraco-storage
+              azureSubscription: umbraco-storage-wif
               Destination: AzureBlob
               storage: umbracoapidocs
               ContainerName: '$web'
@@ -924,7 +924,7 @@ stages:
             displayName: 'Copy UI Docs to blob storage'
             inputs:
               SourcePath: '$(Build.ArtifactStagingDirectory)/ui-docs/*'
-              azureSubscription: umbraco-storage
+              azureSubscription: umbraco-storage-wif
               Destination: AzureBlob
               storage: umbracoapidocs
               ContainerName: '$web'


### PR DESCRIPTION
## Summary
- The `umbraco-storage` service connection's RBAC on `umbracoapidocs` didn't survive a recent resource-group move, breaking the C# docs / Storybook upload jobs.
- Switches `azureSubscription` to the new `umbraco-storage-wif` connection, which uses workload identity federation (no static secret) so this class of break can't recur.

## Test plan
- [ ] Confirm `Upload_API_Docs` stage succeeds on the next real release build (targeted for 03-09-2026)