### PR TITLE
Switch docs upload to umbraco-storage-wif service connection

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -956,7 +956,7 @@ stages:
             displayName: "Copy C# Docs to blob storage"
             inputs:
               SourcePath: "$(Build.ArtifactStagingDirectory)/csharp-docs/*"
-              azureSubscription: umbraco-storage
+              azureSubscription: umbraco-storage-wif
               Destination: AzureBlob
               storage: umbracoapidocs
               ContainerName: "$web"
@@ -980,7 +980,7 @@ stages:
             displayName: "Copy Storybook to blob storage"
             inputs:
               SourcePath: "$(Build.ArtifactStagingDirectory)/ui-docs/*"
-              azureSubscription: umbraco-storage
+              azureSubscription: umbraco-storage-wif
               Destination: AzureBlob
               storage: umbracoapidocs
               ContainerName: "$web"
@@ -1004,7 +1004,7 @@ stages:
             displayName: "Copy UI API Docs to blob storage"
             inputs:
               SourcePath: "$(Build.ArtifactStagingDirectory)/ui-api-docs/*"
-              azureSubscription: umbraco-storage
+              azureSubscription: umbraco-storage-wif
               Destination: AzureBlob
               storage: umbracoapidocs
               ContainerName: "$web"


### PR DESCRIPTION
## Summary
- The `umbraco-storage` service connection's RBAC on `umbracoapidocs` didn't survive a recent resource-group move, breaking the C# docs / Storybook / UI API docs upload jobs.
- Switches `azureSubscription` to the new `umbraco-storage-wif` connection, which uses workload identity federation (no static secret) so this class of break can't recur.
- Per team discussion, this targets v17/dev only (v13/dev handled separately in #23591); v17/dev is expected to forward-merge cleanly into main and v19/dev.

## Test plan
- [ ] Confirm `Upload_API_Docs` stage succeeds on the next real release build (targeted for 03-09-2026)