### PR TITLE
Add locking to Add/Remove calls on HashSet in ContentNavigationServiceBase

### DIFF
--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -77,8 +77,8 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     private NavigationSnapshot _navigation = new(new(), []);
     private NavigationSnapshot _recycleBinNavigation = new(new(), []);
 
-    private Lock _lockNavigation = new();
-    private Lock _lockRecycleBinNavigation = new();
+    private readonly Lock _lockNavigation = new();
+    private readonly Lock _lockRecycleBinNavigation = new();
 
     /// <summary>
     ///     Gets the approximate number of nodes currently held in memory across the active navigation

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -152,7 +152,12 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         //
         // Verified by: DocumentNavigationServiceTests.Concurrent_Rebuild_And_Queries_Never_Transiently_Lose_Content
         NavigationSnapshot snapshot = _navigation;
-        return TryGetRootKeysFromStructure(snapshot.Roots, snapshot.Structure, out rootKeys);
+        Guid[] roots;
+        lock (_lockNavigation)
+        {
+            roots = snapshot.Roots.ToArray();
+        }
+        return TryGetRootKeysFromStructure(roots, snapshot.Structure, out rootKeys);
     }
 
     /// <summary>
@@ -172,7 +177,12 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         {
             // See TryGetRootKeys for why we snapshot into a local.
             NavigationSnapshot snapshot = _navigation;
-            return TryGetRootKeysFromStructure(snapshot.Roots, snapshot.Structure, out rootKeys, contentTypeKey);
+            Guid[] roots;
+            lock (_lockNavigation)
+            {
+                roots = snapshot.Roots.ToArray();
+            }
+            return TryGetRootKeysFromStructure(roots, snapshot.Structure, out rootKeys, contentTypeKey);
         }
 
         // Content type alias doesn't exist
@@ -722,12 +732,12 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     }
 
     private static bool TryGetRootKeysFromStructure(
-        HashSet<Guid> input,
+        Guid[] input,
         ConcurrentDictionary<Guid, NavigationNode> structure,
         out IEnumerable<Guid> rootKeys,
         Guid? contentTypeKey = null)
     {
-        var keysWithSortOrder = new List<(Guid Key, int SortOrder)>(input.Count);
+        var keysWithSortOrder = new List<(Guid Key, int SortOrder)>(input.Length);
         foreach (Guid key in input)
         {
             if (structure.TryGetValue(key, out NavigationNode? navigationNode) is false)

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -77,6 +77,9 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     private NavigationSnapshot _navigation = new(new(), []);
     private NavigationSnapshot _recycleBinNavigation = new(new(), []);
 
+    private Lock _lockNavigation = new();
+    private Lock _lockRecycleBinNavigation = new();
+
     /// <summary>
     ///     Gets the approximate number of nodes currently held in memory across the active navigation
     ///     structure and the recycle bin structure, for diagnostics. Each snapshot reference is read once,
@@ -483,7 +486,10 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         }
         else
         {
-            _navigation.Roots.Add(key);
+            lock (_lockNavigation)
+            {
+                _navigation.Roots.Add(key);
+            }
         }
 
         // Note: sortOrder can't be automatically determined for items at root level, so it needs to be passed in
@@ -523,7 +529,10 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
             return false; // Cannot move a node to itself
         }
 
-        _navigation.Roots.Remove(key); // Just in case
+        lock (_lockNavigation)
+        {
+            _navigation.Roots.Remove(key); // Just in case
+        }
 
         NavigationNode? targetParentNode = null;
         if (targetParentKey.HasValue)
@@ -535,7 +544,10 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         }
         else
         {
-            _navigation.Roots.Add(key);
+            lock(_lockNavigation)
+            {
+                _navigation.Roots.Add(key);
+            }
         }
 
         // Remove the node from its current parent's children list
@@ -598,7 +610,10 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
             return false; // Node doesn't exist
         }
 
-        _recycleBinNavigation.Roots.Remove(key);
+        lock (_lockRecycleBinNavigation)
+        {
+            _recycleBinNavigation.Roots.Remove(key);
+        }
 
         RemoveDescendantsRecursively(nodeToRemove);
 
@@ -928,8 +943,14 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
 
     private void AddDescendantsToRecycleBinRecursively(NavigationNode node)
     {
-        _recycleBinNavigation.Roots.Add(node.Key);
-        _navigation.Roots.Remove(node.Key);
+        lock (_lockRecycleBinNavigation)
+        {
+            _recycleBinNavigation.Roots.Add(node.Key);
+        }
+        lock (_lockNavigation)
+        {
+            _navigation.Roots.Remove(node.Key);
+        }
         IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _navigation.Structure);
 
         foreach (Guid childKey in childrenKeys)
@@ -970,10 +991,16 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     {
         if (node.Parent is null)
         {
-            _navigation.Roots.Add(node.Key);
+            lock(_lockNavigation)
+            {
+                _navigation.Roots.Add(node.Key);
+            }
         }
 
-        _recycleBinNavigation.Roots.Remove(node.Key);
+        lock(_lockRecycleBinNavigation)
+        {
+            _recycleBinNavigation.Roots.Remove(node.Key);
+        }
         IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _recycleBinNavigation.Structure);
 
         foreach (Guid childKey in childrenKeys)


### PR DESCRIPTION
### Prerequisites

- [ x ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/23577

### Description
In the linked issue, it has been shown that there is a possibility that a non-thread-safe access to a `HashSet<T>` can be made in `ContentNavigationServiceBase`

This PR addresses this problem by adding locking whenever Add or Remove is called on this HashSet. As these methods are very quick to execute, there should be a negligible performance impact.

Another option would be to replace HashSet with a different data structure, but there is no functionally equivalent thread safe collection type in .NET, so this would have entailed further dependencies and/or functional differences, which I did not think appropriate.

NOTE: This PR needs to be backported to Umbraco 17 as well.

To test this you will have to simulate multiple threads simultaneously adding and/or deleting content, as this only occurs when multiple threads access the HashSet concurrently.