### PR TITLE
ESlint: Advice `null` controller alias

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/eslint/rules/enforce-null-observe-alias-in-constructor.cjs
+++ b/src/Umbraco.Web.UI.Client/devops/eslint/rules/enforce-null-observe-alias-in-constructor.cjs
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isFunctionLike(node) {
+	return (
+		node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression'
+	);
+}
+
+/**
+ * Walks up from `node` and returns the nearest enclosing function-like node, or null if there is none.
+ * @param {import('estree').Node} node
+ * @returns {import('estree').Node | null}
+ */
+function getEnclosingFunction(node) {
+	let current = node.parent;
+	while (current) {
+		if (isFunctionLike(current)) return current;
+		current = current.parent;
+	}
+	return null;
+}
+
+/**
+ * @param {import('estree').Node | null} functionNode
+ * @returns {boolean}
+ */
+function isConstructor(functionNode) {
+	return (
+		!!functionNode &&
+		functionNode.type === 'FunctionExpression' &&
+		functionNode.parent?.type === 'MethodDefinition' &&
+		functionNode.parent.kind === 'constructor'
+	);
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Enforce a `null` controller alias on `this.observe()` calls made directly in a constructor, since the constructor only ever runs once and an auto-generated or reused alias can collide with another observation on the same host and silently destroy it before it ever runs.',
+			category: 'Possible Errors',
+			recommended: true,
+		},
+		fixable: 'code',
+		schema: [],
+		messages: {
+			missingNullAlias: 'Pass `null` as the third argument to `this.observe()` when calling it directly in a constructor.',
+			nonNullAlias: 'Observations in the constructor must have `null` as the third argument, unless you explicitly need to remove the controller manually on a later stage.',
+		},
+	},
+	create(context) {
+		return {
+			CallExpression(node) {
+				const { callee } = node;
+				if (
+					callee.type !== 'MemberExpression' ||
+					callee.object.type !== 'ThisExpression' ||
+					callee.property.type !== 'Identifier' ||
+					callee.property.name !== 'observe' ||
+					node.arguments.length < 2
+				) {
+					return;
+				}
+
+				if (!isConstructor(getEnclosingFunction(node))) return;
+
+				const thirdArg = node.arguments[2];
+
+				if (!thirdArg) {
+					const lastArg = node.arguments[node.arguments.length - 1];
+					context.report({
+						node,
+						messageId: 'missingNullAlias',
+						fix: (fixer) => fixer.insertTextAfter(lastArg, ', null'),
+					});
+					return;
+				}
+
+				if (thirdArg.type !== 'Literal' || thirdArg.value !== null) {
+					context.report({
+						node: thirdArg,
+						messageId: 'nonNullAlias',
+						fix: (fixer) => fixer.replaceText(thirdArg, 'null'),
+					});
+				}
+			},
+		};
+	},
+};

--- a/src/Umbraco.Web.UI.Client/devops/eslint/rules/enforce-null-observe-alias-in-constructor.cjs
+++ b/src/Umbraco.Web.UI.Client/devops/eslint/rules/enforce-null-observe-alias-in-constructor.cjs
@@ -50,9 +50,11 @@ module.exports = {
 		fixable: 'code',
 		schema: [],
 		messages: {
-			missingNullAlias: 'Pass `null` as the third argument to `this.observe()` when calling it directly in a constructor.',
-			nonNullAlias: 'Observations in the constructor must have `null` as the third argument, unless you explicitly need to remove the controller manually on a later stage.',
-		},
+			messages: {
+				missingNullAlias: 'Pass `null` as the third argument to `this.observe()` when calling it directly in a constructor.',
+				nonNullAlias:
+					'Observations in the constructor must have `null` as the third argument. If you truly need a stable alias for manual removal, disable this rule for that line and document why.',
+			},
 	},
 	create(context) {
 		return {

--- a/src/Umbraco.Web.UI.Client/devops/eslint/rules/enforce-null-observe-alias-in-constructor.cjs
+++ b/src/Umbraco.Web.UI.Client/devops/eslint/rules/enforce-null-observe-alias-in-constructor.cjs
@@ -50,11 +50,10 @@ module.exports = {
 		fixable: 'code',
 		schema: [],
 		messages: {
-			messages: {
-				missingNullAlias: 'Pass `null` as the third argument to `this.observe()` when calling it directly in a constructor.',
-				nonNullAlias:
-					'Observations in the constructor must have `null` as the third argument. If you truly need a stable alias for manual removal, disable this rule for that line and document why.',
-			},
+			missingNullAlias: 'Pass `null` as the third argument to `this.observe()` when calling it directly in a constructor.',
+			nonNullAlias:
+				'Observations in the constructor must have `null` as the third argument. If you truly need a stable alias for manual removal, disable this rule for that line and document why.',
+		},
 	},
 	create(context) {
 		return {

--- a/src/Umbraco.Web.UI.Client/eslint-local-rules.cjs
+++ b/src/Umbraco.Web.UI.Client/eslint-local-rules.cjs
@@ -9,6 +9,7 @@ const preferStaticStylesLastRule = require('./devops/eslint/rules/prefer-static-
 const noRelativeImportToImportMapModule = require('./devops/eslint/rules/no-relative-import-to-import-map-module.cjs');
 const noUnsafeLocalize = require('./devops/eslint/rules/no-unsafe-localize.cjs');
 const enforceManifestAliasRule = require('./devops/eslint/rules/enforce-manifest-alias.cjs');
+const enforceNullObserveAliasInConstructorRule = require('./devops/eslint/rules/enforce-null-observe-alias-in-constructor.cjs');
 
 module.exports = {
 	'enforce-element-suffix-on-element-class-name': enforceElementSuffixOnElementClassNameRule,
@@ -20,4 +21,5 @@ module.exports = {
 	'no-relative-import-to-import-map-module': noRelativeImportToImportMapModule,
 	'no-unsafe-localize': noUnsafeLocalize,
 	'enforce-manifest-alias': enforceManifestAliasRule,
+	'enforce-null-observe-alias-in-constructor': enforceNullObserveAliasInConstructorRule,
 };

--- a/src/Umbraco.Web.UI.Client/eslint.config.js
+++ b/src/Umbraco.Web.UI.Client/eslint.config.js
@@ -56,6 +56,8 @@ export default [
 			'local-rules/enforce-manifest-alias': 'warn',
 			'local-rules/prefer-static-styles-last': 'warn',
 			'local-rules/no-unsafe-localize': 'error',
+			// TODO: change to 'error' when the ~130 current violations are cleaned up. [NL]
+			'local-rules/enforce-null-observe-alias-in-constructor': 'warn',
 			'local-rules/enforce-umbraco-external-imports': [
 				'error',
 				{

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-content-no-router.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-content-no-router.element.ts
@@ -55,10 +55,14 @@ export class UmbBlockWorkspaceViewEditContentNoRouterElement extends UmbLitEleme
 
 		this.#tabsStructureHelper.setIsRoot(true);
 		this.#tabsStructureHelper.setContainerChildType('Tab');
-		this.observe(this.#tabsStructureHelper.childContainers, (tabs) => {
-			this._tabs = tabs;
-			this.#setupViewContexts();
-		});
+		this.observe(
+			this.#tabsStructureHelper.childContainers,
+			(tabs) => {
+				this._tabs = tabs;
+				this.#setupViewContexts();
+			},
+			null,
+		);
 
 		this.observe(
 			this.#tabsStructureHelper.hasProperties,
@@ -66,7 +70,7 @@ export class UmbBlockWorkspaceViewEditContentNoRouterElement extends UmbLitEleme
 				this._hasRootProperties = hasRootProperties;
 				this.#setupViewContexts();
 			},
-			'observeRootProperties',
+			null,
 		);
 
 		this.consumeContext(UMB_BLOCK_WORKSPACE_CONTEXT, (context) => {


### PR DESCRIPTION
ESLint warning that advices to give a `null` controller aliases for observations(this.observe) directly in a constructor.

This helps devs not set unnecessary ctrl aliases or forget to define it as `null`, which leads to an auto-generated one — which is not necessary.

Visualized by this change (Code of a constructor):

<img width="1409" height="357" alt="image" src="https://github.com/user-attachments/assets/e187536b-4c22-4a70-a078-9c964a820b19" />
