### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,8 +46,8 @@
   </ItemGroup>
   <!-- Third-party packages -->
   <ItemGroup>
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.1" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.2.1" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.2.1" />
     <PackageVersion Include="BitFaster.Caching" Version="2.6.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
     <PackageVersion Include="Examine" Version="3.9.0" />


### PR DESCRIPTION
## Description

Routine dependency maintenance for the **18.2.0-rc** release. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Asp.Versioning.Mvc | 10.0.1 | 10.2.1 |
| Asp.Versioning.Mvc.ApiExplorer | 10.0.1 | 10.2.1 |

### Test packages (`tests/Directory.Packages.props`)

No changes.

### Inline / template versions

- `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: no changes.
- `templates/UmbracoExtension`: no changes (does not pin `Asp.Versioning`).

### Deliberately left unchanged

- `Microsoft.OpenApi` — only a minor update is available (2.9.0 → 2.11.0), but it is explicitly held (`HOLD at 2.9.0 - do not bump`) in `Directory.Packages.props` due to a rework of OpenAPI 3.0 nullability serialization in 2.10.0+.

## Testing

Solution builds and unit tests pass locally; CI checks are the source of truth.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FATXGZZCqD2dMqX5TLLsuh)_