### PR TITLE
Content type designer: add root property styles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-tab.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-tab.element.ts
@@ -317,6 +317,7 @@ export class UmbContentTypeDesignEditorTabElement extends UmbLitElement {
 			uui-box.opaque {
 				background-color: transparent;
 				border-color: transparent;
+				--uui-box-default-padding: 0;
 			}
 
 			.container-list {


### PR DESCRIPTION
Makes the Add Property button get full width:

<img width="1148" height="389" alt="image" src="https://github.com/user-attachments/assets/14ae9a88-08fb-4bf7-88b0-70206a37a66a" />

Before:

<img width="1384" height="372" alt="image" src="https://github.com/user-attachments/assets/88881227-b2c2-4814-93aa-b8ae5a7c6ec7" />
