### PR TITLE
Notifications: Show notification handler messages on the first save of new content (closes #23589)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/resources/api-interceptor.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/resources/api-interceptor.controller.test.ts
@@ -1,5 +1,5 @@
 import { UmbApiInterceptorController } from './api-interceptor.controller.js';
-import { expect } from '@open-wc/testing';
+import { expect, waitUntil } from '@open-wc/testing';
 import { customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
 import type { umbHttpClient } from '@umbraco-cms/backoffice/http-client';
@@ -112,5 +112,77 @@ describe('UmbApiInterceptorController', () => {
 		const result = await responseInterceptors[0](originalResponse, new Request('https://example.com'), {});
 
 		expect(result).to.equal(originalResponse);
+	});
+
+	describe('created (201) responses', () => {
+		const notificationsHeader = JSON.stringify([
+			{ category: 'BackOfficeNotifications', message: 'Saving Handler Message', type: 'Success' },
+		]);
+
+		function createdResponse() {
+			return new Response(null, {
+				status: 201,
+				headers: {
+					'Umb-Generated-Resource': 'a-key',
+					'Umb-Notifications': notificationsHeader,
+				},
+			});
+		}
+
+		it('preserves the Umb-Notifications header when moving the generated resource into the body', async () => {
+			controller.addUmbGeneratedResourceInterceptor(fakeClient);
+			const generatedResourceInterceptor = responseInterceptors[responseInterceptors.length - 1];
+
+			const result = await generatedResourceInterceptor(createdResponse(), new Request('https://example.com'), {});
+
+			expect(await result.text()).to.equal('a-key');
+			expect(result.headers.get('Umb-Notifications')).to.equal(notificationsHeader);
+		});
+
+		it('preserves "X-" headers when rewriting', async () => {
+			controller.addUmbGeneratedResourceInterceptor(fakeClient);
+			const generatedResourceInterceptor = responseInterceptors[responseInterceptors.length - 1];
+			const originalResponse = new Response(null, {
+				status: 201,
+				headers: { 'Umb-Generated-Resource': 'a-key', 'X-Correlation-Id': 'a-correlation-id' },
+			});
+
+			const result = await generatedResourceInterceptor(originalResponse, new Request('https://example.com'), {});
+
+			expect(result.headers.get('X-Correlation-Id')).to.equal('a-correlation-id');
+		});
+
+		it('notifies about event messages returned alongside a generated resource', async () => {
+			// Imported dynamically, as the interceptor itself does, to avoid a circular reference.
+			const { UmbNotificationContext } = await import('@umbraco-cms/backoffice/notification');
+			const notificationContext = new UmbNotificationContext(hostElement);
+
+			let notifications: Array<{ color: string; element: Element }> = [];
+			const subscription = notificationContext.notifications.subscribe((value) => (notifications = value));
+
+			// Registered in the same order as bindDefaultInterceptors, so the notifications interceptor sees
+			// the response rebuilt by the generated resource interceptor.
+			controller.addUmbGeneratedResourceInterceptor(fakeClient);
+			controller.addUmbNotificationsInterceptor(fakeClient);
+			const chain = responseInterceptors.slice(-2);
+
+			let response = createdResponse();
+			for (const interceptor of chain) {
+				response = await interceptor(response, new Request('https://example.com'), {});
+			}
+
+			await waitUntil(() => notifications.length === 1, 'Expected a notification to be shown');
+
+			const layout = notifications[0].element.firstElementChild as
+				| (Element & { data?: { message?: string } })
+				| null;
+			expect(layout?.data?.message).to.equal('Saving Handler Message');
+			expect(notifications[0].color).to.equal('positive');
+
+			// The notifications interceptor reports the messages but leaves the header in place.
+			expect(response.headers.get('Umb-Notifications')).to.equal(notificationsHeader);
+
+			subscription.unsubscribe();
+		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/resources/api-interceptor.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/resources/api-interceptor.controller.ts
@@ -277,7 +277,7 @@ export class UmbApiInterceptorController extends UmbControllerBase {
 	}
 
 	/**
-	 * Interceptor which checks responses for the umb-notifications header and displays them as a notification if any. Removes the umb-notifications from the headers.
+	 * Interceptor which checks responses for the umb-notifications header and displays them as a notification if any.
 	 * @param {umbHttpClient} client The OpenAPI client to add the interceptor to. It can be any client supporting Response and Request interceptors.
 	 * @internal
 	 */
@@ -364,10 +364,13 @@ export class UmbApiInterceptorController extends UmbControllerBase {
 		const contentType = isString ? 'text/plain' : 'application/json';
 		const responseBody = isString ? body : JSON.stringify(body);
 
-		// Construct new headers but preserve "X-" headers from the original response
+		// Construct new headers but preserve "X-" headers and Umbraco's own "Umb-" headers from the original
+		// response, so interceptors running after the one that rebuilt it can still read them.
+		// @see https://github.com/umbraco/Umbraco-CMS/issues/23589
 		const headersOverride: Record<string, string> = {};
 		originalResponse.headers.forEach((value, key) => {
-			if (key.toLowerCase().startsWith('x-')) {
+			const name = key.toLowerCase();
+			if (name.startsWith('x-') || name.startsWith('umb-')) {
 				headersOverride[key] = value;
 			}
 		});


### PR DESCRIPTION
## Description

An `EventMessage` added by a notification handler is surfaced in the backoffice as a toast, via the `Umb-Notifications` response header. Saving an **existing** document showed the message; saving a **newly created** one did not. On "Save and publish" of new content only the publishing message appeared.

### The cause

From the server side both headers are present on a create response.

The message was lost in the backoffice interceptor chain (`api-interceptor.controller.ts`). Since a create returns 201 with an empty body, the generated-resource interceptor rebuilds the response through `#createResponse` to put the new entity key in the body — and `#createResponse` copied **only `x-*` headers**.

### The fix

`#createResponse` now preserves Umbraco's own `umb-*` headers alongside the existing `x-*` allowlist, so an interceptor running after one that rebuilt the response can still read them.

Fixes #23589

## Testing

### Automated 

Automated: three tests added to `api-interceptor.controller.test.ts` — the header survives the 201 rewrite, a notification actually reaches the notification context when both interceptors run in `bindDefaultInterceptors` order, and `x-*` headers are still preserved. The first two fail without the fix.

### Manual

Drop this single file into an Umbraco site, then create a document and save it.

```csharp
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

namespace Issue23589;

public sealed class TestContentSavingNotificationHandler : INotificationHandler<ContentSavingNotification>
{
    public void Handle(ContentSavingNotification notification)
        => notification.Messages.Add(new EventMessage(
            "BackOfficeNotifications",
            "Saving Handler Message",
            EventMessageType.Success));
}

public sealed class TestContentPublishingNotificationHandler : INotificationHandler<ContentPublishingNotification>
{
    public void Handle(ContentPublishingNotification notification)
        => notification.Messages.Add(new EventMessage(
            "BackOfficeNotifications",
            "Publishing Handler Message",
            EventMessageType.Success));
}

public sealed class TestNotificationHandlersComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ContentSavingNotification, TestContentSavingNotificationHandler>();
        builder.AddNotificationHandler<ContentPublishingNotification, TestContentPublishingNotificationHandler>();
    }
}
```

| Step | Before | After |
|---|---|---|
| New document → Save | no toast | "Saving Handler Message" |
| Same document → Save again | "Saving Handler Message" | unchanged |
| New document → Save and publish | publishing toast only | both toasts |
