### PR TITLE
Documentation: Add a warning that discourages the use of `StripHtml` for XSS prevention

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
@@ -395,13 +395,21 @@ public static partial class StringExtensions
     /// Strips all HTML tags from a string.
     /// </summary>
     /// <remarks>
-    /// Not suitable for XSS prevention, <see cref="CleanForXss"/> is preferred instead.
-    /// This method strips only <i>valid</i> HTML tags, which means the following potential
-    /// XSS payload will be mitigated:
+    /// <para>
+    /// This is not a sanitizer and must not be relied on for XSS prevention. Only well-formed tags are
+    /// stripped, so this payload is neutralized:
     /// <code>&lt;script&gt;alert(1)&lt;/script&gt;</code>
-    /// But a payload containing a malformed tag that can still be rendered by a browser will not be
-    /// stripped:
+    /// whereas a tag left unterminated within the value survives:
     /// <code>&lt;img src=x onerror=alert(1)</code>
+    /// Once that output is concatenated into a page, the surrounding markup supplies the closing
+    /// <c>&gt;</c> and the browser renders the tag.
+    /// </para>
+    /// <para>
+    /// Rely on context-aware output encoding instead (Razor encodes <c>@</c> expressions by default),
+    /// or a dedicated HTML sanitizer where markup has to be preserved. For plain text values,
+    /// <see cref="CleanForXss"/> is an option, though it applies a blunt character filter and is
+    /// destructive to legitimate content.
+    /// </para>
     /// </remarks>
     /// <param name="text">The text to strip HTML from.</param>
     /// <returns>The string with all HTML tags removed.</returns>
@@ -412,6 +420,10 @@ public static partial class StringExtensions
     /// Strips all HTML tags from a string, replacing them with the specified character and ensuring that
     /// no more than one instance of the replacement string appears in a row.
     /// </summary>
+    /// <remarks>
+    /// This is not a sanitizer and must not be relied on for XSS prevention. See the remarks on
+    /// <see cref="StripHtml(string)"/>.
+    /// </remarks>
     /// <param name="text">The text to strip HTML from.</param>
     /// <param name="replacement">The string to replace the HTML tags with.</param>
     /// <returns>The string with all HTML tags removed.</returns>

--- a/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
@@ -394,6 +394,15 @@ public static partial class StringExtensions
     /// <summary>
     /// Strips all HTML tags from a string.
     /// </summary>
+    /// <remarks>
+    /// Not suitable for XSS prevention, <see cref="CleanForXss"/> is preferred instead.
+    /// This method strips only <i>valid</i> HTML tags, which means the following potential
+    /// XSS payload will be mitigated:
+    /// <code>&lt;script&gt;alert(1)&lt;/script&gt;</code>
+    /// But a payload containing a malformed tag that can still be rendered by a browser will not be
+    /// stripped:
+    /// <code>&lt;img src=x onerror=alert(1)</code>
+    /// </remarks>
     /// <param name="text">The text to strip HTML from.</param>
     /// <returns>The string with all HTML tags removed.</returns>
     public static string StripHtml(this string text)


### PR DESCRIPTION

### Prerequisites

- [x] I have added steps to test this contribution in the description below (tests not applicable for this PR)

### Description
When trying to patch an XSS vulnerability, this function may at first sight look like a solution. In order to prevent such confusion I think it would be wise to make abundantly clear in documentation that StripHtml is not suitable for preventing XSS.