### PR TITLE
Navigation Cache: Change from `HashSet<T>` to `ConcurrentHashSet<T>` in `NavigationSnapshot` (closes #23577)

### DIFF
--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Collections;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Navigation;
 using Umbraco.Cms.Core.Persistence.Repositories;
@@ -41,7 +42,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
 #pragma warning restore CS0419 // Ambiguous reference in cref attribute
     private sealed record NavigationSnapshot(
         ConcurrentDictionary<Guid, NavigationNode> Structure,
-        HashSet<Guid> Roots)
+        ConcurrentHashSet<Guid> Roots)
     {
         private long _generation;
 
@@ -680,7 +681,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         // readers never observe a transiently empty navigation state or a mismatched pair
         // of Structure and Roots.
         var newStructure = new ConcurrentDictionary<Guid, NavigationNode>();
-        var newRoots = new HashSet<Guid>();
+        var newRoots = new ConcurrentHashSet<Guid>();
 
         if (trashed)
         {
@@ -712,7 +713,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     }
 
     private static bool TryGetRootKeysFromStructure(
-        HashSet<Guid> input,
+        ConcurrentHashSet<Guid> input,
         ConcurrentDictionary<Guid, NavigationNode> structure,
         out IEnumerable<Guid> rootKeys,
         Guid? contentTypeKey = null)
@@ -1063,7 +1064,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         return true;
     }
 
-    private static void BuildNavigationDictionary(ConcurrentDictionary<Guid, NavigationNode> nodesStructure, HashSet<Guid> roots, IEnumerable<INavigationModel> entities)
+    private static void BuildNavigationDictionary(ConcurrentDictionary<Guid, NavigationNode> nodesStructure, ConcurrentHashSet<Guid> roots, IEnumerable<INavigationModel> entities)
     {
         var entityList = entities.ToList();
         var idToKeyMap = entityList.ToDictionary(x => x.Id, x => x.Key);

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -487,16 +487,20 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
                 return false; // Parent node doesn't exist
             }
         }
-        else
-        {
-            _navigation.Roots.Add(key);
-        }
 
         // Note: sortOrder can't be automatically determined for items at root level, so it needs to be passed in
         var newNode = new NavigationNode(key, contentTypeKey, sortOrder ?? 0);
         if (_navigation.Structure.TryAdd(key, newNode) is false)
         {
             return false; // Node with this key already exists
+        }
+
+        // Registered as a root only once the key is known to be new. A key rejected above is already in
+        // the structure, so registering it here would report the existing node as a root regardless of
+        // the parent it actually has.
+        if (parentKey.HasValue is false)
+        {
+            _navigation.Roots.Add(key);
         }
 
         // If sortOrder supplied → caller is asserting the position, preserve it; otherwise append last.

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -442,22 +442,30 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool MoveToBin(Guid key)
     {
-        if (TryRemoveNodeFromParentInStructure(_navigation.Structure, key, out NavigationNode? nodeToRemove) is false || nodeToRemove is null)
+        // Snapshot references are read once here and passed down, so every step of the move — including
+        // the recursive descendant walk — acts on one coherent pair of structures. If a rebuild swaps a
+        // field mid-operation, the work lands on the snapshot being replaced and is discarded with it,
+        // which is what we want: the rebuild has already read the same state from the database. The
+        // mutators below follow the same convention; see TryGetRootKeys for the reader side.
+        NavigationSnapshot navigation = _navigation;
+        NavigationSnapshot recycleBinNavigation = _recycleBinNavigation;
+
+        if (TryRemoveNodeFromParentInStructure(navigation.Structure, key, out NavigationNode? nodeToRemove) is false || nodeToRemove is null)
         {
             return false; // Node doesn't exist
         }
 
         // Recursively remove all descendants and add them to recycle bin
-        AddDescendantsToRecycleBinRecursively(nodeToRemove);
+        AddDescendantsToRecycleBinRecursively(navigation, recycleBinNavigation, nodeToRemove);
 
         // Reset the SortOrder based on its new position in the bin
-        nodeToRemove.UpdateSortOrder(_recycleBinNavigation.Structure.Count);
-        var moved = _recycleBinNavigation.Structure.TryAdd(nodeToRemove.Key, nodeToRemove) &&
-                    _navigation.Structure.TryRemove(key, out _);
+        nodeToRemove.UpdateSortOrder(recycleBinNavigation.Structure.Count);
+        var moved = recycleBinNavigation.Structure.TryAdd(nodeToRemove.Key, nodeToRemove) &&
+                    navigation.Structure.TryRemove(key, out _);
 
         // Both snapshots' descendant lists are now potentially stale.
-        _navigation.Invalidate();
-        _recycleBinNavigation.Invalidate();
+        navigation.Invalidate();
+        recycleBinNavigation.Invalidate();
 
         return moved;
     }
@@ -479,10 +487,12 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool Add(Guid key, Guid contentTypeKey, Guid? parentKey = null, int? sortOrder = null)
     {
+        NavigationSnapshot navigation = _navigation;
+
         NavigationNode? parentNode = null;
         if (parentKey.HasValue)
         {
-            if (_navigation.Structure.TryGetValue(parentKey.Value, out parentNode) is false)
+            if (navigation.Structure.TryGetValue(parentKey.Value, out parentNode) is false)
             {
                 return false; // Parent node doesn't exist
             }
@@ -490,7 +500,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
 
         // Note: sortOrder can't be automatically determined for items at root level, so it needs to be passed in
         var newNode = new NavigationNode(key, contentTypeKey, sortOrder ?? 0);
-        if (_navigation.Structure.TryAdd(key, newNode) is false)
+        if (navigation.Structure.TryAdd(key, newNode) is false)
         {
             return false; // Node with this key already exists
         }
@@ -500,13 +510,13 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         // the parent it actually has.
         if (parentKey.HasValue is false)
         {
-            _navigation.Roots.Add(key);
+            navigation.Roots.Add(key);
         }
 
         // If sortOrder supplied → caller is asserting the position, preserve it; otherwise append last.
-        parentNode?.AddChild(_navigation.Structure, key, appendAsLastItem: sortOrder is null);
+        parentNode?.AddChild(navigation.Structure, key, appendAsLastItem: sortOrder is null);
 
-        _navigation.Invalidate();
+        navigation.Invalidate();
         return true;
     }
 
@@ -523,7 +533,9 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool Move(Guid key, Guid? targetParentKey = null)
     {
-        if (_navigation.Structure.TryGetValue(key, out NavigationNode? nodeToMove) is false)
+        NavigationSnapshot navigation = _navigation;
+
+        if (navigation.Structure.TryGetValue(key, out NavigationNode? nodeToMove) is false)
         {
             return false; // Node doesn't exist
         }
@@ -536,7 +548,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         NavigationNode? targetParentNode = null;
         if (targetParentKey.HasValue)
         {
-            if (_navigation.Structure.TryGetValue(targetParentKey.Value, out targetParentNode) is false)
+            if (navigation.Structure.TryGetValue(targetParentKey.Value, out targetParentNode) is false)
             {
                 return false; // Target parent doesn't exist
             }
@@ -547,23 +559,23 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         // one that is already a root stays a root throughout rather than being briefly removed first.
         if (targetParentNode is null)
         {
-            _navigation.Roots.Add(key);
+            navigation.Roots.Add(key);
         }
         else
         {
-            _navigation.Roots.Remove(key);
+            navigation.Roots.Remove(key);
         }
 
         // Remove the node from its current parent's children list
-        if (nodeToMove.Parent is not null && _navigation.Structure.TryGetValue(nodeToMove.Parent.Value, out NavigationNode? currentParentNode))
+        if (nodeToMove.Parent is not null && navigation.Structure.TryGetValue(nodeToMove.Parent.Value, out NavigationNode? currentParentNode))
         {
-            currentParentNode.RemoveChild(_navigation.Structure, key);
+            currentParentNode.RemoveChild(navigation.Structure, key);
         }
 
         // Set the new parent for the node (if parent node is null - the node is moved to root)
-        targetParentNode?.AddChild(_navigation.Structure, key);
+        targetParentNode?.AddChild(navigation.Structure, key);
 
-        _navigation.Invalidate();
+        navigation.Invalidate();
         return true;
     }
 
@@ -577,7 +589,9 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool UpdateSortOrder(Guid key, int newSortOrder)
     {
-        if (_navigation.Structure.TryGetValue(key, out NavigationNode? node) is false)
+        NavigationSnapshot navigation = _navigation;
+
+        if (navigation.Structure.TryGetValue(key, out NavigationNode? node) is false)
         {
             return false; // Node doesn't exist
         }
@@ -587,14 +601,14 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         // The parent's cached ordered-children snapshot sorts by child SortOrder and is now
         // stale — invalidate so the next read rebuilds against the new value.
         if (node.Parent is not null
-            && _navigation.Structure.TryGetValue(node.Parent.Value, out NavigationNode? parentNode))
+            && navigation.Structure.TryGetValue(node.Parent.Value, out NavigationNode? parentNode))
         {
             parentNode.InvalidateOrderedChildren();
         }
 
         // Descendants lists are sort-order-presorted (depth-first using each parent's
         // ordered children), so re-ordering a child re-orders any cached ancestor descendants.
-        _navigation.Invalidate();
+        navigation.Invalidate();
 
         return true;
     }
@@ -609,17 +623,19 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool RemoveFromBin(Guid key)
     {
-        if (TryRemoveNodeFromParentInStructure(_recycleBinNavigation.Structure, key, out NavigationNode? nodeToRemove) is false || nodeToRemove is null)
+        NavigationSnapshot recycleBinNavigation = _recycleBinNavigation;
+
+        if (TryRemoveNodeFromParentInStructure(recycleBinNavigation.Structure, key, out NavigationNode? nodeToRemove) is false || nodeToRemove is null)
         {
             return false; // Node doesn't exist
         }
 
-        _recycleBinNavigation.Roots.Remove(key);
+        recycleBinNavigation.Roots.Remove(key);
 
-        RemoveDescendantsRecursively(nodeToRemove);
+        RemoveDescendantsRecursively(recycleBinNavigation, nodeToRemove);
 
-        var removed = _recycleBinNavigation.Structure.TryRemove(key, out _);
-        _recycleBinNavigation.Invalidate();
+        var removed = recycleBinNavigation.Structure.TryRemove(key, out _);
+        recycleBinNavigation.Invalidate();
         return removed;
     }
 
@@ -637,30 +653,33 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool RestoreFromBin(Guid key, Guid? targetParentKey = null)
     {
-        if (_recycleBinNavigation.Structure.TryGetValue(key, out NavigationNode? nodeToRestore) is false)
+        NavigationSnapshot navigation = _navigation;
+        NavigationSnapshot recycleBinNavigation = _recycleBinNavigation;
+
+        if (recycleBinNavigation.Structure.TryGetValue(key, out NavigationNode? nodeToRestore) is false)
         {
             return false; // Node doesn't exist
         }
 
         // If a target parent is specified, try to find it in the main structure
         NavigationNode? targetParentNode = null;
-        if (targetParentKey.HasValue && _navigation.Structure.TryGetValue(targetParentKey.Value, out targetParentNode) is false)
+        if (targetParentKey.HasValue && navigation.Structure.TryGetValue(targetParentKey.Value, out targetParentNode) is false)
         {
             return false; // Target parent doesn't exist
         }
 
         // Set the new parent for the node (if parent node is null - the node is moved to root)
-        targetParentNode?.AddChild(_recycleBinNavigation.Structure, key);
+        targetParentNode?.AddChild(recycleBinNavigation.Structure, key);
 
         // Restore the node and its descendants from the recycle bin to the main structure
-        RestoreNodeAndDescendantsRecursively(nodeToRestore);
+        RestoreNodeAndDescendantsRecursively(navigation, recycleBinNavigation, nodeToRestore);
 
-        var restored = _navigation.Structure.TryAdd(nodeToRestore.Key, nodeToRestore) &&
-                       _recycleBinNavigation.Structure.TryRemove(key, out _);
+        var restored = navigation.Structure.TryAdd(nodeToRestore.Key, nodeToRestore) &&
+                       recycleBinNavigation.Structure.TryRemove(key, out _);
 
         // Both snapshots' descendant lists are now potentially stale.
-        _navigation.Invalidate();
-        _recycleBinNavigation.Invalidate();
+        navigation.Invalidate();
+        recycleBinNavigation.Invalidate();
 
         return restored;
     }
@@ -942,69 +961,75 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         return true;
     }
 
-    private void AddDescendantsToRecycleBinRecursively(NavigationNode node)
+    private static void AddDescendantsToRecycleBinRecursively(
+        NavigationSnapshot navigation,
+        NavigationSnapshot recycleBinNavigation,
+        NavigationNode node)
     {
-        _recycleBinNavigation.Roots.Add(node.Key);
-        _navigation.Roots.Remove(node.Key);
-        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _navigation.Structure);
+        recycleBinNavigation.Roots.Add(node.Key);
+        navigation.Roots.Remove(node.Key);
+        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, navigation.Structure);
 
         foreach (Guid childKey in childrenKeys)
         {
-            if (_navigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
+            if (navigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
             {
                 continue;
             }
 
             // Reset the SortOrder based on its new position in the bin
-            childNode.UpdateSortOrder(_recycleBinNavigation.Structure.Count);
-            AddDescendantsToRecycleBinRecursively(childNode);
+            childNode.UpdateSortOrder(recycleBinNavigation.Structure.Count);
+            AddDescendantsToRecycleBinRecursively(navigation, recycleBinNavigation, childNode);
 
             // Only remove the child from the main structure if it was successfully added to the recycle bin
-            if (_recycleBinNavigation.Structure.TryAdd(childKey, childNode))
+            if (recycleBinNavigation.Structure.TryAdd(childKey, childNode))
             {
-                _navigation.Structure.TryRemove(childKey, out _);
+                navigation.Structure.TryRemove(childKey, out _);
             }
         }
     }
 
-    private void RemoveDescendantsRecursively(NavigationNode node)
+    private static void RemoveDescendantsRecursively(NavigationSnapshot recycleBinNavigation, NavigationNode node)
     {
-        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _recycleBinNavigation.Structure);
+        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, recycleBinNavigation.Structure);
         foreach (Guid childKey in childrenKeys)
         {
-            if (_recycleBinNavigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
+            if (recycleBinNavigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
             {
                 continue;
             }
 
-            RemoveDescendantsRecursively(childNode);
-            _recycleBinNavigation.Structure.TryRemove(childKey, out _);
+            RemoveDescendantsRecursively(recycleBinNavigation, childNode);
+            recycleBinNavigation.Structure.TryRemove(childKey, out _);
         }
     }
 
-    private void RestoreNodeAndDescendantsRecursively(NavigationNode node)
+    private static void RestoreNodeAndDescendantsRecursively(
+        NavigationSnapshot navigation,
+        NavigationSnapshot recycleBinNavigation,
+        NavigationNode node)
     {
         if (node.Parent is null)
         {
-            _navigation.Roots.Add(node.Key);
+            navigation.Roots.Add(node.Key);
         }
 
-        _recycleBinNavigation.Roots.Remove(node.Key);
-        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _recycleBinNavigation.Structure);
+        recycleBinNavigation.Roots.Remove(node.Key);
+        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, recycleBinNavigation.Structure);
 
         foreach (Guid childKey in childrenKeys)
         {
-            if (_recycleBinNavigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
+            if (recycleBinNavigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
             {
                 continue;
             }
 
-            RestoreNodeAndDescendantsRecursively(childNode);
+            RestoreNodeAndDescendantsRecursively(navigation, recycleBinNavigation, childNode);
 
             // Only remove the child from the recycle bin structure if it was successfully added to the main one
-            if (_navigation.Structure.TryAdd(childKey, childNode))
+            if (navigation.Structure.TryAdd(childKey, childNode))
             {
-                _recycleBinNavigation.Structure.TryRemove(childKey, out _);
+                recycleBinNavigation.Structure.TryRemove(childKey, out _);
             }
         }
     }

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -533,8 +533,6 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
             return false; // Cannot move a node to itself
         }
 
-        _navigation.Roots.Remove(key); // Just in case
-
         NavigationNode? targetParentNode = null;
         if (targetParentKey.HasValue)
         {
@@ -543,9 +541,17 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
                 return false; // Target parent doesn't exist
             }
         }
-        else
+
+        // Updated only once the move is known to go ahead, so a node that fails the checks above keeps
+        // the place it already had. One operation per destination: a node moving to root is added, and
+        // one that is already a root stays a root throughout rather than being briefly removed first.
+        if (targetParentNode is null)
         {
             _navigation.Roots.Add(key);
+        }
+        else
+        {
+            _navigation.Roots.Remove(key);
         }
 
         // Remove the node from its current parent's children list

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
@@ -2092,6 +2092,121 @@ public class ContentNavigationServiceBaseTests
         Assert.IsEmpty(resolvedAliases, "Aliases were resolved through the content type service again, so not every concurrent write reached the alias map.");
     }
 
+    [Test]
+    public async Task Concurrent_Root_Mutations_Do_Not_Corrupt_The_Roots_Set()
+    {
+        // Arrange
+        // Content operations write the roots sets from live request threads: trashing a root removes it
+        // from the main set and adds it to the bin's, emptying the bin removes it from the bin's, and
+        // moving a node to root adds it to the main set. Run in parallel, every one of those operations
+        // succeeds and every write lands, leaving the roots sets holding exactly the nodes that are
+        // roots. See #23577.
+        const int KeysPerThread = 256;
+        const int ThreadCount = 8;
+
+        var navigationService = new TestContentNavigationService(
+            Mock.Of<ICoreScopeProvider>(),
+            Mock.Of<INavigationRepository>(),
+            Mock.Of<IContentTypeService>());
+
+        var contentTypeKey = Guid.NewGuid();
+
+        // Two disjoint workloads, so the roots sets are the only state shared between threads and the
+        // assertions speak only to them: one set of keys starts at root and is trashed then permanently
+        // deleted, the other starts under a parent and is promoted to root.
+        var keysToTrash = new Guid[ThreadCount][];
+        var keysToPromote = new Guid[ThreadCount][];
+        var untouchedRootKeys = new List<Guid>(ThreadCount * KeysPerThread);
+        for (var thread = 0; thread < ThreadCount; thread++)
+        {
+            keysToTrash[thread] = new Guid[KeysPerThread];
+            keysToPromote[thread] = new Guid[KeysPerThread];
+            for (var i = 0; i < KeysPerThread; i++)
+            {
+                var keyToTrash = Guid.NewGuid();
+                navigationService.Add(keyToTrash, contentTypeKey);
+                keysToTrash[thread][i] = keyToTrash;
+
+                // Each promoted key gets a parent of its own, so Move never mutates a NavigationNode
+                // shared with another thread and the roots set stays the only contended collection.
+                var parentKey = Guid.NewGuid();
+                navigationService.Add(parentKey, contentTypeKey);
+                untouchedRootKeys.Add(parentKey);
+
+                var keyToPromote = Guid.NewGuid();
+                navigationService.Add(keyToPromote, contentTypeKey, parentKey);
+                keysToPromote[thread][i] = keyToPromote;
+            }
+        }
+
+        var exceptions = new ConcurrentQueue<Exception>();
+        var failedOperations = new ConcurrentQueue<string>();
+
+        // All workers start together to maximise overlap on the roots sets, on dedicated threads so
+        // releasing the gate never waits on thread pool growth.
+        var startGate = new Barrier(ThreadCount);
+
+        // Act
+        Task workers = Task.WhenAll(Enumerable.Range(0, ThreadCount).Select(thread => Task.Factory.StartNew(
+            () =>
+            {
+                startGate.SignalAndWait();
+                for (var i = 0; i < KeysPerThread; i++)
+                {
+                    try
+                    {
+                        Guid keyToTrash = keysToTrash[thread][i];
+                        if (navigationService.MoveToBin(keyToTrash) is false)
+                        {
+                            failedOperations.Enqueue($"MoveToBin('{keyToTrash}')");
+                        }
+
+                        if (navigationService.RemoveFromBin(keyToTrash) is false)
+                        {
+                            failedOperations.Enqueue($"RemoveFromBin('{keyToTrash}')");
+                        }
+
+                        Guid keyToPromote = keysToPromote[thread][i];
+                        if (navigationService.Move(keyToPromote) is false)
+                        {
+                            failedOperations.Enqueue($"Move('{keyToPromote}')");
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        exceptions.Enqueue(exception);
+                    }
+                }
+            },
+            TaskCreationOptions.LongRunning)));
+
+        // Finishing inside this window is part of what is asserted, not just a guard against slowness:
+        // the writers are expected to keep making progress throughout, never to stall on each other.
+        Task completed = await Task.WhenAny(workers, Task.Delay(TimeSpan.FromSeconds(30)));
+
+        // Assert
+        // The gate is disposed once the workers are done rather than with `using`, so that it stays
+        // valid for as long as a worker could still be waiting on it.
+        Assert.Multiple(() =>
+        {
+            Assert.AreSame(workers, completed, "Concurrent root mutations did not finish; the roots set has likely livelocked.");
+            Assert.IsEmpty(exceptions, $"Concurrent root mutations threw: {exceptions.FirstOrDefault()}");
+            Assert.IsEmpty(failedOperations, $"Navigation operations reported failure: {failedOperations.FirstOrDefault()}");
+        });
+
+        // Surfaces any worker fault raised outside the per-iteration try (e.g. from the start gate).
+        await workers;
+        startGate.Dispose();
+
+        // The roots set now holds every promoted key, alongside the parents they were promoted away
+        // from, and none of the trashed keys — so each concurrent add and remove is accounted for,
+        // which holds whether or not any thread threw.
+        Assert.IsTrue(navigationService.TryGetRootKeys(out IEnumerable<Guid> rootKeys));
+
+        Guid[] expectedRootKeys = [.. untouchedRootKeys, .. keysToPromote.SelectMany(keys => keys)];
+        CollectionAssert.AreEquivalent(expectedRootKeys, rootKeys, "The roots set does not hold exactly the expected roots, so a concurrent write was lost.");
+    }
+
     private void CreateTestData()
     {
         ContentType = new Guid("217C492D-0067-478C-BEA8-D0CE2DECBEB9");

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
@@ -1634,10 +1634,11 @@ public class ContentNavigationServiceBaseTests
     }
 
     [Test]
-    public void Cannot_Move_Node_When_Target_Parent_Does_Not_Exist()
+    [TestCase("E48DD82A-7059-418E-9B82-CDD5205796CF")] // Root
+    [TestCase("C6173927-0C59-4778-825D-D7B9F45D8DDE")] // Child 1
+    public void Cannot_Move_Node_When_Target_Parent_Does_Not_Exist(Guid nodeToMove)
     {
         // Arrange
-        Guid nodeToMove = Child1;
         var nonExistentTargetParentKey = Guid.NewGuid();
 
         // Act
@@ -1645,6 +1646,11 @@ public class ContentNavigationServiceBaseTests
 
         // Assert
         Assert.IsFalse(result);
+
+        // A node that fails to move keeps the place it already had, so a root asked to move under a
+        // parent that turns out not to exist is still a root afterwards.
+        _navigationService.TryGetRootKeys(out IEnumerable<Guid> rootKeys);
+        CollectionAssert.AreEquivalent(new[] { Root }, rootKeys);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
@@ -1547,6 +1547,18 @@ public class ContentNavigationServiceBaseTests
 
         // Assert
         Assert.IsFalse(result);
+
+        // The rejected key keeps the place it already had. No parent was passed above, so the add asked
+        // for the node at root level, yet the roots set is left as it was and the node stays under Root.
+        _navigationService.TryGetRootKeys(out IEnumerable<Guid> rootKeys);
+        var nodeExists = _navigationService.TryGetParentKey(Child1, out Guid? existingParentKey);
+
+        Assert.Multiple(() =>
+        {
+            CollectionAssert.AreEquivalent(new[] { Root }, rootKeys);
+            Assert.IsTrue(nodeExists);
+            Assert.AreEqual(Root, existingParentKey);
+        });
     }
 
     [Test]


### PR DESCRIPTION
### Prerequisites

- [ x ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23577

### Description
In the linked issue, it has been shown that there is a possibility that a non-thread-safe access to a `HashSet<T>` can be made in `ContentNavigationServiceBase`

This PR addresses this problem by changing to using the `ConcurrentHashSet<T>` already used in the Umbraco codebase.

NOTE: This PR needs to be backported to Umbraco 17 as well.

To test this you will have to simulate multiple threads simultaneously adding and/or deleting content, as this only occurs when multiple threads access the HashSet concurrently.