### PR TITLE
Localization: Restore from recycle bin and image crops property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2448,11 +2448,13 @@ export default {
 		autocompleteLabel: 'Autocomplete',
 	},
 	recycleBin: {
+		restoreItemTo: (from: string, to: string) => `Restore <strong>${from}</strong> to <strong>${to}</strong>`,
 		contentTrashed: 'Trashed content with Id: {0} related to original parent content with Id: {1}',
 		mediaTrashed: 'Trashed media with Id: {0} related to original parent media item with Id: {1}',
 		itemCannotBeRestored: 'Cannot automatically restore this item',
 		itemCannotBeRestoredHelpText:
 			'There is no location where this item can be automatically restored. You can move the item manually using the tree below.',
+		restoreToTitle: 'Restore to',
 		wasRestored: 'was restored under',
 	},
 	relationType: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2456,8 +2456,9 @@ export default {
 		mediaTrashed: 'Trashed media with Id: {0} related to original parent media item with Id: {1}',
 		itemCannotBeRestored: 'Cannot automatically restore this item',
 		itemCannotBeRestoredHelpText:
-			'There is no location where this item can be automatically restored. You can move the item manually using the tree below.',
+			'There is no location where this item can be automatically restored. You can select a new location below.',
 		restoreToTitle: 'Restore to',
+		selectRestoreLocation: 'Select location',
 		wasRestored: 'was restored under',
 	},
 	relationType: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ja.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ja.ts
@@ -413,6 +413,7 @@ export default {
 		install: 'インストール',
 		invalid: '無効',
 		justify: '位置揃え',
+		label: 'ラベル',
 		language: '言語',
 		layout: 'レイアウト',
 		links: 'リンク',
@@ -422,6 +423,7 @@ export default {
 		logoff: 'ログオフ',
 		logout: 'ログアウト',
 		macro: 'マクロ',
+		mandatory: '必須',
 		move: '移動',
 		name: '名前',
 		new: '新規',
@@ -440,6 +442,7 @@ export default {
 		reciept: 'フォームからEmailを受信',
 		recycleBin: 'ごみ箱',
 		remaining: '残り',
+		remove: '削除',
 		rename: '名前の変更',
 		renew: '更新',
 		required: 'この項目は必須です',
@@ -701,6 +704,7 @@ export default {
 		noColors: '設定済みの色はありません。',
 	},
 	propertyEditorPicker: {
+		title: 'プロパティエディターの選択',
 		selectAction: 'プロパティエディターの選択',
 	},
 	relatedlinks: {
@@ -1085,6 +1089,13 @@ export default {
 		invalidFalse: 'このフィールドはオンにする必要があります',
 		invalidPattern: '値が無効です。正しいパターンと一致しません',
 		customValidation: 'カスタム検証',
+	},
+	recycleBin: {
+		restoreItemTo: (from: string, to: string) => `<strong>${from}</strong> を<strong>${to}</strong> に復元します`,
+		itemCannotBeRestored: 'この項目は自動的に復元できません',
+		itemCannotBeRestoredHelpText:
+			'この項目を自動的に復元できる場所がありません。以下のツリーを使用して手動で移動できます。',
+		restoreToTitle: '復元先',
 	},
 	logViewer: {
 		selectAllLogLevelFilters: 'すべて選択',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ja.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ja.ts
@@ -1094,8 +1094,9 @@ export default {
 		restoreItemTo: (from: string, to: string) => `<strong>${from}</strong> を<strong>${to}</strong> に復元します`,
 		itemCannotBeRestored: 'この項目は自動的に復元できません',
 		itemCannotBeRestoredHelpText:
-			'この項目を自動的に復元できる場所がありません。以下のツリーを使用して手動で移動できます。',
+			'この項目を自動的に復元できる場所がありません。以下から新しい場所を選択できます。',
 		restoreToTitle: '復元先',
+		selectRestoreLocation: '場所を選択',
 	},
 	logViewer: {
 		selectAllLogLevelFilters: 'すべて選択',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ja.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ja.ts
@@ -1093,8 +1093,7 @@ export default {
 	recycleBin: {
 		restoreItemTo: (from: string, to: string) => `<strong>${from}</strong> を<strong>${to}</strong> に復元します`,
 		itemCannotBeRestored: 'この項目は自動的に復元できません',
-		itemCannotBeRestoredHelpText:
-			'この項目を自動的に復元できる場所がありません。以下から新しい場所を選択できます。',
+		itemCannotBeRestoredHelpText: 'この項目を自動的に復元できる場所がありません。以下から新しい場所を選択できます。',
 		restoreToTitle: '復元先',
 		selectRestoreLocation: '場所を選択',
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
@@ -170,14 +170,11 @@ export class UmbRestoreFromRecycleBinModalElement extends UmbModalBaseElement<
 			${this._destinationItem && this._destinationItemName
 				? html`<uui-ref-node name=${this._destinationItemName}>
 						<uui-action-bar slot="actions">
-							<uui-button @click=${() => (this._destinationItem = undefined)} label=${this.localize.term('general_remove')}
-								></uui-button
-							>
+							<uui-button @click=${() => (this._destinationItem = undefined)} label=${this.localize.term('general_remove')}></uui-button>
 						</uui-action-bar>
 					</uui-ref-node>`
-				: html` <uui-button id="placeholder" look="placeholder" label=${this.localize.term('general_choose')} @click=${this.#onSelectCustomDestination}
-						></uui-button
-					>`}
+				: html` <uui-button id="placeholder" look="placeholder" label=${this.localize.term('general_choose')} @click=${this.#onSelectCustomDestination}></uui-button>`
+			}
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
@@ -173,7 +173,7 @@ export class UmbRestoreFromRecycleBinModalElement extends UmbModalBaseElement<
 							<uui-button @click=${() => (this._destinationItem = undefined)} label=${this.localize.term('general_remove')}></uui-button>
 						</uui-action-bar>
 					</uui-ref-node>`
-				: html` <uui-button id="placeholder" look="placeholder" label=${this.localize.term('general_choose')} @click=${this.#onSelectCustomDestination}></uui-button>`
+				: html` <uui-button id="placeholder" look="placeholder" label=${this.localize.term('recycleBin_selectRestoreLocation')} @click=${this.#onSelectCustomDestination}></uui-button>`
 			}
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
@@ -170,18 +170,32 @@ export class UmbRestoreFromRecycleBinModalElement extends UmbModalBaseElement<
 			${this._destinationItem && this._destinationItemName
 				? html`<uui-ref-node name=${this._destinationItemName}>
 						<uui-action-bar slot="actions">
-							<uui-button @click=${() => (this._destinationItem = undefined)} label=${this.localize.term('general_remove')}></uui-button>
+							<uui-button
+								@click=${() => (this._destinationItem = undefined)}
+								label=${this.localize.term('general_remove')}></uui-button>
 						</uui-action-bar>
 					</uui-ref-node>`
-				: html` <uui-button id="placeholder" look="placeholder" label=${this.localize.term('recycleBin_selectRestoreLocation')} @click=${this.#onSelectCustomDestination}></uui-button>`
-			}
+				: html` <uui-button
+						id="placeholder"
+						look="placeholder"
+						label=${this.localize.term('recycleBin_selectRestoreLocation')}
+						@click=${this.#onSelectCustomDestination}></uui-button>`}
 		`;
 	}
 
 	#renderActions() {
 		return html`
-			<uui-button slot="actions" id="cancel" label=${this.localize.term('general_cancel')} @click="${this._rejectModal}"></uui-button>
-			<uui-button slot="actions" color="positive" look="primary" label=${this.localize.term('general_restore')} @click=${this.#onSubmit}></uui-button>
+			<uui-button
+				slot="actions"
+				id="cancel"
+				label=${this.localize.term('general_cancel')}
+				@click="${this._rejectModal}"></uui-button>
+			<uui-button
+				slot="actions"
+				color="positive"
+				look="primary"
+				label=${this.localize.term('general_restore')}
+				@click=${this.#onSubmit}></uui-button>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
@@ -151,10 +151,10 @@ export class UmbRestoreFromRecycleBinModalElement extends UmbModalBaseElement<
 
 	override render() {
 		return html`
-			<umb-body-layout headline="Restore">
+			<umb-body-layout headline=${this.localize.term('general_restore')}>
 				<uui-box>
 					${this._isAutomaticRestore
-						? html` Restore ${this._restoreItemName} to ${this._destinationItemName}`
+						? this.localize.htmlString('#recycleBin_restoreItemTo', this._restoreItemName, this._destinationItemName)
 						: this.#renderCustomSelectDestination()}
 				</uui-box>
 				${this.#renderActions()}
@@ -164,27 +164,27 @@ export class UmbRestoreFromRecycleBinModalElement extends UmbModalBaseElement<
 
 	#renderCustomSelectDestination() {
 		return html`
-			<h4>Cannot automatically restore this item.</h4>
-			<p>There is no location where this item can be automatically restored. You can select a new location below.</p>
-			<h5>Restore to:</h5>
+			<h4><umb-localize key="recycleBin_itemCannotBeRestored"></umb-localize></h4>
+			<p><umb-localize key="recycleBin_itemCannotBeRestoredHelpText"></umb-localize></p>
+			<h5><umb-localize key="recycleBin_restoreToTitle"></umb-localize>:</h5>
 			${this._destinationItem && this._destinationItemName
 				? html`<uui-ref-node name=${this._destinationItemName}>
 						<uui-action-bar slot="actions">
-							<uui-button @click=${() => (this._destinationItem = undefined)} label="Remove"
-								>${this.localize.term('general_remove')}</uui-button
+							<uui-button @click=${() => (this._destinationItem = undefined)} label=${this.localize.term('general_remove')}
+								></uui-button
 							>
 						</uui-action-bar>
 					</uui-ref-node>`
-				: html` <uui-button id="placeholder" look="placeholder" @click=${this.#onSelectCustomDestination}
-						>Select location</uui-button
+				: html` <uui-button id="placeholder" look="placeholder" label=${this.localize.term('general_choose')} @click=${this.#onSelectCustomDestination}
+						></uui-button
 					>`}
 		`;
 	}
 
 	#renderActions() {
 		return html`
-			<uui-button slot="actions" id="cancel" label="Cancel" @click="${this._rejectModal}"></uui-button>
-			<uui-button slot="actions" color="positive" look="primary" label="Restore" @click=${this.#onSubmit}></uui-button>
+			<uui-button slot="actions" id="cancel" label=${this.localize.term('general_cancel')} @click="${this._rejectModal}"></uui-button>
+			<uui-button slot="actions" color="positive" look="primary" label=${this.localize.term('general_restore')} @click=${this.#onSubmit}></uui-button>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -622,7 +622,7 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 					look="outline"
 					color="default"
 					.disabled=${this._noAccess}></uui-button>
-				<uui-button compact popovertarget="media-picker-view-popover" label="View">
+				<uui-button compact popovertarget="media-picker-view-popover" label=${this.localize.term('general_view')}>
 					<umb-icon name=${this._currentView === 'cards' ? 'icon-grid' : 'icon-table'}></umb-icon>
 				</uui-button>
 				<uui-popover-container id="media-picker-view-popover" placement="bottom-end">

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
@@ -109,10 +109,12 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 			<uui-form>
 				<form @submit=${this.#onSubmit}>
 					<div class="input">
-						<uui-label for="label">Label</uui-label>
+						<uui-label for="label">
+							<umb-localize key="general_label"></umb-localize>
+						</uui-label>
 						<uui-input
 							@input=${this.#onLabelInput}
-							label="Label"
+							label=${this.localize.term('general_label')}
 							id="label"
 							name="label"
 							type="text"
@@ -120,9 +122,11 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 							.value=${initial?.label ?? ''}></uui-input>
 					</div>
 					<div class="input">
-						<uui-label for="alias">Alias</uui-label>
+						<uui-label for="alias">
+							<umb-localize key="general_alias"></umb-localize>
+						</uui-label>
 						<uui-input
-							label="Alias"
+							label=${this.localize.term('general_alias')}
 							id="alias"
 							name="alias"
 							type="text"
@@ -131,9 +135,11 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 							.value=${initial?.alias ?? ''}></uui-input>
 					</div>
 					<div class="input">
-						<uui-label for="width">Width</uui-label>
+						<uui-label for="width">
+							<umb-localize key="general_width"></umb-localize>
+						</uui-label>
 						<uui-input
-							label="Width"
+							label=${this.localize.term('general_width')}
 							id="width"
 							name="width"
 							type="number"
@@ -145,9 +151,11 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 						</uui-input>
 					</div>
 					<div class="input">
-						<uui-label for="height">Height</uui-label>
+						<uui-label for="height">
+							<umb-localize key="general_height"></umb-localize>
+						</uui-label>
 						<uui-input
-							label="Height"
+							label=${this.localize.term('general_height')}
 							id="height"
 							name="height"
 							type="number"
@@ -160,7 +168,7 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 					</div>
 					<div class="action-wrapper">
 						${this.editCropAlias
-							? html`<uui-button @click=${this.#onEditCancel}>Cancel</uui-button>
+							? html`<uui-button @click=${this.#onEditCancel} label=${this.localize.term('general_cancel')}></uui-button>
 									<uui-button look="secondary" type="submit" label=${this.localize.term('general_edit')}></uui-button>`
 							: html`<uui-button
 									look="secondary"


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Added
- localization for the restore from recycle bin
- localization for the image crops property editor
- Added view localization for media picker modal button view
- Corresponding Japanese translations

### How to test
1. Change to backoffice lang to Japanese
2. Create a new node
3. Trash it
4. Click on restore (Modal should now show Japanese)
---
1. Change to backoffice lang to Japanese
2. Go to media picker data type
3. Click Create under `Image Crops` (Show now display Japanese)
