### PR TITLE
Hotfix: export a Backoffice version of demandCustomElement

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/uui/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/uui/index.ts
@@ -16,6 +16,7 @@ declare global {
 }
 
 /**
+ * @deprecated
  * For v.17 we need to keep this function around for backwards compatibility with the legacy UUI 1.x custom elements.
  * TODO: To be removed in v.18.
  * Fire a warning if the custom element with the provided name isn't available.

--- a/src/Umbraco.Web.UI.Client/src/external/uui/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/uui/index.ts
@@ -17,9 +17,9 @@ declare global {
 
 /**
  * For v.17 we need to keep this function around for backwards compatibility with the legacy UUI 1.x custom elements.
- * TODO: Remove this in v.18.
+ * TODO: To be removed in v.18.
  * Fire a warning if the custom element with the provided name isn't available.
- * @func defineElement
+ * @func demandCustomElement
  * @param {HTMLElement} requester - Reference to the element requiring this custom element..
  * @param {string} elementName - Tag name of the required custom element.
  * @param {string} message - Optional message describing the consequences of it not begin available.

--- a/src/Umbraco.Web.UI.Client/src/external/uui/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/uui/index.ts
@@ -14,3 +14,27 @@ declare global {
 		disabled?: boolean;
 	}
 }
+
+/**
+ * For v.17 we need to keep this function around for backwards compatibility with the legacy UUI 1.x custom elements.
+ * TODO: Remove this in v.18.
+ * Fire a warning if the custom element with the provided name isn't available.
+ * @func defineElement
+ * @param {HTMLElement} requester - Reference to the element requiring this custom element..
+ * @param {string} elementName - Tag name of the required custom element.
+ * @param {string} message - Optional message describing the consequences of it not begin available.
+ */
+export const demandCustomElement = (
+	requester: HTMLElement,
+	elementName: string,
+	message: string = `This element has to be present for ${requester.nodeName} to work appropriate.`,
+) => {
+	if (!customElements.get(elementName)) {
+		console.warn(
+			`%c ${requester.nodeName} requires ${elementName} element to be registered!`,
+			'font-weight: bold;',
+			message,
+			requester,
+		);
+	}
+};


### PR DESCRIPTION
export demandCustomElement as part of the Backoffice impartmap: '@umbraco-cms/backoffice/external/uui';

making it posible to do this: `import { demandCustomElement } from '@umbraco-cms/backoffice/external/uui';`