### PR TITLE
Partial View: entry point 'Umb.EntryPoint.Partial View' renamed to 'Umb.EntryPoint.PartialView'

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/manifests.ts
@@ -14,7 +14,7 @@ export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> =
 	...workspaceManifests,
 	{
 		name: 'Partial View Backoffice Entry Point',
-		alias: 'Umb.EntryPoint.Partial View',
+		alias: 'Umb.EntryPoint.PartialView',
 		type: 'backofficeEntryPoint',
 		js: entryPointModule,
 	},


### PR DESCRIPTION
Breaking: rename 'Umb.EntryPoint.Partial View' to 'Umb.EntryPoint.PartialView' to align with the naming convention for Manifest Aliases