### PR TITLE
ESLint: clean up old params

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/context-api/provide/context-boundary.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/context-api/provide/context-boundary.ts
@@ -15,7 +15,6 @@ export class UmbContextBoundary {
 	 * Creates an instance of UmbContextBoundary.
 	 * @param {EventTarget} eventTarget - the host element for this context provider
 	 * @param {string | UmbContextToken} contextIdentifier - a string or token to identify the context
-	 * @param {*} instance - the instance to provide
 	 * @memberof UmbContextBoundary
 	 */
 	constructor(eventTarget: EventTarget, contextIdentifier: string | UmbContextToken<any>) {

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/utils/partial-update-frozen-array.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/utils/partial-update-frozen-array.function.ts
@@ -1,11 +1,8 @@
 /**
  * @function partialUpdateFrozenArray
- * @param {Observable<T>} source - RxJS Subject to use for this Observable.
  * @param {T} data - Initial data for this Observable.
  * @param {Partial<T>} partialEntry - New data to be added in this Observable.
  * @param {(entry: T) => boolean} findMethod - Method to find the data to be updated.
- * @param {(mappable: T) => R} mappingFunction - Method to return the part for this Observable to return.
- * @param {(previousResult: R, currentResult: R) => boolean} [memoizationFunction] - Method to Compare if the data has changed. Should return true when data is different.
  * @returns {T[]} - New data set with the updated entry.
  * @description - Creates a RxJS Observable from RxJS Subject.
  * @example <caption>Example append new entry for a ArrayState or a part of UmbDeepState/UmbObjectState it which is an array. Where the key is unique and the item will be updated if matched with existing.</caption>

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/utils/push-at-to-unique-array.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/utils/push-at-to-unique-array.function.ts
@@ -1,9 +1,9 @@
 /**
  * @function pushToUniqueArray
  * @param {T[]} data - An array of objects.
- * @param {number} index - The index to insert the entry at, if it doesn't already exist.
  * @param {T} entry - The object to insert or replace with.
  * @param {(entry: T) => unknown} [getUniqueMethod] - Method to get the unique value of an entry.
+ * @param {number} index - The index to insert the entry at, if it doesn't already exist.
  * @description - Append or replaces an item of an Array.
  * @returns {T[]} - Returns a new array with the updated entry.
  * @example <caption>Example append new entry for a Array. Where the key is unique and the item will be updated if matched with existing.</caption>

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/validation/data-path-element-data-query.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/validation/data-path-element-data-query.function.ts
@@ -3,7 +3,6 @@ import type { UmbBlockDataModel } from '../types.js';
 /**
  * Validation Data Path Query generator for Block Element Data.
  * write a JSON-Path filter similar to `?(@.key == 'my-key://1234')`
- * @param {string} key - The key of the block Element data.
  * @param {{key: string}} data - A data object with the key property.
  * @returns {string} The JSON-Path filter query.
  */

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/path-pattern.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/path-pattern.class.ts
@@ -47,7 +47,6 @@ export class UmbPathPattern<
 	/**
 	 * generate an absolute path from the path pattern
 	 * @param {LocalParamsType} params - The local pattern parameters.
-	 * @param {BaseParamsType} baseParams - The base pattern parameters.
 	 * @returns {string} The generated absolute path.
 	 */
 	generateAbsolute(params: LocalParamsType & BaseParamsType) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/date/date.timezone.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/date/date.timezone.ts
@@ -33,7 +33,6 @@ export function getTimeZoneList(filter: Array<string> | undefined = undefined): 
 
 /**
  * Retrieves the client's time zone information.
- * @param {DateTime} [selectedDate] - An optional Luxon DateTime object to format the offset of the time zone.
  * @returns {UmbTimeZone} An object containing the client's time zone name and value.
  */
 export function getClientTimeZone(): UmbTimeZone {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation-path-translation/validation-property-path-translation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation-path-translation/validation-property-path-translation.controller.ts
@@ -8,7 +8,6 @@ import type { UmbPropertyValueDataPotentiallyWithEditorAlias } from '@umbraco-cm
 export class UmbValidationPropertyPathTranslationController extends UmbControllerBase {
 	/**
 	 * translates the property data.
-	 * @param {UmbPropertyValueDataPotentiallyWithEditorAlias} property - The property data.
 	 * @param {Array<string>} paths - The paths to be translated.
 	 * @param {Array<UmbPropertyValueDataPotentiallyWithEditorAlias>} data - The property data to translate against.
 	 * @param {(entry: UmbPropertyValueDataPotentiallyWithEditorAlias) => string} queryConstructor - Builds a lookup query for a given property data entry.

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/detail/server-data-source/data-type-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/detail/server-data-source/data-type-detail.server.data-source.ts
@@ -24,7 +24,6 @@ export class UmbDataTypeServerDataSource
 
 	/**
 	 * Creates a new Data Type scaffold
-	 * @param {(string | null)} parentUnique - The unique identifier of the parent, if any.
 	 * @param {Partial<UmbDataTypeDetailModel>} preset - The preset data to populate the scaffold with.
 	 * @returns { CreateDataTypeRequestModel } The data type scaffold.
 	 * @memberof UmbDataTypeServerDataSource
@@ -117,7 +116,6 @@ export class UmbDataTypeServerDataSource
 
 	/**
 	 * Updates a DataType on the server
-	 * @param {UmbDataTypeDetailModel} DataType - The data type to update.
 	 * @param {UmbDataTypeDetailModel} model - The data type to update.
 	 * @returns {*} The updated data type.
 	 * @memberof UmbDataTypeServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/entity-action/move-to/repository/dictionary-move.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/entity-action/move-to/repository/dictionary-move.server.data-source.ts
@@ -21,8 +21,6 @@ export class UmbMoveDictionaryServerDataSource implements UmbMoveDataSource {
 
 	/**
 	 * Move an item for the given id to the target unique
-	 * @param {string} unique - The unique identifier of the item to move.
-	 * @param {(string | null)} targetUnique - The unique identifier of the target to move the item to.
 	 * @param {UmbMoveToRequestArgs} args - The arguments for the move operation.
 	 * @returns {*} Undefined if the operation succeeded, otherwise an error.
 	 * @memberof UmbMoveDictionaryServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/repository/detail/dictionary-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/repository/detail/dictionary-detail.server.data-source.ts
@@ -103,7 +103,6 @@ export class UmbDictionaryServerDataSource implements UmbDetailDataSource<UmbDic
 
 	/**
 	 * Updates a Dictionary on the server
-	 * @param {UmbDictionaryDetailModel} Dictionary - The dictionary to update.
 	 * @param {UmbDictionaryDetailModel} model - The dictionary to update.
 	 * @returns {*} The updated dictionary.
 	 * @memberof UmbDictionaryServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/entity-actions/move-to/repository/document-blueprint-move.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/entity-actions/move-to/repository/document-blueprint-move.server.data-source.ts
@@ -21,8 +21,6 @@ export class UmbMoveDocumentBlueprintServerDataSource implements UmbMoveDataSour
 
 	/**
 	 * Move an item for the given id to the target unique
-	 * @param {string} unique - The unique identifier of the item to move.
-	 * @param {(string | null)} targetUnique - The unique identifier of the target to move the item to.
 	 * @param {UmbMoveToRequestArgs} args - The arguments for the move operation.
 	 * @returns {*} Undefined if the operation succeeded, otherwise an error.
 	 * @memberof UmbMoveDocumentBlueprintServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/repository/detail/document-blueprint-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/repository/detail/document-blueprint-detail.server.data-source.ts
@@ -146,7 +146,6 @@ export class UmbDocumentBlueprintServerDataSource implements UmbDetailDataSource
 
 	/**
 	 * Updates a Document on the server
-	 * @param {UmbDocumentBlueprintDetailModel} Document - The document blueprint to update.
 	 * @param {UmbDocumentBlueprintDetailModel} model - The document blueprint to update.
 	 * @returns {*} The updated document blueprint.
 	 * @memberof UmbDocumentBlueprintServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/entity-actions/move-to/repository/document-type-move.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/entity-actions/move-to/repository/document-type-move.server.data-source.ts
@@ -21,8 +21,6 @@ export class UmbMoveDocumentTypeServerDataSource implements UmbMoveDataSource {
 
 	/**
 	 * Move an item for the given id to the target unique
-	 * @param {string} unique - The unique identifier of the item to move.
-	 * @param {(string | null)} targetUnique - The unique identifier of the target to move the item to.
 	 * @param {UmbMoveToRequestArgs} args - The arguments for the move operation.
 	 * @returns {*} Undefined if the operation succeeded, otherwise an error.
 	 * @memberof UmbMoveDocumentTypeServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/composition/document-type-composition.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/composition/document-type-composition.server.data-source.ts
@@ -54,7 +54,6 @@ export class UmbDocumentTypeCompositionServerDataSource implements UmbContentTyp
 	}
 	/**
 	 * Updates the compositions for a document type on the server
-	 * @param {DocumentTypeCompositionRequestModel} body - The composition request body.
 	 * @param {UmbDocumentTypeAvailableCompositionRequestModel} args - The arguments to determine the available compositions.
 	 * @returns {*} The compatible compositions for the document type.
 	 * @memberof UmbDocumentTypeCompositionServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/server-data-source/document-type-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/server-data-source/document-type-detail.server.data-source.ts
@@ -24,7 +24,6 @@ export class UmbDocumentTypeDetailServerDataSource
 
 	/**
 	 * Creates a new Document Type scaffold
-	 * @param {(string | null)} parentUnique - The unique identifier of the parent document type.
 	 * @param {Partial<UmbDocumentTypeDetailModel>} preset - The preset data to populate the scaffold with.
 	 * @returns { CreateDocumentTypeRequestModel } The document type scaffold.
 	 * @memberof UmbDocumentTypeServerDataSource
@@ -156,7 +155,6 @@ export class UmbDocumentTypeDetailServerDataSource
 
 	/**
 	 * Updates a DocumentType on the server
-	 * @param {UmbDocumentTypeDetailModel} DocumentType - The document type to update.
 	 * @param {UmbDocumentTypeDetailModel} model - The document type to update.
 	 * @returns {*} The updated document type.
 	 * @memberof UmbDocumentTypeServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create-blueprint/repository/document-create-blueprint.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create-blueprint/repository/document-create-blueprint.server.data-source.ts
@@ -22,7 +22,6 @@ export class UmbDocumentCreateBlueprintServerDataSource {
 
 	/**
 	 * Fetches the Culture and Hostnames for the given Document unique
-	 * @param {string} unique - The unique identifier of the Document
 	 * @param {CreateDocumentBlueprintFromDocumentRequestModel} body - The blueprint request body
 	 * @memberof UmbDocumentCreateBlueprintServerDataSource
 	 */

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/move-to/repository/document-move.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/move-to/repository/document-move.server.data-source.ts
@@ -21,8 +21,6 @@ export class UmbMoveDocumentServerDataSource implements UmbMoveDataSource {
 
 	/**
 	 * Move an item for the given id to the target unique
-	 * @param {string} unique - The unique identifier of the item to move
-	 * @param {(string | null)} targetUnique - The unique identifier of the target destination
 	 * @param {UmbMoveToRequestArgs} args - The move request arguments
 	 * @returns {*} The result of the move request
 	 * @memberof UmbMoveDocumentServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.repository.ts
@@ -40,8 +40,6 @@ export class UmbDocumentPublishingRepository extends UmbRepositoryBase {
 
 	/**
 	 * Publish one or more variants of a Document
-	 * @param {string} id - The unique of the Document
-	 * @param {Array<UmbVariantId>} variantIds - The variants to publish
 	 * @param {string} unique - The unique of the Document
 	 * @param {Array<UmbDocumentVariantPublishModel>} variants - The variants to publish
 	 * @returns {*} The result of the publish request

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.server.data-source.ts
@@ -99,7 +99,6 @@ export class UmbDocumentPublishingServerDataSource {
 	/**
 	 * Publish one or more variants of a Document
 	 * @param {string} unique - The unique of the Document
-	 * @param {Array<UmbVariantId>} variantIds - The variants to publish
 	 * @param {Array<UmbDocumentVariantPublishModel>} variants - The variants to publish
 	 * @returns {*} The result of the publish request
 	 * @memberof UmbDocumentPublishingServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/entity-actions/move-to/repository/media-type-move.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/entity-actions/move-to/repository/media-type-move.server.data-source.ts
@@ -21,8 +21,6 @@ export class UmbMoveMediaTypeServerDataSource implements UmbMoveDataSource {
 
 	/**
 	 * Move an item for the given id to the target unique
-	 * @param {string} unique - The unique ID of the media type to move
-	 * @param {(string | null)} targetUnique - The unique ID of the destination
 	 * @param {UmbMoveToRequestArgs} args - The move request arguments
 	 * @returns {*} A promise that resolves once the media type has been moved
 	 * @memberof UmbMoveMediaTypeServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/composition/media-type-composition.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/composition/media-type-composition.server.data-source.ts
@@ -51,7 +51,6 @@ export class UmbMediaTypeCompositionServerDataSource implements UmbContentTypeCo
 	}
 	/**
 	 * Updates the compositions for a media type on the server
-	 * @param {MediaTypeCompositionRequestModel} body - The request body
 	 * @param {UmbMediaTypeAvailableCompositionRequestModel} args - The composition request arguments
 	 * @returns {*} The available compositions
 	 * @memberof UmbMediaTypeCompositionServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/detail/media-type-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/detail/media-type-detail.server.data-source.ts
@@ -145,7 +145,6 @@ export class UmbMediaTypeDetailServerDataSource
 
 	/**
 	 * Updates a MediaType on the server
-	 * @param {UmbMediaTypeDetailModel} MediaType - The media type to update
 	 * @param {UmbMediaTypeDetailModel} model - The media type to update
 	 * @returns {*} The updated media type
 	 * @memberof UmbMediaTypeDetailServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/move-to/repository/media-move.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/move-to/repository/media-move.server.data-source.ts
@@ -21,8 +21,6 @@ export class UmbMoveMediaServerDataSource implements UmbMoveDataSource {
 
 	/**
 	 * Move an item for the given id to the target unique
-	 * @param {string} unique - The unique ID of the media to move
-	 * @param {(string | null)} targetUnique - The unique ID of the destination
 	 * @param {UmbMoveToRequestArgs} args - The move request arguments
 	 * @returns {*} A promise that resolves once the media has been moved
 	 * @memberof UmbMoveMediaServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
@@ -145,7 +145,6 @@ export class UmbMediaServerDataSource extends UmbControllerBase implements UmbDe
 
 	/**
 	 * Updates a Media on the server
-	 * @param {UmbMediaDetailModel} Media - The media to update
 	 * @param {UmbMediaDetailModel} model - The media to update
 	 * @returns {*} The updated media
 	 * @memberof UmbMediaServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/collection/repository/member-group-collection.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/collection/repository/member-group-collection.server.data-source.ts
@@ -25,7 +25,7 @@ export class UmbMemberGroupCollectionServerDataSource implements UmbCollectionDa
 
 	/**
 	 * Gets the member group collection filtered by the given filter.
-	 * @param {UmbMemberGroupCollectionFilterModel} filter The filter to apply to the collection.
+	 * @param {UmbMemberGroupCollectionFilterModel} query The filter to apply to the collection.
 	 * @returns {*} The member group collection.
 	 * @memberof UmbMemberGroupCollectionServerDataSource
 	 */

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/repository/detail/member-group-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/repository/detail/member-group-detail.server.data-source.ts
@@ -26,7 +26,6 @@ export class UmbMemberGroupServerDataSource implements UmbDetailDataSource<UmbMe
 
 	/**
 	 * Creates a new Member Group scaffold
-	 * @param {(string | null)} parentUnique - The unique identifier of the parent, if any.
 	 * @returns { CreateMemberGroupRequestModel } The scaffolded Member Group.
 	 * @memberof UmbMemberGroupServerDataSource
 	 */

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/detail/member-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/detail/member-detail.server.data-source.ts
@@ -170,7 +170,6 @@ export class UmbMemberServerDataSource extends UmbControllerBase implements UmbD
 
 	/**
 	 * Updates a Member on the server
-	 * @param {UmbMemberDetailModel} Member - The member to update.
 	 * @param {UmbMemberDetailModel} model - The member to update.
 	 * @returns {*} The updated member.
 	 * @memberof UmbMemberServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/repository/tag.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/repository/tag.store.ts
@@ -35,7 +35,6 @@ export class UmbTagStore extends UmbStoreBase {
 
 	/**
 	 * Append a tag to the store
-	 * @param {id} TagResponseModel id.
 	 * @param {TagResponseModel['id']} id - The unique identifier of the tag to fetch.
 	 * @returns {*} The tag observable part.
 	 * @memberof UmbTagStore

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user.repository.ts
@@ -93,7 +93,6 @@ export class UmbCurrentUserRepository extends UmbRepositoryBase {
 
 	/**
 	 * Enable an MFA provider
-	 * @param {string} provider The provider to enable
 	 * @param {string} providerName The name of the provider to enable
 	 * @param {string} code The activation code of the provider to enable
 	 * @param {string} secret The secret used to verify the provider's activation code
@@ -114,7 +113,6 @@ export class UmbCurrentUserRepository extends UmbRepositoryBase {
 
 	/**
 	 * Disable an MFA provider
-	 * @param {string} provider The provider to disable
 	 * @param {string} providerName The name of the provider to disable
 	 * @param {string} code The activation code of the provider to disable
 	 * @returns {*} An error if the provider could not be disabled
@@ -133,10 +131,8 @@ export class UmbCurrentUserRepository extends UmbRepositoryBase {
 	}
 	/**
 	 * Change password for current user
-	 * @param {string} userId The id of the user to change the password for
 	 * @param {string} newPassword The new password
 	 * @param {string} oldPassword The old password
-	 * @param {boolean} isCurrentUser Whether the change is for the current user
 	 * @returns {*} The result of the change password request
 	 */
 	async changePassword(newPassword: string, oldPassword: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user.server.data-source.ts
@@ -135,10 +135,8 @@ export class UmbCurrentUserServerDataSource extends UmbControllerBase {
 
 	/**
 	 * Change the password for current user
-	 * @param {string} id The id of the user to change the password for
 	 * @param {string} newPassword The new password
 	 * @param {string} oldPassword The old password
-	 * @param {boolean} isCurrentUser Whether the change is for the current user
 	 * @returns {*} The result of the change password request
 	 */
 	async changePassword(newPassword: string, oldPassword: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/repository/detail/user-group-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/repository/detail/user-group-detail.server.data-source.ts
@@ -23,7 +23,6 @@ export class UmbUserGroupServerDataSource
 
 	/**
 	 * Creates a new User Group scaffold
-	 * @param {(string | null)} parentUnique - The unique id of the parent User Group.
 	 * @returns {CreateUserGroupRequestModel} The User Group scaffold.
 	 * @memberof UmbUserGroupServerDataSource
 	 */
@@ -157,7 +156,6 @@ export class UmbUserGroupServerDataSource
 
 	/**
 	 * Updates a UserGroup on the server
-	 * @param {UmbUserGroupDetailModel} UserGroup - The User Group to update.
 	 * @param {UmbUserGroupDetailModel} model - The User Group to update.
 	 * @returns {*} The updated User Group.
 	 * @memberof UmbUserGroupServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/invite/repository/invite-user.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/invite/repository/invite-user.repository.ts
@@ -35,7 +35,6 @@ export class UmbInviteUserRepository extends UmbUserRepositoryBase {
 
 	/**
 	 * Resend an invite to a user
-	 * @param {string} userUnique - The unique id of the user to resend the invite to.
 	 * @param {InviteUserRequestModel} request - The resend invite request data.
 	 * @returns {*} The result of the resend invite operation.
 	 * @memberof UmbInviteUserRepository

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/detail/user-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/detail/user-detail.server.data-source.ts
@@ -32,7 +32,6 @@ export class UmbUserServerDataSource implements UmbDetailDataSource<UmbUserDetai
 
 	/**
 	 * Creates a new User scaffold
-	 * @param {(string | null)} parentUnique - The unique id of the parent
 	 * @returns { CreateUserRequestModel } The scaffolded user
 	 * @memberof UmbUserServerDataSource
 	 */
@@ -178,7 +177,6 @@ export class UmbUserServerDataSource implements UmbDetailDataSource<UmbUserDetai
 
 	/**
 	 * Updates a User on the server
-	 * @param {UmbUserDetailModel} User - The user to update
 	 * @param {UmbUserDetailModel} model - The user model to update
 	 * @returns {*} The updated user
 	 * @memberof UmbUserServerDataSource

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/sources/user-set-group.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/sources/user-set-group.server.data-source.ts
@@ -20,7 +20,6 @@ export class UmbUserSetGroupsServerDataSource {
 
 	/**
 	 * Set groups for users
-	 * @param {Array<string>} id - The ids of the users to set groups for
 	 * @param {Array<string>} userIds - The ids of the users to set groups for
 	 * @param {Array<string>} userGroupIds - The ids of the groups to set for the users
 	 * @returns {*} The result of setting the groups


### PR DESCRIPTION
An auto cleanup of old/not-existing params, properly originating from bad git-merges.