### PR TITLE
Pagination: 100% wide

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/audit-log/info-app/content-audit-log-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/audit-log/info-app/content-audit-log-workspace-info-app.element.ts
@@ -227,9 +227,6 @@ export class UmbContentAuditLogWorkspaceInfoAppElement extends UmbLitElement {
 			}
 
 			uui-pagination {
-				flex: 1;
-				display: flex;
-				justify-content: center;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/components/pagination/collection-pagination.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/components/pagination/collection-pagination.element.ts
@@ -98,7 +98,6 @@ export class UmbCollectionPaginationElement extends UmbLitElement {
 			}
 
 			uui-pagination {
-				display: block;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/picker-search-result.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/picker-search-result.element.ts
@@ -172,7 +172,6 @@ export class UmbPickerSearchResultElement extends UmbLitElement {
 			}
 
 			uui-pagination {
-				display: block;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/components/tree-pagination.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/components/tree-pagination.element.ts
@@ -57,7 +57,6 @@ export class UmbTreePaginationElement extends UmbLitElement {
 			}
 
 			uui-pagination {
-				display: block;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/components/tree-pagination.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/components/tree-pagination.element.ts
@@ -57,6 +57,7 @@ export class UmbTreePaginationElement extends UmbLitElement {
 			}
 
 			uui-pagination {
+				display: block;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -319,10 +319,6 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 				}
 			}
 
-			uui-pagination {
-				display: inline-block;
-			}
-
 			.pagination {
 				display: flex;
 				justify-content: center;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/audit-log/info-app/document-history-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/audit-log/info-app/document-history-workspace-info-app.element.ts
@@ -199,9 +199,6 @@ export class UmbDocumentHistoryWorkspaceInfoAppElement extends UmbLitElement {
 			}
 
 			uui-pagination {
-				flex: 1;
-				display: flex;
-				justify-content: center;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-messages-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-messages-list.element.ts
@@ -148,7 +148,6 @@ export class UmbLogViewerMessagesListElement extends UmbLitElement {
 	static override styles = [
 		css`
 			uui-pagination {
-				display: block;
 				margin-bottom: var(--uui-size-layout-1);
 			}
 			uui-box {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/audit-log/info-app/media-history-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/audit-log/info-app/media-history-workspace-info-app.element.ts
@@ -183,9 +183,6 @@ export class UmbMediaHistoryWorkspaceInfoAppElement extends UmbLitElement {
 			}
 
 			uui-pagination {
-				flex: 1;
-				display: flex;
-				justify-content: center;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -811,7 +811,6 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 			}
 
 			uui-pagination {
-				display: block;
 				margin-top: var(--uui-size-layout-1);
 			}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/components/member-group-picker-modal/member-group-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/components/member-group-picker-modal/member-group-picker-modal.element.ts
@@ -119,7 +119,6 @@ export class UmbMemberGroupPickerModalElement extends UmbModalBaseElement<
 	static override styles = [
 		css`
 			uui-pagination {
-				display: block;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/created/packages-created-overview.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/created/packages-created-overview.element.ts
@@ -147,9 +147,6 @@ export class UmbPackagesCreatedOverviewElement extends UmbLitElement {
 				display: flex;
 				justify-content: space-around;
 			}
-			uui-pagination {
-				display: inline-block;
-			}
 
 			.container {
 				display: flex;

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/workspace/relation-type/views/relation-type-detail-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/workspace/relation-type/views/relation-type-detail-workspace-view.element.ts
@@ -229,7 +229,6 @@ export class UmbRelationTypeDetailWorkspaceViewElement extends UmbLitElement imp
 
 			uui-pagination {
 				margin-top: var(--uui-size-layout-1);
-				display: block;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relations/reference/workspace-info-app/entity-references-workspace-view-info.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relations/reference/workspace-info-app/entity-references-workspace-view-info.element.ts
@@ -167,11 +167,6 @@ export class UmbEntityReferencesWorkspaceInfoAppElement extends UmbLitElement {
 				justify-content: center;
 				margin-top: var(--uui-size-space-4);
 			}
-
-			uui-pagination {
-				flex: 1;
-				display: inline-block;
-			}
 		`,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
@@ -116,8 +116,6 @@ export class UmbCurrentUserHistoryUserProfileAppElement extends UmbLitElement {
 			}
 
 			uui-pagination {
-				display: flex;
-				justify-content: center;
 				margin-top: var(--uui-size-layout-1);
 			}
 		`,


### PR DESCRIPTION
Fixes the change from UUI v.1 to v.2 where the pagination component handles its display property on its own.


**Test Notes:**
Review the various places a Pagination component is used, for example, in a collection in Documents.

Screenshots below show Pagination because page size has been set to 10.

Before: 
<img width="1964" height="689" alt="image" src="https://github.com/user-attachments/assets/485543c6-2db1-4790-8cd7-01d3b2ce3d19" />

After:
<img width="1951" height="913" alt="image" src="https://github.com/user-attachments/assets/3bd9cad6-b9ca-4f32-97be-5c13a81adda9" />
