### PR TITLE
Package Manifests: Hash the host cache-buster into a short hash as documented (closes #23641)

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/UmbracoPluginSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UmbracoPluginSettings.cs
@@ -13,8 +13,9 @@ public class UmbracoPluginSettings
 {
     /// <summary>
     ///     Gets or sets an optional host-controlled cache-buster for package <c>/App_Plugins</c> assets. When set (e.g.
-    ///     to a build number or deployment id), it is appended as <c>umb__rnd</c> to every package's assets — importmap
-    ///     and extensions — forcing a re-fetch regardless of each package's own <c>version</c>. Empty by default (no effect).
+    ///     to a build number or deployment id), a short hash of it is appended as <c>umb__rnd</c> to every package's
+    ///     assets — importmap and extensions — forcing a re-fetch regardless of each package's own <c>version</c>. Only
+    ///     the hash is exposed in the asset URLs, never the configured value itself. Empty by default (no effect).
     /// </summary>
     [DefaultValue("")]
     public string Cachebuster { get; set; } = string.Empty;

--- a/src/Umbraco.Core/Configuration/Models/UmbracoPluginSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UmbracoPluginSettings.cs
@@ -13,9 +13,10 @@ public class UmbracoPluginSettings
 {
     /// <summary>
     ///     Gets or sets an optional host-controlled cache-buster for package <c>/App_Plugins</c> assets. When set (e.g.
-    ///     to a build number or deployment id), a short hash of it is appended as <c>umb__rnd</c> to every package's
-    ///     assets — importmap and extensions — forcing a re-fetch regardless of each package's own <c>version</c>. Only
-    ///     the hash is exposed in the asset URLs, never the configured value itself. Empty by default (no effect).
+    ///     to a build number or deployment id), a short hash of it forms the host part of each package's cache-bust
+    ///     value — <c>&lt;version&gt;-&lt;hash&gt;</c>, appended as <c>umb__rnd</c> to importmap and extension assets —
+    ///     so changing it forces a re-fetch even when the package's own <c>version</c> is unchanged. Only the hash
+    ///     reaches the asset URLs, never the configured value itself. Empty by default (no effect).
     /// </summary>
     [DefaultValue("")]
     public string Cachebuster { get; set; } = string.Empty;

--- a/src/Umbraco.Core/Manifest/PackageManifestCacheBuster.cs
+++ b/src/Umbraco.Core/Manifest/PackageManifestCacheBuster.cs
@@ -9,6 +9,8 @@ namespace Umbraco.Cms.Core.Manifest;
 /// </summary>
 public static class PackageManifestCacheBuster
 {
+    private const int ShortHashLength = 7;
+
     // The /App_Plugins root with a trailing slash, so the StartsWith check honours a path-segment boundary
     // (and never matches e.g. "/App_PluginsFoo/...").
     private static readonly string _appPluginsPrefix = Constants.SystemDirectories.AppPlugins.EnsureEndsWith('/');
@@ -19,14 +21,22 @@ public static class PackageManifestCacheBuster
     ///     version alone when no host cache-buster is set, to the short hash alone when the package has no version, and
     ///     to <c>null</c> when there is nothing to bust.
     /// </summary>
+    /// <remarks>
+    ///     Hashing keeps the value's length and character set predictable, and keeps host deployment identifiers out of
+    ///     the publicly served asset URLs (see https://github.com/umbraco/Umbraco-CMS/issues/23641).
+    /// </remarks>
     public static string? ComputeCacheBuster(string? version, string? cacheBuster)
-        => (version.NullOrWhiteSpaceAsNull(), cacheBuster.NullOrWhiteSpaceAsNull()) switch
+    {
+        var hostHash = cacheBuster.NullOrWhiteSpaceAsNull() is { } hostCacheBuster ? ShortHash(hostCacheBuster) : null;
+
+        return (version.NullOrWhiteSpaceAsNull(), hostHash) switch
         {
-            (not null, not null) => $"{version}-{cacheBuster}",
+            (not null, not null) => $"{version}-{hostHash}",
             (not null, null) => version,
-            (null, not null) => cacheBuster,
+            (null, not null) => hostHash,
             _ => null,
         };
+    }
 
     /// <summary>
     ///     Appends <c>?umb__rnd=&lt;cacheBuster&gt;</c> to a clean <c>/App_Plugins</c> URL. URLs outside
@@ -51,4 +61,6 @@ public static class PackageManifestCacheBuster
             ? $"{url}?{query}"
             : $"{url[..fragmentIndex]}?{query}{url[fragmentIndex..]}";
     }
+
+    private static string ShortHash(string value) => value.GenerateHash()[..ShortHashLength];
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/PackageManifestCacheBusterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Manifest/PackageManifestCacheBusterTests.cs
@@ -10,8 +10,23 @@ public class PackageManifestCacheBusterTests
     public void ComputeCacheBuster_CombinesVersionWithShortHostHash()
     {
         var result = PackageManifestCacheBuster.ComputeCacheBuster("1.2.3", "deploy-1");
-        Assert.That(result, Is.EqualTo("1.2.3-deploy-1"));
+        Assert.That(result, Is.EqualTo("1.2.3-7bb8e1f"));
     }
+
+    [Test]
+    public void ComputeCacheBuster_HashesAwayCharactersNeedingEscaping()
+    {
+        // The host cache-buster is often an informational version, which the .NET SDK stamps with the commit
+        // sha after a '+'. Hashing keeps it out of the (publicly served) asset URLs (#23641).
+        var result = PackageManifestCacheBuster.ComputeCacheBuster("17.0.0", "1.0.0+abc123");
+        Assert.That(result, Is.EqualTo("17.0.0-d7adb85"));
+    }
+
+    [Test]
+    public void ComputeCacheBuster_ProducesDifferentHashes_ForDifferentHostCacheBusters()
+        => Assert.That(
+            PackageManifestCacheBuster.ComputeCacheBuster("1.2.3", "deploy-1"),
+            Is.Not.EqualTo(PackageManifestCacheBuster.ComputeCacheBuster("1.2.3", "deploy-2")));
 
     [TestCase(null)]
     [TestCase("")]
@@ -21,7 +36,7 @@ public class PackageManifestCacheBusterTests
 
     [Test]
     public void ComputeCacheBuster_UsesShortHashAlone_WhenNoVersion()
-        => Assert.That(PackageManifestCacheBuster.ComputeCacheBuster(null, "deploy-1"), Is.EqualTo("deploy-1"));
+        => Assert.That(PackageManifestCacheBuster.ComputeCacheBuster(null, "deploy-1"), Is.EqualTo("7bb8e1f"));
 
     [Test]
     public void ComputeCacheBuster_ReturnsNull_WhenNoVersionAndNoHostCacheBuster()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Manifest/PackageManifestServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Manifest/PackageManifestServiceTests.cs
@@ -141,7 +141,7 @@ public class PackageManifestServiceTests
 
         var result = await service.GetPackageManifestImportmapAsync();
 
-        Assert.That(result.Imports["pkg"], Is.EqualTo($"/App_Plugins/Pkg/index.js?umb__rnd=2.0.0-deploy-1"));
+        Assert.That(result.Imports["pkg"], Is.EqualTo("/App_Plugins/Pkg/index.js?umb__rnd=2.0.0-7bb8e1f"));
     }
 
     [Test]
@@ -153,6 +153,6 @@ public class PackageManifestServiceTests
 
         var result = await service.GetPackageManifestImportmapAsync();
 
-        Assert.That(result.Imports["pkg"], Is.EqualTo($"/App_Plugins/Pkg/index.js?umb__rnd=deploy-1"));
+        Assert.That(result.Imports["pkg"], Is.EqualTo("/App_Plugins/Pkg/index.js?umb__rnd=7bb8e1f"));
     }
 }


### PR DESCRIPTION
## Description

`Umbraco:CMS:Plugins:Cachebuster` (new in 17.6, #23094) is described as being hashed and shortened to seven characters — in the XML doc on `PackageManifestCacheBuster.ComputeCacheBuster`, in [the documentation](https://docs.umbraco.com/umbraco-cms/17.latest/develop-with-umbraco/configuration/pluginssettings#cachebuster), in the #23094 PR description, and even in the name of the unit test `ComputeCacheBuster_CombinesVersionWithShortHostHash`. The implementation did no hashing at all — it concatenated the configured value verbatim.

The documented behaviour is the correct one, so this fixes the code rather than the docs.

Fixes #23641

```
Cachebuster = "1.0.0+abc123", package version = "1.4.2"

before:  ?umb__rnd=1.4.2-1.0.0%2Babc123
after:   ?umb__rnd=1.4.2-d7adb85
```

Hashing uses the repo's existing `string.GenerateHash()` helper, which is what `UrlHelperExtensions.GetCacheBustHash` already uses for the backoffice cache-bust hash, so the two cache-busting mechanisms stay consistent.

Only the host cache-buster is hashed; the package's own `version` stays verbatim, per the documented `<version>-<hash>` format. The version is already public on the manifest response, so it is not an information leak, and keeping it readable makes an asset URL traceable to a package build.

## Testing

### Automated

Updated the existing `ComputeCacheBuster` unit tests (confirmed failing before the fix) and added cases for the reported `+` value and for hash distinctness.

### Manual

Set `Umbraco:CMS:Plugins:Cachebuster` to `1.0.0+abc123` and compared the `<script type="importmap">` block in the backoffice page source on `v17/dev` and on this branch. This needs a local `App_Plugins` package that declares an `importmap`.

With a package at version `1.4.2`:

| import | `v17/dev` | this branch |
|---|---|---|
| clean `/App_Plugins` path | `…/index.js?umb__rnd=1.4.2-1.0.0%2Babc123` | `…/index.js?umb__rnd=1.4.2-d7adb85` |
| `/App_Plugins` path with an existing query | `…/index.js?v=1` | unchanged |
| external CDN url | `https://cdn.example.com/not-a-plugin.js` | unchanged |

`d7adb85` is the first seven characters of the SHA1 of `1.0.0+abc123`, so the value matches the documented algorithm rather than merely being internally consistent. The lower two rows confirm the existing-query and non-`/App_Plugins` guards in `ApplyCacheBust` still short-circuit as before.

<details>
<summary>Setting up an <code>App_Plugins</code> package to reproduce this</summary>

Create `src/Umbraco.Web.UI/App_Plugins/cachebust-test/umbraco-package.json`:

```json
{
  "name": "Cachebust Test (local dev only)",
  "version": "1.4.2",
  "extensions": [],
  "importmap": {
    "imports": {
      "cachebust-test/stamped": "/App_Plugins/cachebust-test/index.js",
      "cachebust-test/already-queried": "/App_Plugins/cachebust-test/index.js?v=1",
      "cachebust-test/external": "https://cdn.example.com/not-a-plugin.js"
    }
  }
}
```

Add an `index.js` next to it (`export const extensions = [];`) so the stamped URL resolves, then set the host cache-buster in `appsettings.Development.json`:

```json
"Umbraco": { "CMS": { "Plugins": { "Cachebuster": "1.0.0+abc123" } } }
```

</details>