### PR TITLE
Profiling: Read debug mode from the server rather than hardcoding it (closes #23609)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/Server/ServerConfigurationMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Server/ServerConfigurationMapDefinition.cs
@@ -35,5 +35,6 @@ public class ServerConfigurationMapDefinition : IMapDefinition
         target.Version = source.SemVersion.ToSemanticString();
         target.AssemblyVersion = source.SemVersion.ToSemanticStringWithoutBuild();
         target.BaseUtcOffset = source.TimeZoneInfo.BaseUtcOffset.ToString();
+        target.IsDebugMode = source.IsDebugMode;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -51042,6 +51042,7 @@
         "required": [
           "assemblyVersion",
           "baseUtcOffset",
+          "isDebugMode",
           "runtimeMode",
           "version"
         ],
@@ -51058,6 +51059,9 @@
           },
           "runtimeMode": {
             "$ref": "#/components/schemas/RuntimeModeModel"
+          },
+          "isDebugMode": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Server/ServerInformationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Server/ServerInformationResponseModel.cs
@@ -11,16 +11,24 @@ public class ServerInformationResponseModel
     /// Gets or sets the version string of the Umbraco server instance.
     /// </summary>
     public string Version { get; set; } = string.Empty;
+
     /// <summary>
     /// Gets or sets the version of the server's assembly.
     /// </summary>
     public string AssemblyVersion { get; set; } = string.Empty;
+
     /// <summary>
     /// Gets or sets the base UTC offset of the server.
     /// </summary>
     public string BaseUtcOffset { get; set; } = string.Empty;
+
     /// <summary>
     /// Gets or sets the current runtime mode of the Umbraco server.
     /// </summary>
     public RuntimeMode RuntimeMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Umbraco server is running in debug mode.
+    /// </summary>
+    public bool IsDebugMode { get; set; }
 }

--- a/src/Umbraco.Core/Models/ServerInformation.cs
+++ b/src/Umbraco.Core/Models/ServerInformation.cs
@@ -6,23 +6,52 @@ namespace Umbraco.Cms.Core.Models;
 /// <summary>
 /// Represents information about the Umbraco server instance.
 /// </summary>
-/// <param name="semVersion">The semantic version of the Umbraco installation.</param>
-/// <param name="timeZoneInfo">The time zone information for the server.</param>
-/// <param name="runtimeMode">The current runtime mode of the server.</param>
-public class ServerInformation(SemVersion semVersion, TimeZoneInfo timeZoneInfo, RuntimeMode runtimeMode)
+public class ServerInformation
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerInformation"/> class.
+    /// </summary>
+    /// <param name="semVersion">The semantic version of the Umbraco installation.</param>
+    /// <param name="timeZoneInfo">The time zone information for the server.</param>
+    /// <param name="runtimeMode">The current runtime mode of the server.</param>
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
+    public ServerInformation(SemVersion semVersion, TimeZoneInfo timeZoneInfo, RuntimeMode runtimeMode)
+        : this(semVersion, timeZoneInfo, runtimeMode, isDebugMode: false)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerInformation"/> class.
+    /// </summary>
+    /// <param name="semVersion">The semantic version of the Umbraco installation.</param>
+    /// <param name="timeZoneInfo">The time zone information for the server.</param>
+    /// <param name="runtimeMode">The current runtime mode of the server.</param>
+    /// <param name="isDebugMode">A value indicating whether the server is running in debug mode.</param>
+    public ServerInformation(SemVersion semVersion, TimeZoneInfo timeZoneInfo, RuntimeMode runtimeMode, bool isDebugMode)
+    {
+        SemVersion = semVersion;
+        TimeZoneInfo = timeZoneInfo;
+        RuntimeMode = runtimeMode;
+        IsDebugMode = isDebugMode;
+    }
+
     /// <summary>
     /// Gets the semantic version of the Umbraco installation.
     /// </summary>
-    public SemVersion SemVersion { get; } = semVersion;
+    public SemVersion SemVersion { get; }
 
     /// <summary>
     /// Gets the time zone information for the server.
     /// </summary>
-    public TimeZoneInfo TimeZoneInfo { get; } = timeZoneInfo;
+    public TimeZoneInfo TimeZoneInfo { get; }
 
     /// <summary>
     /// Gets the current runtime mode of the server.
     /// </summary>
-    public RuntimeMode RuntimeMode { get; } = runtimeMode;
+    public RuntimeMode RuntimeMode { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the server is running in debug mode.
+    /// </summary>
+    public bool IsDebugMode { get; }
 }

--- a/src/Umbraco.Core/Services/IServerInformationService.cs
+++ b/src/Umbraco.Core/Services/IServerInformationService.cs
@@ -1,6 +1,3 @@
-using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core.Configuration;
-using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services;
@@ -15,31 +12,4 @@ public interface IServerInformationService
     /// </summary>
     /// <returns>A <see cref="ServerInformation"/> object containing the server details.</returns>
     ServerInformation GetServerInformation();
-}
-
-/// <summary>
-///     Default implementation of <see cref="IServerInformationService"/>.
-/// </summary>
-public class ServerInformationService : IServerInformationService
-{
-    private readonly IUmbracoVersion _umbracoVersion;
-    private readonly TimeProvider _timeProvider;
-    private RuntimeSettings _runtimeSettings;
-
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="ServerInformationService"/> class.
-    /// </summary>
-    /// <param name="umbracoVersion">The Umbraco version provider.</param>
-    /// <param name="timeProvider">The time provider for timezone information.</param>
-    /// <param name="runtimeSettingsOptionsMonitor">The runtime settings monitor.</param>
-    public ServerInformationService(IUmbracoVersion umbracoVersion, TimeProvider timeProvider, IOptionsMonitor<RuntimeSettings> runtimeSettingsOptionsMonitor)
-    {
-        _umbracoVersion = umbracoVersion;
-        _timeProvider = timeProvider;
-        _runtimeSettings = runtimeSettingsOptionsMonitor.CurrentValue;
-        runtimeSettingsOptionsMonitor.OnChange(runtimeSettings => _runtimeSettings = runtimeSettings);
-    }
-
-    /// <inheritdoc />
-    public ServerInformation GetServerInformation() => new(_umbracoVersion.SemanticVersion, _timeProvider.LocalTimeZone, _runtimeSettings.Mode);
 }

--- a/src/Umbraco.Core/Services/ServerInformationService.cs
+++ b/src/Umbraco.Core/Services/ServerInformationService.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services;
+
+/// <summary>
+///     Default implementation of <see cref="IServerInformationService"/>.
+/// </summary>
+public class ServerInformationService : IServerInformationService
+{
+    private readonly IUmbracoVersion _umbracoVersion;
+    private readonly TimeProvider _timeProvider;
+    private readonly IHostingEnvironment _hostingEnvironment;
+    private RuntimeSettings _runtimeSettings;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ServerInformationService"/> class.
+    /// </summary>
+    /// <param name="umbracoVersion">The Umbraco version provider.</param>
+    /// <param name="timeProvider">The time provider for timezone information.</param>
+    /// <param name="runtimeSettingsOptionsMonitor">The runtime settings monitor.</param>
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
+    public ServerInformationService(IUmbracoVersion umbracoVersion, TimeProvider timeProvider, IOptionsMonitor<RuntimeSettings> runtimeSettingsOptionsMonitor)
+        : this(
+            umbracoVersion,
+            timeProvider,
+            runtimeSettingsOptionsMonitor,
+            StaticServiceProvider.Instance.GetRequiredService<IHostingEnvironment>())
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ServerInformationService"/> class.
+    /// </summary>
+    /// <param name="umbracoVersion">The Umbraco version provider.</param>
+    /// <param name="timeProvider">The time provider for timezone information.</param>
+    /// <param name="runtimeSettingsOptionsMonitor">The runtime settings monitor.</param>
+    /// <param name="hostingEnvironment">The hosting environment.</param>
+    public ServerInformationService(
+        IUmbracoVersion umbracoVersion,
+        TimeProvider timeProvider,
+        IOptionsMonitor<RuntimeSettings> runtimeSettingsOptionsMonitor,
+        IHostingEnvironment hostingEnvironment)
+    {
+        _umbracoVersion = umbracoVersion;
+        _timeProvider = timeProvider;
+        _hostingEnvironment = hostingEnvironment;
+        _runtimeSettings = runtimeSettingsOptionsMonitor.CurrentValue;
+        runtimeSettingsOptionsMonitor.OnChange(runtimeSettings => _runtimeSettings = runtimeSettings);
+    }
+
+    /// <inheritdoc />
+    public ServerInformation GetServerInformation()
+        => new(_umbracoVersion.SemanticVersion, _timeProvider.LocalTimeZone, _runtimeSettings.Mode, _hostingEnvironment.IsDebugMode);
+}

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/server.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/server.handlers.ts
@@ -46,6 +46,7 @@ export const serverInformationHandlers = [
 			assemblyVersion: version,
 			baseUtcOffset: '01:00:00',
 			runtimeMode: RuntimeModeModel.BACKOFFICE_DEVELOPMENT,
+			isDebugMode: true,
 		});
 	}),
 	http.get(umbracoPath('/server/troubleshooting'), () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
@@ -2487,6 +2487,7 @@ export type ServerInformationResponseModel = {
     assemblyVersion: string;
     baseUtcOffset: string;
     runtimeMode: RuntimeModeModel;
+    isDebugMode: boolean;
 };
 
 export type ServerStatusResponseModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/server.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/server.context.ts
@@ -23,13 +23,20 @@ export class UmbServerContext extends UmbContextBase {
 	 * The server information is fetched lazily on first subscription.
 	 */
 	public readonly isProductionMode = defer(() => {
-		if (!this.#serverInformationFetched) {
-			this.#serverInformationFetched = true;
-			this.#fetchServerInformation();
-		}
+		this.#ensureServerInformation();
 		return this.#serverInformation.asObservablePart((info) =>
 			info ? info.runtimeMode === RuntimeModeModel.PRODUCTION : undefined,
 		);
+	});
+
+	/**
+	 * Observable that emits true when the server is running in debug mode,
+	 * false when not, or undefined until server information is loaded.
+	 * The server information is fetched lazily on first subscription.
+	 */
+	public readonly isDebugMode = defer(() => {
+		this.#ensureServerInformation();
+		return this.#serverInformation.asObservablePart((info) => (info ? info.isDebugMode : undefined));
 	});
 
 	/**
@@ -42,6 +49,12 @@ export class UmbServerContext extends UmbContextBase {
 		this.#serverUrl = config.serverUrl;
 		this.#backofficePath = config.backofficePath;
 		this.#serverConnection = config.serverConnection;
+	}
+
+	#ensureServerInformation() {
+		if (this.#serverInformationFetched) return;
+		this.#serverInformationFetched = true;
+		this.#fetchServerInformation();
 	}
 
 	async #fetchServerInformation() {

--- a/src/Umbraco.Web.UI.Client/src/packages/performance-profiling/dashboard-performance-profiling.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/performance-profiling/dashboard-performance-profiling.element.ts
@@ -5,33 +5,54 @@ import { ProfilingService } from '@umbraco-cms/backoffice/external/backend-api';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
 import { consumeContext } from '@umbraco-cms/backoffice/context-api';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
+import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
 
 @customElement('umb-dashboard-performance-profiling')
 export class UmbDashboardPerformanceProfilingElement extends UmbLitElement {
 	@state()
 	private _profilingStatus = true;
 
-	// TODO: Get this from the management api configuration when available
 	@state()
-	private _isDebugMode = true;
+	private _isDebugMode?: boolean;
 
 	@state()
 	private _isLoading = true;
 
 	@query('#toggle')
-	private _toggle!: HTMLInputElement;
+	private _toggle?: HTMLInputElement;
 
 	@consumeContext({ context: UMB_NOTIFICATION_CONTEXT })
 	private _notificationContext: typeof UMB_NOTIFICATION_CONTEXT.TYPE | undefined;
 
+	#profilingStatusRequested = false;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_SERVER_CONTEXT, (context) => {
+			this.observe(context?.isDebugMode, (isDebugMode) => {
+				this._isDebugMode = isDebugMode;
+
+				// The profiler can only be toggled in debug mode, so there is nothing to request otherwise.
+				if (isDebugMode && !this.#profilingStatusRequested) {
+					this.#profilingStatusRequested = true;
+					this.#requestProfilingStatus();
+				}
+			});
+		});
+	}
+
 	#setToggle(value: boolean) {
-		this._toggle.checked = value;
+		if (this._toggle) {
+			this._toggle.checked = value;
+		}
 		this._profilingStatus = value;
 		this._isLoading = false;
 	}
 
-	override async firstUpdated() {
+	async #requestProfilingStatus() {
 		const status = await this.#getProfilingStatus();
+		await this.updateComplete;
 		this.#setToggle(status);
 	}
 
@@ -121,9 +142,7 @@ export class UmbDashboardPerformanceProfilingElement extends UmbLitElement {
 	override render() {
 		return html`
 			<uui-box headline=${this.localize.term('profiling_performanceProfiling')}>
-				${typeof this._profilingStatus === 'undefined'
-					? html`<uui-loader></uui-loader>`
-					: this.#renderProfilingStatus()}
+				${this._isDebugMode === undefined ? html`<uui-loader></uui-loader>` : this.#renderProfilingStatus()}
 			</uui-box>
 		`;
 	}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ServerInformationServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ServerInformationServiceTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
+
+[TestFixture]
+public class ServerInformationServiceTests
+{
+    private static readonly TimeZoneInfo TestTimeZone =
+        TimeZoneInfo.CreateCustomTimeZone("Umbraco/Test", TimeSpan.FromHours(2), "Umbraco Test", "Umbraco Test");
+
+    [TestCase(true, ExpectedResult = true)]
+    [TestCase(false, ExpectedResult = false)]
+    public bool GetServerInformation_Returns_IsDebugMode_From_HostingEnvironment(bool isDebugMode)
+        => CreateSut(isDebugMode: isDebugMode).GetServerInformation().IsDebugMode;
+
+    [TestCase(RuntimeMode.BackofficeDevelopment)]
+    [TestCase(RuntimeMode.Development)]
+    [TestCase(RuntimeMode.Production)]
+    public void GetServerInformation_Returns_RuntimeMode_From_RuntimeSettings(RuntimeMode runtimeMode)
+    {
+        ServerInformation result = CreateSut(runtimeMode: runtimeMode).GetServerInformation();
+
+        Assert.AreEqual(runtimeMode, result.RuntimeMode);
+    }
+
+    [Test]
+    public void GetServerInformation_Returns_SemVersion_From_UmbracoVersion()
+    {
+        var semVersion = new SemVersion(17, 3, 1, "rc", "abc123");
+
+        ServerInformation result = CreateSut(semVersion: semVersion).GetServerInformation();
+
+        Assert.AreEqual(semVersion, result.SemVersion);
+    }
+
+    [Test]
+    public void GetServerInformation_Returns_TimeZoneInfo_From_TimeProvider()
+    {
+        ServerInformation result = CreateSut().GetServerInformation();
+
+        Assert.AreEqual(TestTimeZone, result.TimeZoneInfo);
+    }
+
+    private static ServerInformationService CreateSut(
+        SemVersion? semVersion = null,
+        RuntimeMode runtimeMode = RuntimeMode.BackofficeDevelopment,
+        bool isDebugMode = false)
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetLocalTimeZone(TestTimeZone);
+
+        return new ServerInformationService(
+            Mock.Of<IUmbracoVersion>(x => x.SemanticVersion == (semVersion ?? new SemVersion(17, 0, 0))),
+            timeProvider,
+            Mock.Of<IOptionsMonitor<RuntimeSettings>>(x => x.CurrentValue == new RuntimeSettings { Mode = runtimeMode }),
+            Mock.Of<IHostingEnvironment>(x => x.IsDebugMode == isDebugMode));
+    }
+}


### PR DESCRIPTION
## Description

The **Settings → Profiling** dashboard always displayed *"Umbraco currently runs in debug mode"* along with the profiler toggle, regardless of `Umbraco:CMS:Hosting:Debug`. The dashboard element carried a hardcoded placeholder:

```ts
// TODO: Get this from the management api configuration when available
@state()
private _isDebugMode = true;
```

so the "not in debug mode" branch was unreachable dead code. The information wasn't available from the Management API at all — neither `ServerConfigurationResponseModel` nor `ServerInformationResponseModel` exposed a debug flag.

### Changes made

#### Server

`isDebugMode` is now exposed on `GET /server/information`, sourced from `IHostingEnvironment.IsDebugMode` (so it follows `Umbraco:CMS:Hosting:Debug` and reloads on config change).  This endpoint requires backoffice access.

#### Client

`UmbServerContext` gains an `isDebugMode` observable mirroring the existing `isProductionMode`. The dashboard observes it instead of assuming `true`.

Latent problems in the dashboard element were fixed to support the non-debug, that were previously masked by the hardcoded `true`.

Fixes #23609.

## Testing

### Automated

Unit tests are added for the previously uncovered `ServerInformationService`.

### Manual

1. Set `Umbraco:CMS:Hosting:Debug` to `false` and open **Settings → Profiling** — the dashboard shows the "does not run in debug mode" message, with no profiler toggle.

<img width="2533" height="438" alt="image" src="https://github.com/user-attachments/assets/abdf5d7d-eac6-4fc9-a419-949f7dc9a7c2" />

2. Set it to `true` — the description, working toggle and "Friendly reminder" block appear as before.