### PR TITLE
Routing: Don't retain the fallback default culture captured during an upgrade boot (closes #22581)

### DIFF
--- a/src/Umbraco.Core/PublishedCache/DefaultCultureAccessor.cs
+++ b/src/Umbraco.Core/PublishedCache/DefaultCultureAccessor.cs
@@ -25,7 +25,12 @@ public class DefaultCultureAccessor : IDefaultCultureAccessor
     }
 
     /// <inheritdoc />
-    public string DefaultCulture => _runtimeState.Level == RuntimeLevel.Run
+    /// <remarks>
+    ///     <see cref="RuntimeLevel.Upgrading" /> is included because during a background unattended upgrade the
+    ///     database is connected and the site is serving: reporting the configured fallback there left content
+    ///     unroutable (https://github.com/umbraco/Umbraco-CMS/issues/22581).
+    /// </remarks>
+    public string DefaultCulture => _runtimeState.Level is RuntimeLevel.Run or RuntimeLevel.Upgrading
         ? _localizationService.GetDefaultLanguageIsoCode() ?? string.Empty // fast
-        : _options.DefaultUILanguage; // default for install and upgrade, when the service is n/a
+        : _options.DefaultUILanguage; // no database to read from yet, e.g. install or early boot
 }

--- a/src/Umbraco.PublishedCache.HybridCache/DomainCache.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DomainCache.cs
@@ -20,8 +20,8 @@ public class DomainCache : IDomainCache
     ///     The default culture, once resolved at a runtime level where it can be trusted.
     /// </summary>
     /// <remarks>
-    ///     Volatile because this singleton is read concurrently by request threads without a lock, so that a resolved
-    ///     value becomes visible promptly.
+    ///     Volatile because this singleton is read concurrently by request threads without a lock: it prevents the JIT
+    ///     caching the field in a register, so every read observes the value once it has been resolved.
     /// </remarks>
     private volatile string? _defaultCulture;
 

--- a/src/Umbraco.PublishedCache.HybridCache/DomainCache.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DomainCache.cs
@@ -16,27 +16,21 @@ public class DomainCache : IDomainCache
     private readonly IDefaultCultureAccessor _defaultCultureAccessor;
     private readonly IRuntimeState _runtimeState;
 
-#pragma warning disable IDE0032 // Use auto property - does not apply here: _defaultCulture conditionally caches the
-                                // result of the computed DefaultCulture getter rather than acting as its backing
-                                // field, so it cannot be folded into an auto-property.
-    private string? _defaultCulture;
-#pragma warning restore IDE0032 // Use auto property
+    /// <summary>
+    ///     The default culture, once resolved at a runtime level where it can be trusted.
+    /// </summary>
+    /// <remarks>
+    ///     Volatile because this singleton is read concurrently by request threads without a lock, so that a resolved
+    ///     value becomes visible promptly.
+    /// </remarks>
+    private volatile string? _defaultCulture;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="DomainCache" /> class.
     /// </summary>
-    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
-    public DomainCache(IDefaultCultureAccessor defaultCultureAccessor, IDomainCacheService domainCacheService)
-        : this(
-            defaultCultureAccessor,
-            domainCacheService,
-            StaticServiceProvider.Instance.GetRequiredService<IRuntimeState>())
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="DomainCache" /> class.
-    /// </summary>
+    /// <param name="defaultCultureAccessor">The accessor used to resolve the site's default culture.</param>
+    /// <param name="domainCacheService">The service providing the configured domains.</param>
+    /// <param name="runtimeState">The runtime state, used to determine when the default culture can be trusted.</param>
     public DomainCache(
         IDefaultCultureAccessor defaultCultureAccessor,
         IDomainCacheService domainCacheService,
@@ -45,6 +39,20 @@ public class DomainCache : IDomainCache
         _defaultCultureAccessor = defaultCultureAccessor;
         _domainCacheService = domainCacheService;
         _runtimeState = runtimeState;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DomainCache" /> class.
+    /// </summary>
+    /// <param name="defaultCultureAccessor">The accessor used to resolve the site's default culture.</param>
+    /// <param name="domainCacheService">The service providing the configured domains.</param>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
+    public DomainCache(IDefaultCultureAccessor defaultCultureAccessor, IDomainCacheService domainCacheService)
+        : this(
+            defaultCultureAccessor,
+            domainCacheService,
+            StaticServiceProvider.Instance.GetRequiredService<IRuntimeState>())
+    {
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.PublishedCache.HybridCache/DomainCache.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DomainCache.cs
@@ -1,6 +1,9 @@
-﻿using Umbraco.Cms.Core.PublishedCache;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Infrastructure.HybridCache.Services;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache;
 
@@ -10,18 +13,65 @@ namespace Umbraco.Cms.Infrastructure.HybridCache;
 public class DomainCache : IDomainCache
 {
     private readonly IDomainCacheService _domainCacheService;
+    private readonly IDefaultCultureAccessor _defaultCultureAccessor;
+    private readonly IRuntimeState _runtimeState;
+
+#pragma warning disable IDE0032 // Use auto property - does not apply here: _defaultCulture conditionally caches the
+                                // result of the computed DefaultCulture getter rather than acting as its backing
+                                // field, so it cannot be folded into an auto-property.
+    private string? _defaultCulture;
+#pragma warning restore IDE0032 // Use auto property
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="DomainCache" /> class.
     /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
     public DomainCache(IDefaultCultureAccessor defaultCultureAccessor, IDomainCacheService domainCacheService)
+        : this(
+            defaultCultureAccessor,
+            domainCacheService,
+            StaticServiceProvider.Instance.GetRequiredService<IRuntimeState>())
     {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DomainCache" /> class.
+    /// </summary>
+    public DomainCache(
+        IDefaultCultureAccessor defaultCultureAccessor,
+        IDomainCacheService domainCacheService,
+        IRuntimeState runtimeState)
+    {
+        _defaultCultureAccessor = defaultCultureAccessor;
         _domainCacheService = domainCacheService;
-        DefaultCulture = defaultCultureAccessor.DefaultCulture;
+        _runtimeState = runtimeState;
     }
 
     /// <inheritdoc />
-    public string DefaultCulture { get; }
+    /// <remarks>
+    ///     Only retained once the runtime reaches <see cref="RuntimeLevel.Run" />. This is a singleton that can be
+    ///     constructed earlier, where <see cref="IDefaultCultureAccessor" /> reports a configured fallback, and
+    ///     retaining that left content unroutable until restart (https://github.com/umbraco/Umbraco-CMS/issues/22581).
+    /// </remarks>
+    public string DefaultCulture
+    {
+        get
+        {
+            if (_defaultCulture is not null)
+            {
+                return _defaultCulture;
+            }
+
+            var defaultCulture = _defaultCultureAccessor.DefaultCulture;
+
+            if (_runtimeState.Level == RuntimeLevel.Run && string.IsNullOrEmpty(defaultCulture) is false)
+            {
+                _defaultCulture = defaultCulture;
+            }
+
+            return defaultCulture;
+        }
+    }
 
     /// <inheritdoc />
     public IEnumerable<Domain> GetAll(bool includeWildcards) => _domainCacheService.GetAll(includeWildcards);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PublishedCache/DefaultCultureAccessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PublishedCache/DefaultCultureAccessorTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PublishedCache;
+
+[TestFixture]
+internal sealed class DefaultCultureAccessorTests
+{
+    private const string SiteDefaultCulture = "en-NZ";
+    private const string ConfiguredUiLanguage = "en-GB";
+
+    [TestCase(RuntimeLevel.Run)]
+    [TestCase(RuntimeLevel.Upgrading)]
+    public void Can_Get_Site_Default_Culture_When_Database_Is_Available(RuntimeLevel level)
+    {
+        DefaultCultureAccessor sut = CreateSut(level);
+
+        Assert.AreEqual(SiteDefaultCulture, sut.DefaultCulture);
+    }
+
+    [TestCase(RuntimeLevel.Boot)]
+    [TestCase(RuntimeLevel.Install)]
+    [TestCase(RuntimeLevel.Upgrade)]
+    [TestCase(RuntimeLevel.Unknown)]
+    public void Can_Get_Configured_Ui_Language_When_Database_Is_Unavailable(RuntimeLevel level)
+    {
+        DefaultCultureAccessor sut = CreateSut(level);
+
+        Assert.AreEqual(ConfiguredUiLanguage, sut.DefaultCulture);
+    }
+
+    [Test]
+    public void Can_Get_Empty_Culture_When_No_Default_Language_Is_Set()
+    {
+        DefaultCultureAccessor sut = CreateSut(RuntimeLevel.Run, siteDefaultCulture: null);
+
+        Assert.AreEqual(string.Empty, sut.DefaultCulture);
+    }
+
+    private static DefaultCultureAccessor CreateSut(RuntimeLevel level, string? siteDefaultCulture = SiteDefaultCulture)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete. This is what DefaultCultureAccessor still calls.
+        var localizationService = new Mock<ILocalizationService>();
+        localizationService.Setup(x => x.GetDefaultLanguageIsoCode()).Returns(siteDefaultCulture!);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        var runtimeState = new Mock<IRuntimeState>();
+        runtimeState.SetupGet(x => x.Level).Returns(level);
+
+        var globalSettings = new GlobalSettings { DefaultUILanguage = ConfiguredUiLanguage };
+
+        return new DefaultCultureAccessor(
+            localizationService.Object,
+            runtimeState.Object,
+            Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == globalSettings));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DomainCacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DomainCacheTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.HybridCache;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.PublishedCache.HybridCache;
+
+[TestFixture]
+internal sealed class DomainCacheTests
+{
+    private const string SiteDefaultCulture = "en-NZ";
+    private const string ConfiguredUiLanguage = "en-GB";
+
+    [Test]
+    public void Can_Get_Site_Default_Culture_When_Constructed_Before_Runtime_Level_Is_Run()
+    {
+        var level = RuntimeLevel.Install;
+        DomainCache sut = CreateSut(() => level, out _);
+
+        // Constructing before the database can be read must not retain the DefaultUILanguage fallback.
+        Assert.AreEqual(ConfiguredUiLanguage, sut.DefaultCulture);
+
+        level = RuntimeLevel.Run;
+
+        Assert.AreEqual(SiteDefaultCulture, sut.DefaultCulture);
+    }
+
+    [Test]
+    public void Can_Get_Site_Default_Culture_When_Constructed_While_Upgrading()
+    {
+        DomainCache sut = CreateSut(() => RuntimeLevel.Upgrading, out _);
+
+        Assert.AreEqual(SiteDefaultCulture, sut.DefaultCulture);
+    }
+
+    [Test]
+    public void Can_Get_Site_Default_Culture_When_Constructed_At_Run()
+    {
+        DomainCache sut = CreateSut(() => RuntimeLevel.Run, out _);
+
+        Assert.AreEqual(SiteDefaultCulture, sut.DefaultCulture);
+    }
+
+    [Test]
+    public void Can_Cache_Site_Default_Culture_Once_Runtime_Level_Is_Run()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        DomainCache sut = CreateSut(() => RuntimeLevel.Run, out Mock<ILocalizationService> localizationService);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.AreEqual(SiteDefaultCulture, sut.DefaultCulture);
+        }
+
+        // Read per URL generated, so the resolved value must not be looked up again once it can be trusted.
+#pragma warning disable CS0618 // Type or member is obsolete. This is what DefaultCultureAccessor still calls.
+        localizationService.Verify(x => x.GetDefaultLanguageIsoCode(), Times.Once);
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    [Test]
+    public void Cannot_Retain_Empty_Site_Default_Culture()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        DomainCache sut = CreateSut(() => RuntimeLevel.Run, out Mock<ILocalizationService> localizationService, siteDefaultCulture: null);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        Assert.AreEqual(string.Empty, sut.DefaultCulture);
+
+#pragma warning disable CS0618 // Type or member is obsolete. This is what DefaultCultureAccessor still calls.
+        localizationService.Setup(x => x.GetDefaultLanguageIsoCode()).Returns(SiteDefaultCulture);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        Assert.AreEqual(SiteDefaultCulture, sut.DefaultCulture);
+    }
+
+    private static DomainCache CreateSut(
+        Func<RuntimeLevel> level,
+#pragma warning disable CS0618 // Type or member is obsolete
+        out Mock<ILocalizationService> localizationService,
+#pragma warning restore CS0618 // Type or member is obsolete
+        string? siteDefaultCulture = SiteDefaultCulture)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        localizationService = new Mock<ILocalizationService>();
+        localizationService.Setup(x => x.GetDefaultLanguageIsoCode()).Returns(siteDefaultCulture!);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        var runtimeState = new Mock<IRuntimeState>();
+        runtimeState.SetupGet(x => x.Level).Returns(level);
+
+        var globalSettings = new GlobalSettings { DefaultUILanguage = ConfiguredUiLanguage };
+        var globalSettingsMonitor = Mock.Of<IOptionsMonitor<GlobalSettings>>(x => x.CurrentValue == globalSettings);
+
+        // The real accessor, so the test exercises the actual runtime-level-dependent behaviour it provides.
+        var defaultCultureAccessor = new DefaultCultureAccessor(
+            localizationService.Object,
+            runtimeState.Object,
+            globalSettingsMonitor);
+
+        return new DomainCache(defaultCultureAccessor, Mock.Of<IDomainCacheService>(), runtimeState.Object);
+    }
+}


### PR DESCRIPTION
## Description

We have had issues raised noting that after an upgrade that runs through the unattended upgrade background service, front-end page requests return 404 and the backoffice reports every document as "This document is published but its URL cannot be routed". Only a process restart clears it.

Reported in #22581 and #23636, and still indicated as present in 17.6, even after the updates in #23258.

Fixes #22581.

### Root cause

`DomainCache` captured `IDefaultCultureAccessor.DefaultCulture` in its **constructor**, into a get-only property, and is registered as a **singleton**. `DefaultCultureAccessor` returned `GlobalSettings.DefaultUILanguage` at any runtime level other than `Run`.

During a boot at `RuntimeLevel.Upgrading` the singleton is constructed while the level is still `Upgrading`, so it permanently held the *configured UI language* instead of the *site's default language* — for the lifetime of the process.

From there:

1. `PublishedRouter.FindDomain` reads `IDomainCache.DefaultCulture`, and `FindAndSetDomain` sets it as the request culture.
2. `ContentFinderByUrlNew` passes that culture to `DocumentUrlService.GetDocumentKeyByRoute`.
3. The resulting keys is filtered through `IsContentPublished(key, culture)`.
4. The publish status cache only holds cultures that are actually installed, so nothing matches → 404.

### How the singleton comes to be constructed during the upgrade window

Two paths, both intentional behaviour:

- **Any request served during the window.** `UseUmbracoRouting()` is registered before `UseRouting()`, so `UmbracoRequestMiddleware` → `EnsureUmbracoContext()` → `UmbracoContextFactory(ICacheManager)` → `CacheManager(IDomainCache, …)` all run before the readiness gate added in #23258 replies. Rendering the maintenance page is itself enough to trigger it.
- **A migration with `RebuildCache = true`.** `MigrationPlanExecutor.RebuildCache()` → `DistributedCache.RefreshAllPublishedSnapshot()` materialises `CacheRefresherCollection`, constructing `ContentCacheRefresher(ICacheManager)` and therefore `DomainCache`. No request needed.

This is why the hardening in #23258 could not close these issues: it gates *serving*, but the bad value is captured at *construction*.

### Why this only happened on certain sites

`GlobalSettings.DefaultUILanguage` defaults to `en-US`, and a default install's language is also `en-US`. On such a site the wrongly captured value **coincidentally equals the correct one**, so nothing breaks and the bug is invisible.

It only surfaces when the site's default language differs from `DefaultUILanguage`. One reporter had `en-NZ` content with `DefaultUILanguage` unset, so the fallback resolved to `en-US`.

That is what made this tricky replicate: my previous attempts used a site where the two values always match.

## The fixes

**1. `DomainCache` — don't retain a value that cannot yet be trusted.**

The culture is now resolved on first read rather than in the constructor, and retained only once the runtime has reached `Run` (and only when non-empty).

**2. `DefaultCultureAccessor` — treat `Upgrading` like `Run`.**

During a background unattended upgrade the database is connected and the site is serving, which is precisely unlike `Install` / early boot that the fallback branch was written for. `RuntimeLevel.Upgrading` was introduced by #22020 and silently inherited that branch.

### Why both changes are included

They address different failure modes:

- Change 2 fixes *"the value reported during a background upgrade is wrong"*.
- Change 1 fixes *"a wrong value, from any cause, becomes permanent"*.

So change 2 is strictly all we need for the fix, but change 1 adds additional hardening (perhaps protecting in future if further pre-run states are introduced).

## Workaround for sites currently affected

Set `Umbraco:CMS:Global:DefaultUILanguage` to the site's actual default language ISO code:

```json
{ "Umbraco": { "CMS": { "Global": { "DefaultUILanguage": "en-NZ" } } } }
```

Then restart. This makes the wrongly captured value equal the correct one, so the symptom cannot occur following additional package or product upgrades.

A process restart also clears the symptom each time it happens.

## Testing

### Automated

New `DomainCacheTests` and `DefaultCultureAccessorTests`. The two `DomainCache` cases asserting the value is not retained fail against the previous behaviour.

### Manual

**Setup**

1. Start from an existing installed site whose default language is `en-US`. Confirm with `SELECT id, languageISOCode FROM umbracoLanguage;` — `en-US` should be listed. Something else, e.g. `en-GB` must **not** be present.
2. In `appsettings.json`, set `Umbraco:CMS:Global:DefaultUILanguage` to `en-GB`.
3. Set `Umbraco:CMS:Unattended:UpgradeUnattended` to `true`.
4. Add `"Umbraco.Cms.Core.Routing": "Debug"` under `Serilog:MinimumLevel:Override`. This is the namespace `PublishedRouter` and `ContentFinderByUrlNew` log to, and it provides useful readout.
5. Widen the upgrade window: what I did was to temporarily add `await Task.Delay(TimeSpan.FromSeconds(20));` at the top of the currently last migration step: `AddContentTypeIdIndexForContent.MigrateAsync()`.
6. Force a pending migration: in `umbracoKeyValue`, set `Umbraco.Core.Upgrader.State+Umbraco.Cms` back to the state immediately before that migration step.

```sql
UPDATE umbracoKeyValue
SET [value] = '{3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}'
WHERE [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
```

7. Verify that `/` currently returns 200s.

**Reproduce, on the code before this PR**

8. Start the site and confirm the log reports `Runtime level: Upgrading - UpgradeMigrations`.
9. Request `/` during the 20 second delay. It returns the maintenance page.
10. Wait for `Unattended upgrade completed successfully` in the log.
11. Request `/`. Expect **404**, with `FindDomain: Culture=en-GB` in the log.
12. Restart the site and confirm it is healthy again, demonstrating that only a restart clears it.

**Verify the fix**

13. Repeat steps 8–11 on this branch. Expect **200**, with `FindDomain: Culture=en-US` in the log.

**Control**

14. Repeat with `DefaultUILanguage` set to `en-US`, matching the installed language. Expect 200 both before and after the fix, confirming the culture mismatch is the variable rather than the upgrade boot itself.

**Observed results**

| Scenario | Result |
|---|---|
| Before fix, mismatched language, request during window | 404, `Culture=en-GB` |
| Before fix, matching language (control) | 200 |
| After fix, mismatched language | 200 |

## Related

- #23258 — earlier hardening of this window; explained above why it could not close these issues
- #22020 — introduced the background unattended upgrade, and with it `RuntimeLevel.Upgrading`