### PR TITLE
Authentication: Log silent auto-link failures in `BackOfficeSignInManager` and `MemberSignInManager` (closes #23632)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Security/AutoLinkSignInResult.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/AutoLinkSignInResult.cs
@@ -30,6 +30,12 @@ public class AutoLinkSignInResult : SignInResult
     public static AutoLinkSignInResult FailedNoEmail { get; } = new() { Succeeded = false };
 
     /// <summary>
+    /// Gets a result indicating the auto-link sign-in failed because a new user could not be
+    /// created without a usable name resolved from the external login's claims.
+    /// </summary>
+    public static AutoLinkSignInResult FailedNoName { get; } = new() { Succeeded = false };
+
+    /// <summary>
     /// Gets the collection of error messages related to the auto-link sign-in process.
     /// </summary>
     public IReadOnlyCollection<string> Errors { get; } = Array.Empty<string>();

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManager.cs
@@ -194,24 +194,33 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         // If there are no autolink options then the attempt is failed (user does not exist)
         if (autoLinkOptions == null || !autoLinkOptions.AutoLinkExternalAccount)
         {
+            Logger.LogInformation(
+                "External login auto-link skipped for provider '{LoginProvider}': auto-linking is not enabled for this provider.",
+                loginInfo.LoginProvider);
             return SignInResult.Failed;
         }
 
         var email = loginInfo.Principal.FindFirstValue(ClaimTypes.Email);
 
-        //we are allowing auto-linking/creating of local accounts
+        // We are allowing auto-linking/creating of local accounts
         if (email.IsNullOrWhiteSpace())
         {
+            // Only claim *types* are logged here, never claim values, to avoid leaking personal
+            // information such as email addresses or names into the logs.
+            Logger.LogWarning(
+                "External login auto-link failed for provider '{LoginProvider}': no claim resolving to ClaimTypes.Email was present. Available claim types: {ClaimTypes}",
+                loginInfo.LoginProvider,
+                string.Join(", ", loginInfo.Principal.Claims.Select(c => c.Type).Distinct()));
             return AutoLinkSignInResult.FailedNoEmail;
         }
 
-        //Now we need to perform the auto-link, so first we need to lookup/create a user with the email address
+        // Now we need to perform the auto-link, so first we need to lookup/create a user with the email address
         BackOfficeIdentityUser? autoLinkUser = await UserManager.FindByEmailAsync(email!);
         if (autoLinkUser != null)
         {
             try
             {
-                //call the callback if one is assigned
+                // Call the callback if one is assigned
                 autoLinkOptions.OnAutoLinking?.Invoke(autoLinkUser, loginInfo);
             }
             catch (Exception ex)
@@ -234,7 +243,10 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         var name = loginInfo.Principal?.Identity?.Name;
         if (name.IsNullOrWhiteSpace())
         {
-            throw new InvalidOperationException("The Name value cannot be null");
+            Logger.LogWarning(
+                "External login auto-link failed for provider '{LoginProvider}': a Name value could not be resolved for the new user, and creating a user without a name is not supported.",
+                loginInfo.LoginProvider);
+            return AutoLinkSignInResult.FailedNoName;
         }
 
         autoLinkUser = BackOfficeIdentityUser.CreateNew(_globalSettings, email, email!, autoLinkOptions.GetUserAutoLinkCulture(_globalSettings), name);
@@ -244,7 +256,7 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
             autoLinkUser.AddRole(userGroup);
         }
 
-        //call the callback if one is assigned
+        // Call the callback if one is assigned
         try
         {
             autoLinkOptions.OnAutoLinking?.Invoke(autoLinkUser, loginInfo);

--- a/src/Umbraco.Web.Common/CLAUDE.md
+++ b/src/Umbraco.Web.Common/CLAUDE.md
@@ -252,6 +252,7 @@ ASP.NET Core Identity sign-in manager for members.
 **Result Types** (lines 320-348):
 - `ExternalLoginSignInResult.NotAllowed` - Login refused by callback
 - `AutoLinkSignInResult.FailedNoEmail` - No email from provider
+- `AutoLinkSignInResult.FailedNoName` - No name from provider when creating a new account
 - `AutoLinkSignInResult.FailedCreatingUser` - User creation failed
 - `AutoLinkSignInResult.FailedLinkingUser` - Link creation failed
 

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -234,6 +234,9 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
         // If there are no autolink options then the attempt is failed (user does not exist)
         if (autoLinkOptions == null || !autoLinkOptions.AutoLinkExternalAccount)
         {
+            Logger.LogInformation(
+                "External login auto-link skipped for provider '{LoginProvider}': auto-linking is not enabled for this provider.",
+                loginInfo.LoginProvider);
             return SignInResult.Failed;
         }
 
@@ -242,6 +245,12 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
         // we are allowing auto-linking/creating of local accounts
         if (email.IsNullOrWhiteSpace())
         {
+            // Only claim *types* are logged here, never claim values, to avoid leaking personal
+            // information such as email addresses or names into the logs.
+            Logger.LogWarning(
+                "External login auto-link failed for provider '{LoginProvider}': no claim resolving to ClaimTypes.Email was present. Available claim types: {ClaimTypes}",
+                loginInfo.LoginProvider,
+                string.Join(", ", loginInfo.Principal.Claims.Select(c => c.Type).Distinct()));
             return AutoLinkSignInResult.FailedNoEmail;
         }
 
@@ -274,7 +283,10 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
         var name = loginInfo.Principal?.Identity?.Name;
         if (name.IsNullOrWhiteSpace())
         {
-            throw new InvalidOperationException("The Name value cannot be null");
+            Logger.LogWarning(
+                "External login auto-link failed for provider '{LoginProvider}': a Name value could not be resolved for the new user, and creating a user without a name is not supported.",
+                loginInfo.LoginProvider);
+            return AutoLinkSignInResult.FailedNoName;
         }
 
         autoLinkUser = MemberIdentityUser.CreateNew(email!, email!, autoLinkOptions.DefaultMemberTypeAlias, autoLinkOptions.DefaultIsApproved, name);
@@ -462,6 +474,8 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
         public static AutoLinkSignInResult FailedNotLinked { get; } = new() { Succeeded = false };
 
         public static AutoLinkSignInResult FailedNoEmail { get; } = new() { Succeeded = false };
+
+        public static AutoLinkSignInResult FailedNoName { get; } = new() { Succeeded = false };
 
         public IReadOnlyCollection<string> Errors { get; } = Array.Empty<string>();
 

--- a/src/Umbraco.Web.Website/Controllers/UmbExternalLoginController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbExternalLoginController.cs
@@ -171,6 +171,11 @@ public class UmbExternalLoginController : SurfaceController
                 errors.Add(
                     $"The requested provider ({loginInfo.LoginProvider}) has not provided the email claim {ClaimTypes.Email}, the account cannot be linked.");
             }
+            else if (result == MemberSignInManager.AutoLinkSignInResult.FailedNoName)
+            {
+                errors.Add(
+                    $"The requested provider ({loginInfo.LoginProvider}) has not provided a name for the account, the account cannot be linked.");
+            }
             else if (result is MemberSignInManager.AutoLinkSignInResult autoLinkSignInResult &&
                      autoLinkSignInResult.Errors.Count > 0)
             {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManagerTests.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Net;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Security;
+using Umbraco.Cms.Web.Common.Security;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Security;
+
+[TestFixture]
+public class BackOfficeSignInManagerTests
+{
+    private const string TestProvider = "TestProvider";
+    private const string TestEmail = "test@example.com";
+
+    private Mock<BackOfficeUserManager> _userManager = null!;
+
+    [Test]
+    public async Task Cannot_Auto_Link_External_Login_When_Auto_Linking_Is_Not_Enabled()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut(new ExternalSignInAutoLinkOptions(autoLinkExternalAccount: false));
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(CreateExternalLoginInfo(), false);
+
+        // Assert
+        Assert.AreSame(SignInResult.Failed, actual);
+    }
+
+    [Test]
+    public async Task Cannot_Auto_Link_External_Login_Without_Email_Claim()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut();
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(CreateExternalLoginInfo(), false);
+
+        // Assert
+        Assert.AreSame(AutoLinkSignInResult.FailedNoEmail, actual);
+    }
+
+    [Test]
+    public async Task Cannot_Auto_Link_External_Login_Without_Name_Claim()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut();
+
+        // The principal carries an email but nothing resolving to ClaimTypes.Name, so auto-linking
+        // gets as far as creating a new user and finds no name to create it with.
+        ExternalLoginInfo loginInfo = CreateExternalLoginInfoWithEmail();
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(loginInfo, false);
+
+        // Assert
+        Assert.AreSame(AutoLinkSignInResult.FailedNoName, actual);
+    }
+
+    [Test]
+    public async Task Cannot_Auto_Link_External_Login_When_On_Auto_Linking_Callback_Throws()
+    {
+        // Arrange
+        var autoLinkOptions = new ExternalSignInAutoLinkOptions(autoLinkExternalAccount: true)
+        {
+            OnAutoLinking = (_, _) => throw new InvalidOperationException("callback blew up"),
+        };
+        BackOfficeSignInManager sut = CreateSut(autoLinkOptions);
+        _userManager.Setup(x => x.FindByEmailAsync(TestEmail)).ReturnsAsync(CreateUser());
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(CreateExternalLoginInfoWithEmail(), false);
+
+        // Assert
+        Assert.IsInstanceOf<AutoLinkSignInResult>(actual);
+        Assert.AreEqual("callback blew up", ((AutoLinkSignInResult)actual).Errors.Single());
+    }
+
+    [Test]
+    public async Task Cannot_Auto_Link_External_Login_When_On_External_Login_Callback_Refuses()
+    {
+        // Arrange
+        var autoLinkOptions = new ExternalSignInAutoLinkOptions(autoLinkExternalAccount: true)
+        {
+            OnExternalLogin = (_, _) => false,
+        };
+        BackOfficeSignInManager sut = CreateSut(autoLinkOptions);
+        _userManager.Setup(x => x.FindByEmailAsync(TestEmail)).ReturnsAsync(CreateUser());
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(CreateExternalLoginInfoWithEmail(), false);
+
+        // Assert
+        Assert.AreSame(ExternalLoginSignInResult.NotAllowed, actual);
+    }
+
+    [Test]
+    public async Task Cannot_Auto_Link_External_Login_When_User_Creation_Fails()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut();
+        _userManager
+            .Setup(x => x.CreateAsync(It.IsAny<BackOfficeIdentityUser>()))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "cannot create" }));
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(
+            CreateExternalLoginInfoWithEmail(new Claim(ClaimTypes.Name, "Test User")),
+            false);
+
+        // Assert
+        Assert.IsInstanceOf<AutoLinkSignInResult>(actual);
+        Assert.AreEqual("cannot create", ((AutoLinkSignInResult)actual).Errors.Single());
+    }
+
+    /// <remarks>
+    ///     A user that could not be linked is left behind in an inconsistent state, so the back office
+    ///     deletes it again. This differs from members, which are disapproved rather than deleted.
+    /// </remarks>
+    [Test]
+    public async Task Can_Delete_Auto_Linked_User_When_Linking_The_External_Login_Fails()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut();
+        BackOfficeIdentityUser existingUser = CreateUser();
+        _userManager.Setup(x => x.FindByEmailAsync(TestEmail)).ReturnsAsync(existingUser);
+        _userManager.Setup(x => x.GetLoginsAsync(existingUser)).ReturnsAsync([]);
+        _userManager
+            .Setup(x => x.AddLoginAsync(existingUser, It.IsAny<UserLoginInfo>()))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "cannot link" }));
+        _userManager.Setup(x => x.DeleteAsync(existingUser)).ReturnsAsync(IdentityResult.Success);
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(CreateExternalLoginInfoWithEmail(), false);
+
+        // Assert
+        Assert.IsInstanceOf<AutoLinkSignInResult>(actual);
+        Assert.AreEqual("cannot link", ((AutoLinkSignInResult)actual).Errors.Single());
+        _userManager.Verify(x => x.DeleteAsync(existingUser), Times.Once);
+    }
+
+    [Test]
+    public async Task Can_Report_Both_Failures_When_Deleting_An_Unlinkable_User_Also_Fails()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut();
+        BackOfficeIdentityUser existingUser = CreateUser();
+        _userManager.Setup(x => x.FindByEmailAsync(TestEmail)).ReturnsAsync(existingUser);
+        _userManager.Setup(x => x.GetLoginsAsync(existingUser)).ReturnsAsync([]);
+        _userManager
+            .Setup(x => x.AddLoginAsync(existingUser, It.IsAny<UserLoginInfo>()))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "cannot link" }));
+        _userManager
+            .Setup(x => x.DeleteAsync(existingUser))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "cannot delete" }));
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(CreateExternalLoginInfoWithEmail(), false);
+
+        // Assert
+        Assert.IsInstanceOf<AutoLinkSignInResult>(actual);
+        CollectionAssert.AreEquivalent(
+            new[] { "cannot link", "cannot delete" },
+            ((AutoLinkSignInResult)actual).Errors);
+    }
+
+    private BackOfficeSignInManager CreateSut(ExternalSignInAutoLinkOptions? autoLinkOptions = null)
+    {
+        _userManager = MockUserManager();
+
+        return new BackOfficeSignInManager(
+            _userManager.Object,
+            Mock.Of<IHttpContextAccessor>(),
+            MockExternalLoginProviders(autoLinkOptions),
+            Mock.Of<IUserClaimsPrincipalFactory<BackOfficeIdentityUser>>(),
+            Options.Create(new IdentityOptions()),
+            Options.Create(new GlobalSettings()),
+            Mock.Of<ILogger<SignInManager<BackOfficeIdentityUser>>>(),
+            Mock.Of<IAuthenticationSchemeProvider>(),
+            Mock.Of<IUserConfirmation<BackOfficeIdentityUser>>(),
+            Mock.Of<IEventAggregator>(),
+            Options.Create(new SecuritySettings()),
+            Options.Create(new BackOfficeAuthenticationTypeSettings()),
+            Mock.Of<IRequestCache>());
+    }
+
+    private static Mock<BackOfficeUserManager> MockUserManager()
+        => new(
+            Mock.Of<IIpResolver>(),
+            Mock.Of<IUserStore<BackOfficeIdentityUser>>(),
+            Options.Create(new BackOfficeIdentityOptions()),
+            Mock.Of<IPasswordHasher<BackOfficeIdentityUser>>(),
+            Enumerable.Empty<IUserValidator<BackOfficeIdentityUser>>(),
+            Enumerable.Empty<IPasswordValidator<BackOfficeIdentityUser>>(),
+            new Mock<BackOfficeErrorDescriber>(Mock.Of<ILocalizedTextService>()).Object,
+            Mock.Of<IServiceProvider>(),
+            Mock.Of<IHttpContextAccessor>(),
+            Mock.Of<ILogger<UserManager<BackOfficeIdentityUser>>>(),
+            Options.Create(new UserPasswordConfigurationSettings()),
+            Mock.Of<IEventAggregator>(),
+            Mock.Of<IBackOfficeUserPasswordChecker>(),
+            Options.Create(new GlobalSettings()));
+
+    private static BackOfficeIdentityUser CreateUser()
+        => BackOfficeIdentityUser.CreateNew(new GlobalSettings(), TestEmail, TestEmail, "en-US", "Test User");
+
+    private static IBackOfficeExternalLoginProviders MockExternalLoginProviders(ExternalSignInAutoLinkOptions? autoLinkOptions)
+    {
+        var options = new BackOfficeExternalLoginProviderOptions
+        {
+            AutoLinkOptions = autoLinkOptions ?? new ExternalSignInAutoLinkOptions(autoLinkExternalAccount: true),
+        };
+        var scheme = new BackOfficeExternaLoginProviderScheme(
+            new BackOfficeExternalLoginProvider(
+                TestProvider,
+                Mock.Of<IOptionsMonitor<BackOfficeExternalLoginProviderOptions>>(x => x.Get(TestProvider) == options)),
+            new AuthenticationScheme(TestProvider, TestProvider, typeof(IAuthenticationHandler)));
+
+        return Mock.Of<IBackOfficeExternalLoginProviders>(x =>
+            x.GetAsync(TestProvider) == Task.FromResult<BackOfficeExternaLoginProviderScheme?>(scheme));
+    }
+
+    private static ExternalLoginInfo CreateExternalLoginInfo(params Claim[] claims)
+        => new(
+            new ClaimsPrincipal(new ClaimsIdentity(claims)),
+            TestProvider,
+            "provider-key",
+            TestProvider);
+
+    private static ExternalLoginInfo CreateExternalLoginInfoWithEmail(params Claim[] claims)
+        => CreateExternalLoginInfo([new Claim(ClaimTypes.Email, TestEmail), .. claims]);
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -35,7 +35,9 @@ public class MemberSignInManagerTests
     public UserClaimsPrincipalFactory<MemberIdentityUser> CreateClaimsFactory(MemberManager userMgr)
         => new(userMgr, Options.Create(new IdentityOptions()));
 
-    public MemberSignInManager CreateSut(IdentityOptions? identityOptions = null)
+    public MemberSignInManager CreateSut(
+        IdentityOptions? identityOptions = null,
+        IMemberExternalLoginProviders? externalLoginProviders = null)
     {
         _memberManager = MockMemberManager();
         _mockEventAggregator = new Mock<IEventAggregator>();
@@ -82,7 +84,7 @@ public class MemberSignInManagerTests
             _mockLogger.Object,
             Mock.Of<IAuthenticationSchemeProvider>(),
             Mock.Of<IUserConfirmation<MemberIdentityUser>>(),
-            Mock.Of<IMemberExternalLoginProviders>(),
+            externalLoginProviders ?? Mock.Of<IMemberExternalLoginProviders>(),
             _mockEventAggregator.Object,
             Mock.Of<IOptions<SecuritySettings>>(x => x.Value == new SecuritySettings()),
             new DictionaryAppCache(),
@@ -105,11 +107,34 @@ public class MemberSignInManagerTests
             Mock.Of<IHttpContextAccessor>(),
             Mock.Of<IPublishedModelFactory>());
 
+    private static IMemberExternalLoginProviders MockExternalLoginProviders(string authenticationType)
+    {
+        var options = new MemberExternalLoginProviderOptions
+        {
+            AutoLinkOptions = new MemberExternalSignInAutoLinkOptions(autoLinkExternalAccount: true),
+        };
+        var scheme = new MemberExternalLoginProviderScheme(
+            new MemberExternalLoginProvider(
+                authenticationType,
+                Mock.Of<IOptionsMonitor<MemberExternalLoginProviderOptions>>(x => x.Get(authenticationType) == options)),
+            new AuthenticationScheme(authenticationType, authenticationType, typeof(IAuthenticationHandler)));
+
+        return Mock.Of<IMemberExternalLoginProviders>(x =>
+            x.GetAsync(authenticationType) == Task.FromResult<MemberExternalLoginProviderScheme?>(scheme));
+    }
+
+    private static ExternalLoginInfo CreateExternalLoginInfo(string authenticationType, params Claim[] claims)
+        => new(
+            new ClaimsPrincipal(new ClaimsIdentity(claims)),
+            authenticationType,
+            "provider-key",
+            authenticationType);
+
     [Test]
     public async Task
         WhenPasswordSignInAsyncIsCalled_AndEverythingIsSetup_ThenASignInResultSucceededShouldBeReturnedAsync()
     {
-        // arrange
+        // Arrange
         var userId = "bo8w3d32q9b98";
         var sut = CreateSut();
         var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser" };
@@ -124,34 +149,34 @@ public class MemberSignInManagerTests
         _memberManager.Setup(x => x.IsEmailConfirmedAsync(fakeUser)).ReturnsAsync(true);
         _memberManager.Setup(x => x.IsLockedOutAsync(fakeUser)).ReturnsAsync(false);
 
-        // act
+        // Act
         var actual = await sut.PasswordSignInAsync(fakeUser, password, isPersistent, lockoutOnFailure);
 
-        // assert
+        // Assert
         Assert.IsTrue(actual.Succeeded);
     }
 
     [Test]
     public async Task WhenPasswordSignInAsyncIsCalled_AndTheResultFails_ThenASignInFailedResultShouldBeReturnedAsync()
     {
-        // arrange
+        // Arrange
         var sut = CreateSut();
         var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser" };
         var password = "testPassword";
         var lockoutOnFailure = false;
         var isPersistent = true;
 
-        // act
+        // Act
         var actual = await sut.PasswordSignInAsync(fakeUser, password, isPersistent, lockoutOnFailure);
 
-        // assert
+        // Assert
         Assert.IsFalse(actual.Succeeded);
     }
 
     [Test]
     public async Task Can_Publish_Login_Success_Notification()
     {
-        // arrange
+        // Arrange
         var memberKey = Guid.NewGuid();
         var sut = CreateSut();
         var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
@@ -163,10 +188,10 @@ public class MemberSignInManagerTests
         _memberManager.Setup(x => x.IsEmailConfirmedAsync(fakeUser)).ReturnsAsync(true);
         _memberManager.Setup(x => x.IsLockedOutAsync(fakeUser)).ReturnsAsync(false);
 
-        // act
+        // Act
         await sut.PasswordSignInAsync(fakeUser, "password", false, false);
 
-        // assert
+        // Assert
         _mockEventAggregator.Verify(
             x => x.Publish(It.Is<MemberLoginSuccessNotification>(n =>
                 n.IpAddress == TestIpAddress && n.MemberKey == memberKey)),
@@ -176,15 +201,15 @@ public class MemberSignInManagerTests
     [Test]
     public async Task Can_Publish_Login_Failed_Notification_When_Password_Wrong()
     {
-        // arrange
+        // Arrange
         var memberKey = Guid.NewGuid();
         var sut = CreateSut();
         var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
 
-        // act
+        // Act
         await sut.PasswordSignInAsync(fakeUser, "wrong_password", false, false);
 
-        // assert
+        // Assert
         _mockEventAggregator.Verify(
             x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
                 n.IpAddress == TestIpAddress
@@ -196,16 +221,16 @@ public class MemberSignInManagerTests
     [Test]
     public async Task Can_Publish_Login_Failed_Notification_When_User_Not_Found()
     {
-        // arrange
+        // Arrange
         var sut = CreateSut();
 
         // FindByNameAsync returns null by default on the fresh mock, so the
         // string overload of PasswordSignInAsync calls HandleSignIn with a null user.
 
-        // act
+        // Act
         await sut.PasswordSignInAsync("nonexistent_user", "password", false, false);
 
-        // assert
+        // Assert
         _mockEventAggregator.Verify(
             x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
                 n.IpAddress == TestIpAddress
@@ -217,7 +242,7 @@ public class MemberSignInManagerTests
     [Test]
     public async Task Can_Publish_Login_Failed_Notification_When_Locked_Out()
     {
-        // arrange
+        // Arrange
         var memberKey = Guid.NewGuid();
         var sut = CreateSut();
         var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
@@ -225,10 +250,10 @@ public class MemberSignInManagerTests
         _memberManager.Setup(x => x.SupportsUserLockout).Returns(true);
         _memberManager.Setup(x => x.IsLockedOutAsync(fakeUser)).ReturnsAsync(true);
 
-        // act
+        // Act
         await sut.PasswordSignInAsync(fakeUser, "password", false, false);
 
-        // assert
+        // Assert
         _mockEventAggregator.Verify(
             x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
                 n.IpAddress == TestIpAddress
@@ -240,7 +265,7 @@ public class MemberSignInManagerTests
     [Test]
     public async Task Can_Publish_Login_Failed_Notification_When_Not_Allowed()
     {
-        // arrange
+        // Arrange
         var memberKey = Guid.NewGuid();
         var identityOptions = new IdentityOptions { SignIn = { RequireConfirmedEmail = true } };
         var sut = CreateSut(identityOptions);
@@ -249,10 +274,10 @@ public class MemberSignInManagerTests
         // IsEmailConfirmedAsync returns false by default on the mock,
         // so CanSignInAsync returns false → PreSignInCheck returns NotAllowed.
 
-        // act
+        // Act
         await sut.PasswordSignInAsync(fakeUser, "password", false, false);
 
-        // assert
+        // Assert
         _mockEventAggregator.Verify(
             x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
                 n.IpAddress == TestIpAddress
@@ -262,19 +287,51 @@ public class MemberSignInManagerTests
     }
 
     [Test]
+    public async Task Cannot_Auto_Link_External_Login_Without_Email_Claim()
+    {
+        // Arrange
+        const string provider = "TestProvider";
+        var sut = CreateSut(externalLoginProviders: MockExternalLoginProviders(provider));
+
+        // Act
+        var actual = await sut.ExternalLoginSignInAsync(CreateExternalLoginInfo(provider), false);
+
+        // Assert
+        Assert.AreSame(MemberSignInManager.AutoLinkSignInResult.FailedNoEmail, actual);
+    }
+
+    [Test]
+    public async Task Cannot_Auto_Link_External_Login_Without_Name_Claim()
+    {
+        // Arrange
+        const string provider = "TestProvider";
+        var sut = CreateSut(externalLoginProviders: MockExternalLoginProviders(provider));
+
+        // The principal carries an email but nothing resolving to ClaimTypes.Name, so auto-linking
+        // gets as far as creating a new member and finds no name to create it with.
+        var loginInfo = CreateExternalLoginInfo(provider, new Claim(ClaimTypes.Email, "test@example.com"));
+
+        // Act
+        var actual = await sut.ExternalLoginSignInAsync(loginInfo, false);
+
+        // Assert
+        Assert.AreSame(MemberSignInManager.AutoLinkSignInResult.FailedNoName, actual);
+    }
+
+    [Test]
     public async Task Can_Publish_Logout_Success_Notification()
     {
-        // arrange
+        // Arrange
         var memberKey = Guid.NewGuid();
         var sut = CreateSut();
         var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
 
         _memberManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(fakeUser);
 
-        // act
+        // Act
         await sut.SignOutAsync();
 
-        // assert
+        // Assert
         _mockEventAggregator.Verify(
             x => x.Publish(It.Is<MemberLogoutSuccessNotification>(n =>
                 n.IpAddress == TestIpAddress && n.MemberKey == memberKey)),
@@ -284,15 +341,15 @@ public class MemberSignInManagerTests
     [Test]
     public async Task Cannot_Publish_Logout_Notification_When_User_Not_Found()
     {
-        // arrange
+        // Arrange
         var sut = CreateSut();
 
         // GetUserAsync returns null by default on the fresh mock.
 
-        // act
+        // Act
         await sut.SignOutAsync();
 
-        // assert
+        // Assert
         _mockEventAggregator.Verify(
             x => x.Publish(It.IsAny<MemberLogoutSuccessNotification>()),
             Times.Never);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbExternalLoginControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbExternalLoginControllerTests.cs
@@ -219,6 +219,48 @@ public class UmbExternalLoginControllerTests
     }
 
     [Test]
+    public async Task ExternalLoginCallback_FailedNoEmail_ReturnsCurrentPageWithError()
+    {
+        var loginInfo = CreateLoginInfo();
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync(loginInfo);
+        _signInManagerMock
+            .Setup(x => x.ExternalLoginSignInAsync(loginInfo, false, It.IsAny<bool>()))
+            .ReturnsAsync(MemberSignInManager.AutoLinkSignInResult.FailedNoEmail);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        var errors = controller.ViewData.GetExternalSignInProviderErrors();
+        Assert.IsNotNull(errors);
+        Assert.That(errors!.Errors.Single(), Does.Contain("has not provided the email claim"));
+    }
+
+    [Test]
+    public async Task ExternalLoginCallback_FailedNoName_ReturnsCurrentPageWithError()
+    {
+        var loginInfo = CreateLoginInfo();
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync(loginInfo);
+        _signInManagerMock
+            .Setup(x => x.ExternalLoginSignInAsync(loginInfo, false, It.IsAny<bool>()))
+            .ReturnsAsync(MemberSignInManager.AutoLinkSignInResult.FailedNoName);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        var errors = controller.ViewData.GetExternalSignInProviderErrors();
+        Assert.IsNotNull(errors);
+        Assert.That(errors!.Errors.Single(), Does.Contain("has not provided a name"));
+    }
+
+    [Test]
     public async Task ExternalLinkLoginCallback_NoLocalUser_ReturnsCurrentPageWithError()
     {
         _memberManagerMock


### PR DESCRIPTION
Fixes #23632

### Description

`BackOfficeSignInManager.AutoLinkAndSignInExternalAccount` (and the identical logic in `MemberSignInManager`) failed silently in three cases, leaving external login failures completely undiagnosable from the logs:

1. Auto-linking not enabled for the provider.
2. No claim resolving to `ClaimTypes.Email` present on the external login.
3. No usable `Name` claim when creating a brand-new auto-linked user — this one didn't even fail gracefully, it threw `InvalidOperationException("The Name value cannot be null")`.

This PR adds logging to all three cases, and replaces the exception in case 3 with a proper `SignInResult`, consistent with how case 2 already worked:

- Case 1 now logs `Information` — a disabled/not-configured provider is a valid setup, not a problem, so it shouldn't log as a warning.
- Case 2 now logs `Warning`, including only the external login's claim *types* (never claim values) so no personal information ends up in the logs.
- Case 3 now logs `Warning` and returns a new `AutoLinkSignInResult.FailedNoName`, mirroring the existing `FailedNoEmail`, instead of throwing.

The same fix is applied to both `BackOfficeSignInManager` and `MemberSignInManager`, since both had the identical pattern.

This addresses @AndyButland's review comments on #23632 point by point:
- Claim values kept out of the logs (types only).
- Reconsidered the log level for the "auto-link not enabled" case → `Information`.
- Added `FailedNoName` alongside `FailedNoEmail` rather than reusing a generic failure/exception.
- Checked `MemberSignInManager` for the same pattern and applied the fix there too.
- Branched from and targets `v17/dev`.

### How to test

1. Register an external login provider for the backoffice with `AutoLinkOptions.AutoLinkExternalAccount = true`.
2. Sign in with an identity whose claims don't resolve to `ClaimTypes.Email` (e.g. an Entra ID account with no `Mail` attribute set, so it only carries `preferred_username`).
3. Before this PR: sign-in silently fails, and nothing appears in the logs to explain why.
4. After this PR: sign-in still fails the same way (behaviour is unchanged for the end user), but the log now shows a `Warning` line naming the provider and the claim types that were present, e.g. "no claim resolving to ClaimTypes.Email was present. Available claim types: ...".
5. Repeat with a provider that has no `AutoLinkOptions` configured at all: confirm this now logs at `Information`, not `Warning`.
6. Repeat with an identity that resolves an email but no `Name`: confirm sign-in returns `AutoLinkSignInResult.FailedNoName` and logs a `Warning`, instead of throwing an unhandled `InvalidOperationException`.
7. Repeat all of the above against a member external login (`MemberSignInManager`) to confirm the same behaviour.