### PR TITLE
Fix UFM fallback for null and undefined values

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/filters/fallback.filter.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/filters/fallback.filter.test.ts
@@ -22,13 +22,13 @@ describe('UmbUfmFallbackFilter', () => {
 		});
 
 		it('should return fallback when value is null', () => {
-			const result = filter.filter(null as any, 'Fallback');
+			const result = filter.filter(null, 'Fallback');
 
 			expect(result).to.equal('Fallback');
 		});
 
 		it('should return fallback when value is undefined', () => {
-			const result = filter.filter(undefined as any, 'Fallback');
+			const result = filter.filter(undefined, 'Fallback');
 
 			expect(result).to.equal('Fallback');
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/filters/fallback.filter.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/filters/fallback.filter.test.ts
@@ -1,0 +1,36 @@
+import { expect } from '@open-wc/testing';
+import { api as UmbUfmFallbackFilterApi } from './fallback.filter.js';
+
+describe('UmbUfmFallbackFilter', () => {
+	let filter: UmbUfmFallbackFilterApi;
+
+	beforeEach(() => {
+		filter = new UmbUfmFallbackFilterApi();
+	});
+
+	describe('filter', () => {
+		it('should return original value when string has content', () => {
+			const result = filter.filter('Test', 'Fallback');
+
+			expect(result).to.equal('Test');
+		});
+
+		it('should return fallback when string is empty', () => {
+			const result = filter.filter('', 'Fallback');
+
+			expect(result).to.equal('Fallback');
+		});
+
+		it('should return fallback when value is null', () => {
+			const result = filter.filter(null as any, 'Fallback');
+
+			expect(result).to.equal('Fallback');
+		});
+
+		it('should return fallback when value is undefined', () => {
+			const result = filter.filter(undefined as any, 'Fallback');
+
+			expect(result).to.equal('Fallback');
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/filters/fallback.filter.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/filters/fallback.filter.ts
@@ -2,7 +2,7 @@ import { UmbUfmFilterBase } from './base.filter.js';
 
 class UmbUfmFallbackFilterApi extends UmbUfmFilterBase {
 	filter(str: string, fallback: string) {
-		return typeof str !== 'string' || str ? str : fallback;
+		return str === null || str === undefined || str === '' ? fallback : str;
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/filters/fallback.filter.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/filters/fallback.filter.ts
@@ -1,7 +1,7 @@
 import { UmbUfmFilterBase } from './base.filter.js';
 
 class UmbUfmFallbackFilterApi extends UmbUfmFilterBase {
-	filter(str: string, fallback: string) {
+	filter(str: string | null | undefined, fallback?: string) {
 		return str === null || str === undefined || str === '' ? fallback : str;
 	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #23657

### Description
This issue was discovered while working with labels in the Umbraco backoffice, where a fallback value was expected to be shown when a label value was missing. During debugging, I found that the UFM fallback filter only handled empty strings correctly, while null and undefined values were returned unchanged.

This PR fixes the UFM fallback filter so that null and undefined values correctly return the configured fallback value.

The filter now returns the fallback value when the input is:

- an empty string
- null
- undefined

Non-empty string values continue to be returned unchanged.

I have also added regression tests covering these cases.


How to test:

From src/Umbraco.Web.UI.Client, run:

npx web-test-runner --files "src/packages/ufm/filters/fallback.filter.test.ts"

Expected result:

4 passed, 0 failed

I also verified the changes with:

npm run compile
npm run lint -- --quiet

Both complete without errors.
