### PR TITLE
Tree: Avoid reloads on no-change config updates

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
@@ -277,6 +277,7 @@ export class UmbDefaultTreeContext<
 	 * @memberof UmbDefaultTreeContext
 	 */
 	setHideTreeRoot(hideTreeRoot: boolean) {
+		if (this.getHideTreeRoot() === hideTreeRoot) return;
 		this.#hideTreeRoot.setValue(hideTreeRoot);
 		// we need to reset the tree if this config changes
 		this.#clearTree();
@@ -298,6 +299,9 @@ export class UmbDefaultTreeContext<
 	 * @memberof UmbDefaultTreeContext
 	 */
 	setStartNode(startNode: UmbTreeStartNode | undefined) {
+		const current = this.getStartNode();
+		if (current?.unique === startNode?.unique && current?.entityType === startNode?.entityType) return;
+
 		this.#treeItemChildrenManager.setStartNode(startNode);
 		if (startNode) {
 			this.#entityContext.setEntityType(startNode.entityType);
@@ -323,6 +327,7 @@ export class UmbDefaultTreeContext<
 	 * @memberof UmbDefaultTreeContext
 	 */
 	setFoldersOnly(foldersOnly: boolean) {
+		if (this.getFoldersOnly() === foldersOnly) return;
 		this.#treeItemChildrenManager.setFoldersOnly(foldersOnly);
 		// we need to reset the tree if this config changes
 		this.#clearTree();


### PR DESCRIPTION
avoids tree reloads when the tree is being configured with the same configuration.