### PR TITLE
Claude MD: update on when to comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,23 +534,15 @@ Labels are only added, never removed. Claude applies only labels it is confident
 
 ## 9. Code Comment Policy
 
-**Default to no comment.** Applies to all code in this repository — C#, TypeScript, Razor, build scripts. Well-named identifiers and small functions carry the meaning; a comment is a fallback for what the code genuinely cannot say — a non-obvious *why*, a subtle invariant the types don't enforce, or a surprising edge case the code handles deliberately. Add XML doc / JSDoc on public members, but keep it concise.
+**Default to no comment.** Applies to all code in this repository — C#, TypeScript, Razor, build scripts. Identifiers, small functions, and recognized idioms (a guard clause, a null check, an early return) carry their own meaning, even when some other layer has a reason to trigger them redundantly — that reason belongs to that layer, not to a comment here. Write one only for what *this* code genuinely can't say on its own: a non-obvious *why*, an invariant the types don't enforce, or an edge case it deliberately handles. Public members get XML doc / JSDoc, kept concise.
 
-**Write the rule, at the altitude of the code it sits in.** A comment states what must hold going forward, in the vocabulary of the layer it lives in — see §2. Where a comment exists because something once went wrong, the rule is what survives; the incident and the reported scenario belong in the commit message and PR body:
+**When a comment is justified, pitch it at the altitude of the code it sits in** — the vocabulary of the layer it lives in, not the incident that prompted it. §2 shows what that looks like in practice.
 
-```typescript
-// A resolver may emit several groups of inner values.
-// Pair each draft group with its persisted group by the
-// identifier the resolver supplies, not by call order.
-```
-
-**Keep issue references where they stay actionable.** A tracked issue link (`(#21996)`, `https://...`) is welcome wherever it explains a non-obvious *why* — a guard whose reason isn't clear from the code, a workaround for a defect this code cannot fix (so it can be deleted when the fix lands), or a regression test recording why it exists. Elsewhere the comment stands on its own in general terms.
-
-**Let commit messages and PR descriptions carry provenance.** Which task, PR, or issue produced a change (`Fix for X`, `Used by Y`, `Added for the Z flow`, `See PR #1234`) is recorded in git history, where it stays accurate. Source describes the code as it is now.
+**Comments aren't a changelog.** An issue link (`#21996`) earns its place inline only while it's explaining a live *why* — a guard, a workaround, a regression test. It does not belong there as provenance (`// Fix for X`, `// Used by Y`, `// See PR #1234`); which task or PR produced a change lives in the commit message and PR description, where it stays accurate.
 
 ### TODOs
 
-Allowed, and can name the specific issue, implementation, or use case it concerns — the one exception to §2, since the comment is deleted once the TODO is done. Keep them short and trackable: `// TODO (V19): remove once obsolete overload is gone` or `// TODO: pagination [NL]`. A TODO should have an author or a version trigger.
+The one exception to "default to no comment" — deleted once the TODO is done, so it can't rot. Keep them short and trackable, anchored to an author or a version trigger: `// TODO (V19): remove once obsolete overload is gone`, `// TODO: pagination [NL]`.
 
 ---
 

--- a/src/Umbraco.Web.UI.Client/docs/clean-code.md
+++ b/src/Umbraco.Web.UI.Client/docs/clean-code.md
@@ -430,9 +430,10 @@ type ReadonlyContent = Readonly<UmbContentModel>;
 - Restating what the code does. If the comment is a paraphrase of the next two lines, delete it.
 - Narrating a sequence of calls. The order is already in the code.
 - Pointing at the current task, fix, callers, or PR (`// Used by X`, `// Added for the Y flow`, `// Fix for issue Z`). That metadata belongs in the commit message and PR description, not in source — it rots.
+- Explaining a recognized idiom (a guard clause, a null check, an early return). It reads as itself no matter which caller or framework has a reason to trigger it redundantly — that reason belongs in whichever layer it's actually true of, not here.
 
 **When a comment IS justified** — only when removing it would leave a future reader confused. State the rule at the altitude of the code it's in: generic and shared code describes its contract, never a specific extension's implementation of it.
-- A non-obvious **WHY**: a hidden constraint, ordering requirement, or business rule that is not visible from the code.
+- A non-obvious **WHY**: a hidden constraint, ordering requirement, or business rule that is not visible from the code, and not already accounted for by a recognized idiom.
 - A **workaround** for a specific bug or browser quirk. Anchor it to an issue (`(#21996)`) so it can be deleted when the upstream fix lands.
 - A subtle **invariant** the type system does not enforce.
 - An **edge case** the code intentionally handles that would surprise a reader.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
@@ -160,7 +160,12 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 
 	private async _observeProperty(): Promise<void> {
 		const alias = this.#alias.getValue();
-		if (!this.#datasetContext || !alias) return;
+		if (!this.#datasetContext || !alias) {
+			this.removeUmbControllerByAlias('observeVariantId');
+			this.removeUmbControllerByAlias('observeValue');
+			this.removeUmbControllerByAlias('observeDatasetReadOnly');
+			return;
+		}
 
 		const variantIdSource = await this.#datasetContext.propertyVariantId?.(alias);
 		const valueSource = await this.#datasetContext.propertyValueByAlias<ValueType>(alias);
@@ -184,17 +189,21 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 			'observeValue',
 		);
 
-		this.observe(this.#datasetContext?.readOnly, (value) => {
-			const unique = 'UMB_DATASET';
+		this.observe(
+			this.#datasetContext?.readOnly,
+			(value) => {
+				const unique = 'UMB_DATASET';
 
-			if (value) {
-				this.readOnlyState.addState({
-					unique,
-				});
-			} else {
-				this.readOnlyState.removeState(unique);
-			}
-		});
+				if (value) {
+					this.readOnlyState.addState({
+						unique,
+					});
+				} else {
+					this.readOnlyState.removeState(unique);
+				}
+			},
+			'observeDatasetReadOnly',
+		);
 	}
 
 	private _generateVariantDifferenceString() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
@@ -160,12 +160,7 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 
 	private async _observeProperty(): Promise<void> {
 		const alias = this.#alias.getValue();
-		if (!this.#datasetContext || !alias) {
-			this.removeUmbControllerByAlias('observeVariantId');
-			this.removeUmbControllerByAlias('observeValue');
-			this.removeUmbControllerByAlias('observeDatasetReadOnly');
-			return;
-		}
+		if (!this.#datasetContext || !alias) return;
 
 		const variantIdSource = await this.#datasetContext.propertyVariantId?.(alias);
 		const valueSource = await this.#datasetContext.propertyValueByAlias<ValueType>(alias);
@@ -189,21 +184,17 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 			'observeValue',
 		);
 
-		this.observe(
-			this.#datasetContext?.readOnly,
-			(value) => {
-				const unique = 'UMB_DATASET';
+		this.observe(this.#datasetContext?.readOnly, (value) => {
+			const unique = 'UMB_DATASET';
 
-				if (value) {
-					this.readOnlyState.addState({
-						unique,
-					});
-				} else {
-					this.readOnlyState.removeState(unique);
-				}
-			},
-			'observeDatasetReadOnly',
-		);
+			if (value) {
+				this.readOnlyState.addState({
+					unique,
+				});
+			} else {
+				this.readOnlyState.removeState(unique);
+			}
+		});
 	}
 
 	private _generateVariantDifferenceString() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
@@ -160,8 +160,6 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 
 	private async _observeProperty(): Promise<void> {
 		const alias = this.#alias.getValue();
-		// Don't fall through to observing an `undefined` source: that blanks the value and tears down the live value
-		// subscription, so a transient absence of the dataset context or alias would wipe an already-filled value.
 		if (!this.#datasetContext || !alias) return;
 
 		const variantIdSource = await this.#datasetContext.propertyVariantId?.(alias);


### PR DESCRIPTION
Avoid comments that explain what obvious code does. Avoid comments that explain implementations that are outside the scope of the specific file — unless it is needed for the code to make sense.

This PR also condenses the MD file regarding comments, making it more conside.