### PR TITLE
Performance: Only load server information once when instantiating the backoffice

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/backoffice/backoffice.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/backoffice/backoffice.context.ts
@@ -1,12 +1,11 @@
-import { tryExecute } from '@umbraco-cms/backoffice/resources';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
-import { ServerService } from '@umbraco-cms/backoffice/external/backend-api';
 import { UmbBasicState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbExtensionsManifestInitializer } from '@umbraco-cms/backoffice/extension-api';
 import { UmbSysinfoRepository } from '@umbraco-cms/backoffice/sysinfo';
 import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
+import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
 import type { ManifestSection } from '@umbraco-cms/backoffice/section';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbExtensionManifestInitializer } from '@umbraco-cms/backoffice/extension-api';
@@ -25,7 +24,11 @@ export class UmbBackofficeContext extends UmbContextBase {
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_BACKOFFICE_CONTEXT);
 
-		this.#getVersion();
+		this.consumeContext(UMB_SERVER_CONTEXT, (serverContext) => {
+			this.observe(serverContext?.serverInformation, (info) => {
+				this.#setVersion(info?.version);
+			});
+		});
 
 		this.consumeContext(UMB_CURRENT_USER_CONTEXT, (userContext) => {
 			this.observe(
@@ -49,15 +52,16 @@ export class UmbBackofficeContext extends UmbContextBase {
 		});
 	}
 
-	async #getVersion() {
-		const { data } = await tryExecute(this._host, ServerService.getServerInformation(), { disableNotifications: true });
-		if (!data) return;
-
+	#setVersion(rawVersion?: string) {
+		if (!rawVersion) {
+			this.#version.setValue(undefined);
+			return;
+		}
 		// A quick semver parser (to remove the unwanted bits) [LK]
 		// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const [semVer, major, minor, patch, prerelease, buildmetadata] =
-			data.version.match(
+			rawVersion.match(
 				/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/,
 			) ?? [];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/server.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/server.context.ts
@@ -5,7 +5,7 @@ import type { ServerInformationResponseModel } from '@umbraco-cms/backoffice/ext
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
-import { defer } from '@umbraco-cms/backoffice/external/rxjs';
+import { defer, map } from '@umbraco-cms/backoffice/external/rxjs';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
 
 export class UmbServerContext extends UmbContextBase {
@@ -17,31 +17,35 @@ export class UmbServerContext extends UmbContextBase {
 	#serverInformationFetched = false;
 
 	/**
-	 * Observable that emits true when the server is running in Production mode,
-	 * false when not in Production mode, or undefined until server information is loaded.
-	 * UI consumers should treat undefined as restricted (safe default).
-	 * The server information is fetched lazily on first subscription.
+	 * Observable that provides the full server information.
+	 * Every subscriber shares one request: the server is asked for its information at most once per
+	 * app session, no matter how many consumers observe this or the derived `isProductionMode`.
 	 */
-	public readonly isProductionMode = defer(() => {
-		if (!this.#serverInformationFetched) {
-			this.#serverInformationFetched = true;
-			this.#fetchServerInformation();
-		}
-		return this.#serverInformation.asObservablePart((info) =>
-			info ? info.runtimeMode === RuntimeModeModel.PRODUCTION : undefined,
-		);
+	public readonly serverInformation = defer(() => {
+		this.#ensureServerInformationRequested();
+		return this.#serverInformation.asObservable();
 	});
 
 	/**
-	 * Observable that provides the full server information.
+	 * Observable that emits true when the server is running in Production mode,
+	 * false when not in Production mode, or undefined until server information is loaded.
+	 * UI consumers should treat undefined as restricted (safe default).
 	 */
-	public readonly serverInformation = this.#serverInformation.asObservable();
+	public readonly isProductionMode = this.serverInformation.pipe(
+		map((info) => (info ? info.runtimeMode === RuntimeModeModel.PRODUCTION : undefined)),
+	);
 
 	constructor(host: UmbControllerHost, config: UmbServerContextConfig) {
 		super(host, UMB_SERVER_CONTEXT);
 		this.#serverUrl = config.serverUrl;
 		this.#backofficePath = config.backofficePath;
 		this.#serverConnection = config.serverConnection;
+	}
+
+	#ensureServerInformationRequested() {
+		if (this.#serverInformationFetched) return;
+		this.#serverInformationFetched = true;
+		this.#fetchServerInformation();
 	}
 
 	async #fetchServerInformation() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/server.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/server.context.ts
@@ -22,7 +22,7 @@ export class UmbServerContext extends UmbContextBase {
 	 * app session, no matter how many consumers observe this or the derived `isProductionMode`.
 	 */
 	public readonly serverInformation = defer(() => {
-		this.#ensureServerInformationRequested();
+		this.#requestServerInformation();
 		return this.#serverInformation.asObservable();
 	});
 
@@ -42,7 +42,7 @@ export class UmbServerContext extends UmbContextBase {
 		this.#serverConnection = config.serverConnection;
 	}
 
-	#ensureServerInformationRequested() {
+	#requestServerInformation() {
 		if (this.#serverInformationFetched) return;
 		this.#serverInformationFetched = true;
 		this.#fetchServerInformation();
@@ -54,6 +54,9 @@ export class UmbServerContext extends UmbContextBase {
 		});
 		if (data) {
 			this.#serverInformation.setValue(data);
+		} else {
+			this.#serverInformationFetched = false;
+			// Might need a retry mechanism here, but for now we just reset the flag so the next subscriber will trigger a new request. [NL]
 		}
 	}
 


### PR DESCRIPTION
Refactor to avoid loading the Server Information twice.

**Test Notes**
Inspect the network when loading backoffice.