### PR TITLE
Rollback: List document versions for culture-invariant documents that have segment variants (closes #23590)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/AllDocumentVersionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/AllDocumentVersionController.cs
@@ -39,7 +39,7 @@ public class AllDocumentVersionController : DocumentVersionControllerBase
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <param name="documentId">The unique identifier of the document whose versions are to be retrieved.</param>
-    /// <param name="culture">An optional culture identifier to filter document versions by culture; if null, all cultures are included.</param>
+    /// <param name="culture">An optional culture identifier to filter document versions by culture; if null, the versions that carry no culture are returned.</param>
     /// <param name="skip">The number of items to skip before starting to collect the result set (used for pagination).</param>
     /// <param name="take">The maximum number of items to return in the result set (used for pagination).</param>
     /// <returns>
@@ -62,14 +62,17 @@ public class AllDocumentVersionController : DocumentVersionControllerBase
         Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus> attempt =
             await _contentVersionService.GetPagedContentVersionsAsync(documentId, culture, skip, take);
 
+        if (attempt.Success is false)
+        {
+            return MapFailure(attempt.Status);
+        }
+
         var pagedViewModel = new PagedViewModel<DocumentVersionItemResponseModel>
         {
             Total = attempt.Result!.Total,
             Items = await _documentVersionPresentationFactory.CreateMultipleAsync(attempt.Result!.Items),
         };
 
-        return attempt.Success
-            ? Ok(pagedViewModel)
-            : MapFailure(attempt.Status);
+        return Ok(pagedViewModel);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/DocumentVersionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentVersion/DocumentVersionControllerBase.cs
@@ -26,6 +26,10 @@ public abstract class DocumentVersionControllerBase : ManagementApiControllerBas
                 .WithTitle("The requested document could not be found")
                 .Build()),
             ContentVersionOperationStatus.InvalidSkipTake => SkipTakeToPagingProblem(),
+            ContentVersionOperationStatus.InvalidCulture => BadRequest(problemDetailsBuilder
+                .WithTitle("Invalid culture")
+                .WithDetail("The specified culture is not supported by the content item.")
+                .Build()),
             ContentVersionOperationStatus.RollBackFailed => BadRequest(problemDetailsBuilder
                 .WithTitle("Rollback failed")
                 .WithDetail("An unspecified error occurred while rolling back the requested version. Please check the logs for additional information.")),

--- a/src/Umbraco.Core/Services/ContentVersionService.cs
+++ b/src/Umbraco.Core/Services/ContentVersionService.cs
@@ -154,6 +154,18 @@ internal sealed class ContentVersionService : IContentVersionService
             return Attempt<ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.NotFound);
         }
 
+        IContent? content = _contentService.GetById(version.ContentId);
+        if (content is null)
+        {
+            return Attempt<ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.ContentNotFound);
+        }
+
+        // A culture can only be rolled back for content that varies by culture.
+        if (culture is not null && content.ContentType.VariesByCulture() is false)
+        {
+            return Attempt<ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.InvalidCulture);
+        }
+
         OperationResult rollBackResult = _contentService.Rollback(
             version.ContentId,
             version.VersionId,

--- a/src/Umbraco.Core/Services/IContentVersionService.cs
+++ b/src/Umbraco.Core/Services/IContentVersionService.cs
@@ -52,7 +52,10 @@ public interface IContentVersionService
     ///     Rolls back content to a specific version.
     /// </summary>
     /// <param name="versionId">The unique identifier of the version to roll back to.</param>
-    /// <param name="culture">The optional culture to roll back. If <c>null</c>, all cultures are rolled back.</param>
+    /// <param name="culture">
+    ///     The optional culture to roll back. If <c>null</c>, all cultures are rolled back. Can only be supplied for
+    ///     content that varies by culture.
+    /// </param>
     /// <param name="userKey">The unique identifier of the user performing the rollback.</param>
     /// <returns>An attempt containing the operation status.</returns>
     Task<Attempt<ContentVersionOperationStatus>> RollBackAsync(Guid versionId, string? culture, Guid userKey);

--- a/src/Umbraco.Core/Services/OperationStatus/ContentVersionOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentVersionOperationStatus.cs
@@ -33,5 +33,10 @@ public enum ContentVersionOperationStatus
     /// <summary>
     ///     The rollback operation was canceled by a notification handler.
     /// </summary>
-    RollBackCanceled
+    RollBackCanceled,
+
+    /// <summary>
+    ///     The specified culture is not supported by the content item.
+    /// </summary>
+    InvalidCulture
 }

--- a/src/Umbraco.Core/Services/OperationStatus/ContentVersionOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentVersionOperationStatus.cs
@@ -36,7 +36,7 @@ public enum ContentVersionOperationStatus
     RollBackCanceled,
 
     /// <summary>
-    ///     The specified culture is not supported by the content item.
+    ///     A culture was specified for content that does not vary by culture.
     /// </summary>
-    InvalidCulture
+    InvalidCulture,
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/rollback/modal/content-rollback-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/rollback/modal/content-rollback-modal.element.ts
@@ -114,7 +114,9 @@ export class UmbContentRollbackModalElement extends UmbModalBaseElement<
 			this.#currentDocument = data;
 			const itemVariants = this.#currentDocument?.variants ?? [];
 
-			this._isInvariant = itemVariants.length === 1 && new UmbVariantId(itemVariants[0].culture).isInvariant();
+			// A document is culture invariant when none of its variants carry a culture. It may still hold
+			// several variants, as any segment adds one.
+			this._isInvariant = itemVariants.every((variant) => UmbVariantId.Create(variant).isCultureInvariant());
 			this.#selectCulture();
 
 			const cultures = itemVariants.map((x) => x.culture).filter((x) => x !== null) as Array<string>;
@@ -215,7 +217,9 @@ export class UmbContentRollbackModalElement extends UmbModalBaseElement<
 			name: data.variants.find((x) => x.culture === this._selectedCulture)?.name || data.variants[0].name,
 			id: data.id,
 			properties: data.values
-				.filter((x) => x.culture === this._selectedCulture || !x.culture) // When invariant, culture is undefined or null.
+				// When invariant, culture is undefined or null. Segment values are overrides of the default
+				// segment value, so only the default segment is shown here.
+				.filter((x) => (x.culture === this._selectedCulture || !x.culture) && !x.segment)
 				.map((value) => {
 					return {
 						alias: value.alias,
@@ -365,9 +369,11 @@ export class UmbContentRollbackModalElement extends UmbModalBaseElement<
 	async #setDiffs() {
 		if (!this._selectedVersion) return;
 
+		// When invariant, culture is undefined or null. Segment values are overrides of the default segment
+		// value, so only the default segment is diffed.
 		const currentPropertyValues = this.#currentDocument?.values.filter(
-			(x) => x.culture === this._selectedCulture || !x.culture,
-		); // When invariant, culture is undefined or null.
+			(x) => (x.culture === this._selectedCulture || !x.culture) && !x.segment,
+		);
 
 		if (!currentPropertyValues) {
 			throw new Error('Current property values are not set');

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/rollback/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/rollback/types.ts
@@ -12,5 +12,5 @@ export interface UmbContentRollbackVersionItemModel {
 export interface UmbContentRollbackVersionDetailModel {
 	id: string;
 	variants: Array<Pick<UmbEntityVariantModel, 'culture' | 'name'>>;
-	values: Array<{ culture: string | null; alias: string; value: unknown }>;
+	values: Array<{ culture: string | null; segment?: string | null; alias: string; value: unknown }>;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/modal/rollback-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/modal/rollback-modal.element.ts
@@ -194,7 +194,9 @@ export class UmbRollbackModalElement extends UmbModalBaseElement<UmbRollbackModa
 			name: data.variants.find((x) => x.culture === this._selectedCulture)?.name || data.variants[0].name,
 			id: data.id,
 			properties: data.values
-				.filter((x) => x.culture === this._selectedCulture || !x.culture) // When invariant, culture is undefined or null.
+				// When invariant, culture is undefined or null. Segment values are overrides of the default
+				// segment value, so only the default segment is shown here.
+				.filter((x) => (x.culture === this._selectedCulture || !x.culture) && !x.segment)
 				.map((value: any) => {
 					return {
 						alias: value.alias,
@@ -336,9 +338,11 @@ export class UmbRollbackModalElement extends UmbModalBaseElement<UmbRollbackModa
 	async #setDiffs() {
 		if (!this._selectedVersion) return;
 
+		// When invariant, culture is undefined or null. Segment values are overrides of the default segment
+		// value, so only the default segment is diffed.
 		const currentPropertyValues = this.#currentDocument?.values.filter(
-			(x) => x.culture === this._selectedCulture || !x.culture,
-		); // When invariant, culture is undefined or null.
+			(x) => (x.culture === this._selectedCulture || !x.culture) && !x.segment,
+		);
 
 		if (!currentPropertyValues) {
 			throw new Error('Current property values are not set');

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/modal/rollback-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/modal/rollback-modal.element.ts
@@ -104,7 +104,9 @@ export class UmbRollbackModalElement extends UmbModalBaseElement<UmbRollbackModa
 			this.#currentDocument = data;
 			const itemVariants = this.#currentDocument?.variants ?? [];
 
-			this._isInvariant = itemVariants.length === 1 && new UmbVariantId(itemVariants[0].culture).isInvariant();
+			// A document is culture invariant when none of its variants carry a culture. It may still hold
+			// several variants, as any segment adds one.
+			this._isInvariant = itemVariants.every((variant) => UmbVariantId.Create(variant).isCultureInvariant());
 			this.#selectCulture();
 
 			const cultures = itemVariants.map((x) => x.culture).filter((x) => x !== null) as string[];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/repository/rollback.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/repository/rollback.repository.ts
@@ -56,6 +56,7 @@ export class UmbDocumentRollbackRepository extends UmbControllerBase implements 
 					})),
 					values: data.values.map((v) => ({
 						culture: v.culture ?? null,
+						segment: v.segment ?? null,
 						alias: v.alias,
 						value: v.value,
 					})),

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/ExtensionRegistry/Segments/RollbackWithSegments.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/ExtensionRegistry/Segments/RollbackWithSegments.spec.ts
@@ -1,0 +1,57 @@
+import {ConstantHelper, test} from '@umbraco/acceptance-test-helpers';
+import {expect} from "@playwright/test";
+
+// Content
+const contentName = 'TestSegmentRollbackContent';
+// DocumentType
+const documentTypeName = 'TestSegmentRollbackDocType';
+let documentTypeId = '';
+// DataType
+const dataTypeName = 'Textstring';
+// Segments
+const vipMemberSegmentAlias = 'vip-members';
+// Test Values
+const originalValue = 'Original value';
+const updatedValue = 'Updated value';
+const vipSegmentValue = 'VIP segment value';
+
+test.describe('rollback for content with segments', () => {
+  test.beforeEach(async ({umbracoApi}) => {
+    await umbracoApi.document.ensureNameNotExists(contentName);
+    await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+    const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+    // The document type varies by segment, but not by culture.
+    documentTypeId = await umbracoApi.documentType.createDocumentTypeWithPropertyEditor(documentTypeName, dataTypeName, dataTypeData.id, 'TestGroup', false, false, false, true, true);
+  });
+
+  test.afterEach(async ({umbracoApi}) => {
+    await umbracoApi.document.ensureNameNotExists(contentName);
+    await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  });
+
+  test('can rollback a culture invariant document that has a segment value', async ({umbracoApi, umbracoUi}) => {
+    // Arrange
+    const documentId = await umbracoApi.document.createDocumentWithTextContent(contentName, documentTypeId, originalValue, dataTypeName);
+    await umbracoApi.document.publish(documentId);
+    const documentData = await umbracoApi.document.get(documentId);
+    documentData.values[0].value = updatedValue;
+    documentData.values.push({...documentData.values[0], segment: vipMemberSegmentAlias, value: vipSegmentValue});
+    await umbracoApi.document.update(documentId, documentData);
+    await umbracoApi.document.publish(documentId);
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+    // Act
+    await umbracoUi.content.clickActionsMenuForContent(contentName);
+    await umbracoUi.content.clickRollbackActionMenuOption();
+    await umbracoUi.content.waitForRollbackItems();
+    await umbracoUi.content.clickPreviousRollBackItem();
+    await umbracoUi.content.clickRollbackContainerButton();
+
+    // Assert
+    await umbracoUi.content.isSuccessNotificationVisible();
+    const [defaultValue] = await umbracoApi.document.getValuesByCultureAndSegmentForDocument(contentName, [{culture: null, segment: null}]);
+    expect(defaultValue).toBeTruthy();
+    expect(defaultValue.value).toBe(originalValue);
+  });
+});

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentVersionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentVersionServiceTests.cs
@@ -1,0 +1,128 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal class ContentVersionServiceTests : UmbracoIntegrationTest
+{
+    private ITemplateService TemplateService => GetRequiredService<ITemplateService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IContentVersionService ContentVersionService => GetRequiredService<IContentVersionService>();
+
+    [Test]
+    public async Task Can_Roll_Back_Culture_Invariant_Content_When_No_Culture_Is_Specified()
+    {
+        IContent content = await CreateInvariantContentWithTwoVersionsAsync();
+        Guid versionId = await GetHistoricVersionIdAsync(content, culture: null);
+
+        Attempt<ContentVersionOperationStatus> result =
+            await ContentVersionService.RollBackAsync(versionId, null, Constants.Security.SuperUserKey);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("Original title", ContentService.GetById(content.Key)!.GetValue<string>("title"));
+    }
+
+    [Test]
+    public async Task Cannot_Roll_Back_Culture_Invariant_Content_When_A_Culture_Is_Specified()
+    {
+        IContent content = await CreateInvariantContentWithTwoVersionsAsync();
+        Guid versionId = await GetHistoricVersionIdAsync(content, culture: null);
+
+        Attempt<ContentVersionOperationStatus> result =
+            await ContentVersionService.RollBackAsync(versionId, "en-US", Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentVersionOperationStatus.InvalidCulture, result.Result);
+        Assert.AreEqual("Updated title", ContentService.GetById(content.Key)!.GetValue<string>("title"));
+    }
+
+    [Test]
+    public async Task Can_Roll_Back_Culture_Variant_Content_When_A_Culture_Is_Specified()
+    {
+        IContent content = await CreateVariantContentWithTwoVersionsAsync();
+        Guid versionId = await GetHistoricVersionIdAsync(content, "en-US");
+
+        Attempt<ContentVersionOperationStatus> result =
+            await ContentVersionService.RollBackAsync(versionId, "en-US", Constants.Security.SuperUserKey);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("Original title", ContentService.GetById(content.Key)!.GetValue<string>("title", "en-US"));
+    }
+
+    private async Task<IContent> CreateInvariantContentWithTwoVersionsAsync()
+    {
+        IContentType contentType = await CreateContentTypeAsync(ContentVariation.Nothing);
+
+        IContent content = ContentBuilder.CreateSimpleContent(contentType);
+        content.SetValue("title", "Original title");
+        ContentService.Save(content);
+        ContentService.Publish(content, []);
+
+        content.SetValue("title", "Updated title");
+        ContentService.Save(content);
+        ContentService.Publish(content, []);
+
+        return content;
+    }
+
+    private async Task<IContent> CreateVariantContentWithTwoVersionsAsync()
+    {
+        IContentType contentType = await CreateContentTypeAsync(ContentVariation.Culture);
+
+        IContent content = ContentBuilder.CreateSimpleContent(contentType, "Home", culture: "en-US");
+        content.SetCultureName("Home", "en-US");
+        content.SetValue("title", "Original title", "en-US");
+        ContentService.Save(content);
+        ContentService.Publish(content, ["en-US"]);
+
+        content.SetValue("title", "Updated title", "en-US");
+        ContentService.Save(content);
+        ContentService.Publish(content, ["en-US"]);
+
+        return content;
+    }
+
+    private async Task<IContentType> CreateContentTypeAsync(ContentVariation variation)
+    {
+        ITemplate template = TemplateBuilder.CreateTextPageTemplate();
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        IContentType contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbTextpage", "Textpage", defaultTemplateId: template.Id);
+        contentType.Variations = variation;
+        foreach (IPropertyType propertyType in contentType.PropertyTypes)
+        {
+            propertyType.Variations = variation;
+        }
+
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        return contentType;
+    }
+
+    private async Task<Guid> GetHistoricVersionIdAsync(IContent content, string? culture)
+    {
+        Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus> versions =
+            await ContentVersionService.GetPagedContentVersionsAsync(content.Key, culture, 0, 100);
+
+        Assert.IsTrue(versions.Success);
+
+        ContentVersionMeta historicVersion = versions.Result!.Items
+            .First(version => version.CurrentDraftVersion is false && version.CurrentPublishedVersion is false);
+
+        return historicVersion.VersionId.ToGuid();
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentVersionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentVersionServiceTests.cs
@@ -66,7 +66,7 @@ internal class ContentVersionServiceTests : UmbracoIntegrationTest
     {
         IContentType contentType = await CreateContentTypeAsync(ContentVariation.Nothing);
 
-        IContent content = ContentBuilder.CreateSimpleContent(contentType);
+        Content content = ContentBuilder.CreateSimpleContent(contentType);
         content.SetValue("title", "Original title");
         ContentService.Save(content);
         ContentService.Publish(content, []);
@@ -82,7 +82,7 @@ internal class ContentVersionServiceTests : UmbracoIntegrationTest
     {
         IContentType contentType = await CreateContentTypeAsync(ContentVariation.Culture);
 
-        IContent content = ContentBuilder.CreateSimpleContent(contentType, "Home", culture: "en-US");
+        Content content = ContentBuilder.CreateSimpleContent(contentType, "Home", culture: "en-US");
         content.SetCultureName("Home", "en-US");
         content.SetValue("title", "Original title", "en-US");
         ContentService.Save(content);
@@ -97,10 +97,10 @@ internal class ContentVersionServiceTests : UmbracoIntegrationTest
 
     private async Task<IContentType> CreateContentTypeAsync(ContentVariation variation)
     {
-        ITemplate template = TemplateBuilder.CreateTextPageTemplate();
+        Template template = TemplateBuilder.CreateTextPageTemplate();
         await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
 
-        IContentType contentType = ContentTypeBuilder.CreateSimpleContentType(
+        ContentType contentType = ContentTypeBuilder.CreateSimpleContentType(
             "umbTextpage", "Textpage", defaultTemplateId: template.Id);
         contentType.Variations = variation;
         foreach (IPropertyType propertyType in contentType.PropertyTypes)
@@ -120,9 +120,11 @@ internal class ContentVersionServiceTests : UmbracoIntegrationTest
 
         Assert.IsTrue(versions.Success);
 
-        ContentVersionMeta historicVersion = versions.Result!.Items
-            .First(version => version.CurrentDraftVersion is false && version.CurrentPublishedVersion is false);
+        ContentVersionMeta? historicVersion = versions.Result!.Items
+            .FirstOrDefault(version => version.CurrentDraftVersion is false && version.CurrentPublishedVersion is false);
 
-        return historicVersion.VersionId.ToGuid();
+        Assert.IsNotNull(historicVersion, "Expected the content to have at least one historic version.");
+
+        return historicVersion!.VersionId.ToGuid();
     }
 }


### PR DESCRIPTION
## Description

On a content type that does **not** vary by culture but has segment-enabled properties, the Rollback dialog reports "No versions available" as soon as any property value is stored under a non-null segment. The backoffice then contradicts itself: the Info tab still lists the history (it reads the audit log), while Rollback claims there is nothing to roll back to.

Fixes #23590.

### The cause

`ContentMapDefinition.MapVariantViewModels` builds variants as the cross-product of cultures × segments, so a culture-invariant document carrying one segment has two variants — both with `culture: null`, differing only by segment. The rollback modal inferred culture-invariance from `itemVariants.length === 1`, which is false as soon as a segment exists, so it sent the app culture as the `culture` query parameter. `DocumentVersionRepository.GetPagedItemsByContentId` then filters on `umbracoContentVersionCultureVariation.LanguageId`, and culture-invariant content has no rows in that table at all — hence zero versions.

**Only the middle step is wrong**. The cross-product is the legitimate variant set for a segment-varying document, and honouring a supplied culture is consistent with how variance is treated elsewhere: a culture the content type does not support is invalid input (`ContentPublishingOperationStatus.CannotPublishVariantWhenNotVariant`, `ContentEditingOperationStatus.InvalidCulture`, `ContentVariation.ValidateVariation`), not something to silently normalise away. So the fix is client-side, and `GET /document-version` is left honouring the culture it is given.

### The fix

#### Client

Culture-invariance is now derived from the rule instead of the array length: a document is culture-invariant when *every* variant is.

#### Server

Whilst here, I've converted two separate 500s into more correct 400 "Bad Request" responses.

- `POST /umbraco/management/api/v1/document-version/{id}/rollback?culture=<culture code>` for culture-invariant content reached `ContentRepositoryExtensions.CopyFrom`, which threw an uncaught `NotSupportedException`. `ContentVersionService.RollBackAsync` now fails with a new `ContentVersionOperationStatus.InvalidCulture`, mapped to a 400 with problem details.
- `AllDocumentVersionController.All` dereferenced `attempt.Result!` *before* checking `attempt.Success`, turning `ContentNotFound` and `InvalidSkipTake` into a `NullReferenceException` instead of the declared 404/400. The XML doc for the `culture` parameter also claimed a null culture returns all cultures; it actually returns the versions that carry no culture.

## Testing

### Automated

A new integration test is added to cover the rollback contract.

Also added a new end-to-end regression test for the reported bug, in the folder whose `AdditionalSetup` segment service is prepared.

Both new tests fail on `v17/dev` and pass with these changes.

### Manual

Segments need enabling first — register an `ISegmentService` returning a couple of segments and set `SegmentSettings.Enabled`, as described in the testing notes on #23587.

1. Create a document type that does **not** vary by culture, with at least one segment-enabled property.
2. Create a node, then save & publish it three times so it has real version history.
3. Open **Actions → Rollback** and confirm the previous versions are listed.
4. Store a property value under a non-null segment, changing nothing else.
5. Open **Actions → Rollback** again. Before this change the dialog reports "No versions available" from here on; it should now list exactly the same versions as in step 3.

While the dialog is open, also confirm the version preview shows one row per property alias rather than repeating an alias per segment, and that the **Show differences** toggle renders a diff instead of failing.

For the server side, with an invariant document:

- `POST /umbraco/management/api/v1/document-version/{id}/rollback?culture=en-US` returns 400 with problem details (500 before this change).