### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions (v17)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,9 +112,9 @@
     <!--
       Microsoft.Data.Sqlite and Microsoft.EntityFrameworkCore.Sqlite (via SQLitePCLRaw.bundle_e_sqlite3)
       otherwise resolve the native SQLitePCLRaw.lib.e_sqlite3 down to a vulnerable 2.1.11
-      (GHSA-2m69-gcr7-jv3q). Pin forward to the patched 2.1.12 until the referencing packages raise
+      (GHSA-2m69-gcr7-jv3q). Pin forward to the patched 2.1.13 until the referencing packages raise
       their floor.
     -->
-    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.13" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,27 +13,27 @@
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.9.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <!-- Umbraco packages -->

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- Add design/build time support for EF Core migrations -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>
@@ -49,7 +49,7 @@
     of the vulnerable 2.1.11 that Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite otherwise
     resolve (GHSA-2m69-gcr7-jv3q).
     -->
-    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.13" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,13 +5,13 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="10.0.10" />
-    <PackageVersion Include="System.Data.OleDb" Version="10.0.10" />
+    <PackageVersion Include="System.Data.Odbc" Version="10.0.11" />
+    <PackageVersion Include="System.Data.OleDb" Version="10.0.11" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Routine dependency maintenance for the **17.7** release line. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

#### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation | 10.0.10 | 10.0.11 |
| Microsoft.Data.Sqlite | 10.0.10 | 10.0.11 |
| Microsoft.EntityFrameworkCore.Sqlite | 10.0.10 | 10.0.11 |
| Microsoft.EntityFrameworkCore.SqlServer | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Caching.Abstractions | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Caching.Memory | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Configuration.Abstractions | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Configuration.Json | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.DependencyInjection | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.FileProviders.Embedded | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.FileProviders.Physical | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Hosting.Abstractions | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Http | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Identity.Core | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Identity.Stores | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Logging | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Options | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Options.ConfigurationExtensions | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Options.DataAnnotations | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Caching.Hybrid | 10.8.0 | 10.9.0 |

#### Test packages (`tests/Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Microsoft.AspNetCore.Mvc.Testing | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Logging.Debug | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.TimeProvider.Testing | 10.8.0 | 10.9.0 |
| Microsoft.NET.Test.Sdk | 18.8.1 | 18.9.0 |
| System.Data.Odbc | 10.0.10 | 10.0.11 |
| System.Data.OleDb | 10.0.10 | 10.0.11 |

#### Inline / template versions

- `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: `Microsoft.EntityFrameworkCore.Design` 10.0.10 → 10.0.11; `SQLitePCLRaw.lib.e_sqlite3` security pin raised 2.1.12 → 2.1.13 (patch release of the forward pin, GHSA-2m69-gcr7-jv3q).
- `templates/UmbracoExtension`: no change needed — the only versioned package there (`Swashbuckle.AspNetCore`) was not bumped in the root file.

#### Deliberately left unchanged

- Any package where only a **major** update is available (out of scope for this PR).
- `Microsoft.OpenApi`, held at `2.9.0` per the `HOLD` comment in `Directory.Packages.props` (2.10.0+ regresses OpenAPI 3.0 nullability serialization).

### How to test

CI build and unit test suite should pass. Locally: `dotnet build umbraco.sln -c Release -p:UmbracoBuild=true` and `dotnet test tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj -c Release -p:UmbracoBuild=true --no-build` both succeeded (6209 passed, 0 failed). `dotnet list umbraco.sln package --vulnerable --include-transitive` reports no vulnerable packages.

<!-- Thanks for contributing to Umbraco CMS! -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNWsyUK2iNLqZm4dT5LNqr)_