### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions (18)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,30 +14,30 @@
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.11" />
     <!-- When updating this version, also update templates/UmbracoExtension/Umbraco.Extension.csproj -->
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.9.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <!-- Umbraco packages -->

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- Add design/build time support for EF Core migrations -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.11" />
     <!--
     Added to align Microsoft.CodeAnalysis.* transitive versions brought in by Microsoft.EntityFrameworkCore.Design,
     which otherwise pulls in Microsoft.CodeAnalysis.CSharp 5.3.0 alongside Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0
@@ -57,7 +57,7 @@
     of the vulnerable 2.1.11 that Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite otherwise
     resolve (GHSA-2m69-gcr7-jv3q).
     -->
-    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.13" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/templates/UmbracoExtension/Directory.Packages.props
+++ b/templates/UmbracoExtension/Directory.Packages.props
@@ -11,6 +11,6 @@
     <PackageVersion Include="Umbraco.Cms.Api.Management" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
   </ItemGroup>
 </Project>

--- a/templates/UmbracoExtension/Umbraco.Extension.csproj
+++ b/templates/UmbracoExtension/Umbraco.Extension.csproj
@@ -64,7 +64,7 @@
       their types directly - only Microsoft.AspNetCore.OpenApi / Microsoft.OpenApi types are
       referenced in the composer.
     -->
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
   </ItemGroup>
   <!--#endif -->
 

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,13 +5,13 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="10.0.10" />
-    <PackageVersion Include="System.Data.OleDb" Version="10.0.10" />
+    <PackageVersion Include="System.Data.Odbc" Version="10.0.11" />
+    <PackageVersion Include="System.Data.OleDb" Version="10.0.11" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Routine dependency maintenance for the **18.2** release line. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

#### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation | 10.0.10 | 10.0.11 |
| Microsoft.AspNetCore.OpenApi | 10.0.10 | 10.0.11 |
| Microsoft.Data.Sqlite | 10.0.10 | 10.0.11 |
| Microsoft.EntityFrameworkCore.Sqlite | 10.0.10 | 10.0.11 |
| Microsoft.EntityFrameworkCore.SqlServer | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Caching.Abstractions | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Caching.Memory | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Configuration.Abstractions | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Configuration.Json | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.DependencyInjection | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.FileProviders.Embedded | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.FileProviders.Physical | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Hosting.Abstractions | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Http | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Identity.Core | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Identity.Stores | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Logging | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Options | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Options.ConfigurationExtensions | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Options.DataAnnotations | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Caching.Hybrid | 10.8.0 | 10.9.0 |

#### Test packages (`tests/Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Microsoft.AspNetCore.Mvc.Testing | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.Logging.Debug | 10.0.10 | 10.0.11 |
| Microsoft.Extensions.TimeProvider.Testing | 10.8.0 | 10.9.0 |
| Microsoft.NET.Test.Sdk | 18.8.1 | 18.9.0 |
| System.Data.Odbc | 10.0.10 | 10.0.11 |
| System.Data.OleDb | 10.0.10 | 10.0.11 |

#### Inline / template versions

- `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: `Microsoft.EntityFrameworkCore.Design` 10.0.10 → 10.0.11; `SQLitePCLRaw.lib.e_sqlite3` security pin raised 2.1.12 → 2.1.13 (patch release of the forward pin, GHSA-2m69-gcr7-jv3q).
- `templates/UmbracoExtension` (`Umbraco.Extension.csproj` and `Directory.Packages.props`): `Microsoft.AspNetCore.OpenApi` 10.0.10 → 10.0.11, kept in sync with the root pin per the comment above it.

#### Deliberately left unchanged

- Any package where only a **major** update is available (out of scope for this PR).
- `Microsoft.OpenApi` in `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`, left at `2.11.0` rather than bumping to the available `2.12.0`: the inline comment on that reference explicitly says "do not bump" due to an OpenAPI 3.0 nullability serialization regression in 2.10.0+ (https://github.com/microsoft/OpenAPI.NET/issues/2967). Note the comment's stated hold version (2.9.0) is stale relative to the current value (2.11.0) — this mismatch predates this PR and is left for a maintainer to reconcile; this PR does not change the package or the comment.

### How to test

CI build and unit test suite should pass. Locally: `dotnet build umbraco.sln -c Release -p:UmbracoBuild=true` and `dotnet test tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj -c Release -p:UmbracoBuild=true --no-build` both succeeded (6538 passed, 0 failed). `dotnet list umbraco.sln package --vulnerable --include-transitive` reports no vulnerable packages.

<!-- Thanks for contributing to Umbraco CMS! -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNWsyUK2iNLqZm4dT5LNqr)_