### PR TITLE
Languages: Accept ISO codes for cultures without a legacy Windows LCID (closes #23679)

### DIFF
--- a/src/Umbraco.Core/Services/IsoCodeValidator.cs
+++ b/src/Umbraco.Core/Services/IsoCodeValidator.cs
@@ -1,11 +1,23 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace Umbraco.Cms.Core.Services;
 
 /// <inheritdoc />
 public class IsoCodeValidator : IIsoCodeValidator
 {
+    private static readonly HashSet<string> _knownCultureNames = new(
+        CultureInfo.GetCultures(CultureTypes.AllCultures)
+            .Select(culture => culture.Name),
+        StringComparer.OrdinalIgnoreCase);
+
     /// <inheritdoc />
-    public bool IsValid(CultureInfo culture) => string.IsNullOrEmpty(culture.Name) is false
-        && culture.CultureTypes.HasFlag(CultureTypes.UserCustomCulture) is false;
+    public bool IsValid(CultureInfo culture) =>
+
+        // A culture is accepted when the platform recognises it. CultureTypes.UserCustomCulture cannot
+        // establish that on its own: it records only the absence of a legacy Windows LCID, which many
+        // recognised cultures lack. Such a culture is told apart from one the platform constructs on
+        // demand for a well-formed but unassigned tag by whether it is among those enumerated.
+        string.IsNullOrEmpty(culture.Name) is false
+            && (culture.CultureTypes.HasFlag(CultureTypes.UserCustomCulture) is false
+                || _knownCultureNames.Contains(culture.Name));
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/LanguageServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/LanguageServiceTests.cs
@@ -247,6 +247,28 @@ internal sealed class LanguageServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public async Task Can_Create_Language_With_IsoCode_Without_Legacy_Windows_Lcid()
+    {
+        var languageEnNg = new LanguageBuilder()
+            .WithCultureInfo("en-NG")
+            .Build();
+        var result = await LanguageService.CreateAsync(languageEnNg, Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success);
+
+        var createdLanguage = await LanguageService.GetAsync("en-NG");
+        Assert.NotNull(createdLanguage);
+    }
+
+    [Test]
+    public async Task Cannot_Create_Language_With_IsoCode_Unknown_To_The_Platform()
+    {
+        var unknownLanguage = new Language("xx-XX", "Unknown to the platform");
+        var result = await LanguageService.CreateAsync(unknownLanguage, Constants.Security.SuperUserKey);
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(LanguageOperationStatus.InvalidIsoCode, result.Status);
+    }
+
+    [Test]
     public async Task Cannot_Create_Duplicate_Languages()
     {
         var isoCode = "en-AU";

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/IsoCodeValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/IsoCodeValidatorTests.cs
@@ -20,18 +20,53 @@ public class IsoCodeValidatorTests
         => _sut.IsValid(CultureInfo.GetCultureInfo(isoCode));
 
     [Test]
+    public void Can_Validate_Every_Culture_Known_To_The_Platform()
+    {
+        CultureInfo[] known = CultureInfo.GetCultures(CultureTypes.AllCultures)
+            .Where(culture => string.IsNullOrEmpty(culture.Name) is false)
+            .ToArray();
+
+        Assert.That(known.Where(culture => _sut.IsValid(culture) is false).Select(culture => culture.Name), Is.Empty);
+    }
+
+    [TestCase("en-NG", ExpectedResult = true)]
+    [TestCase("ha-NG", ExpectedResult = true)]
+    [TestCase("en-DK", ExpectedResult = true)]
+    [TestCase("ar-PS", ExpectedResult = true)]
+    [TestCase("zh-Hant-TW", ExpectedResult = true)]
+    public bool Can_Validate_Culture_Without_Legacy_Windows_Lcid(string isoCode)
+        => _sut.IsValid(CultureInfo.GetCultureInfo(isoCode));
+
+    [TestCase("ca-ES-valencia", ExpectedResult = true)]
+    [TestCase("zh-CHS", ExpectedResult = true)]
+    public bool Can_Validate_Culture_Known_Only_By_Legacy_Windows_Lcid(string isoCode)
+        => _sut.IsValid(CultureInfo.GetCultureInfo(isoCode));
+
+    [Test]
     public void Cannot_Validate_Invariant_Culture()
         => Assert.That(_sut.IsValid(CultureInfo.InvariantCulture), Is.False);
 
-    [Test]
-    public void Can_Validate_Standard_Culture_Via_String_Overload()
+    [TestCase("xx-XX")]
+    [TestCase("qq-ZZ")]
+    [TestCase("en-XY")]
+    [TestCase("aa-BB")]
+    [TestCase("zz")]
+    public void Cannot_Validate_Culture_Unknown_To_The_Platform(string isoCode)
+        => Assert.That(_sut.IsValid(CultureInfo.GetCultureInfo(isoCode)), Is.False);
+
+    [TestCase("en-US")]
+    [TestCase("en-NG")]
+    public void Can_Validate_Standard_Culture_Via_String_Overload(string isoCode)
     {
         IIsoCodeValidator validator = _sut;
-        Assert.That(validator.IsValid("en-US"), Is.True);
+        Assert.That(validator.IsValid(isoCode), Is.True);
     }
 
     [TestCase("not-a-culture")]
     [TestCase("")]
+    [TestCase("xx-XX")]
+    [TestCase("en_US")]
+    [TestCase("en-Latn-US")]
     public void Cannot_Validate_Invalid_IsoCode_Via_String_Overload(string isoCode)
     {
         IIsoCodeValidator validator = _sut;


### PR DESCRIPTION
## Description

`IsoCodeValidator` rejected any culture whose `CultureTypes` includes `UserCustomCulture`. Under ICU — the default on .NET 5+ on every platform — that flag records only that the culture has no entry in the legacy Windows LCID table. It says nothing about whether the platform has data for the locale, so valid BCP 47 tags could not be used as content languages.

Measured on .NET 10, that blocked **495 of the 889 named cultures** the platform enumerates.

The check has been in `IsoCodeValidator` since the class was introduced in #14031 (April 2023, then targeting `net7.0`). #16265 later reshaped it into `IsValid(CultureInfo)` and applied it to the culture list as well, its intent recorded in that PR's test notes as "ensure you cannot create custom cultures".

The flag has never carried that meaning here. Umbraco was already on .NET 7 when the check was written and on .NET 8 when it was extended, so ICU was the default globalization mode throughout, and under ICU `UserCustomCulture` marks the absence of a legacy Windows LCID rather than a user-defined culture.

Fixes #23679

### What changed

A culture carrying `UserCustomCulture` is now accepted when it is one the platform enumerates (`CultureInfo.GetCultures(CultureTypes.AllCultures)`, cached in a static set). The flag is still evaluated first as a short-circuit.

### Why this is safe

The existing predicate is kept as a disjunct, so the change can only ever widen what is accepted — no ISO code that validates today can start failing. That matters because `LanguageService` validates on update as well as create: a narrowing change would break the next language save on a site already using an affected code.

It also keeps working the tags that resolve **only** through the legacy LCID table and are absent from the ICU enumeration — `ca-ES-valencia`, `zh-CHS`, `zh-CHT`, `tg-Cyrl-TJ`. This is why the alternative, validating with `CultureInfo.GetCultureInfo(code, predefinedOnly: true)`, was not used: it is the semantically correct test, but it rejects exactly those four, which is a behavioural break.

Storage is unaffected: the longest name across all enumerated cultures is 11 characters, against `umbracoLanguage.languageISOCode` at `nvarchar(14)`.

### Why made-up cultures are still rejected

The issue suggests dropping the check outright. That would open a hole, because the premise it rests on does not hold under ICU — the default `IsValid(string)` does **not** reject unknown codes. `CultureInfo.GetCultureInfo` constructs a culture on demand for any well-formed tag, with a canonical name matching the input, so `xx-XX` would pass.

### User-facing impact

The culture list offered when creating a language grows from 394 to 889 entries. `UmbCultureRepository` requests `take: 1000` and filters client-side, so this is a single page either way.

## Testing

### Automated

Unit and integration tests added, verified to fail before the fix.

### Manual

1. Settings → Languages → Create, and search the culture list for "Nigeria" — `en-NG` (English, Nigeria) is now offered, and the language saves.
2. `POST /umbraco/management/api/v1/language` with `isoCode: "xx-XX"` still fails with `InvalidIsoCode`.