### PR TITLE
Block Editors: Align element level variance to the culture of the owning property value (closes #23588)

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -315,8 +315,9 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
             // if changes were made to the element type variations, we need those changes reflected in the block property values.
             // for regular content this happens when a content type is saved (copies of property values are created in the DB),
             // but for local block level properties we don't have that kind of handling, so we to do it manually.
-            // to be friendly we'll map "formerly invariant properties" to the default language ISO code instead of performing a
-            // hard reset of the property values (which would likely be the most correct thing to do from a data point of view).
+            // to be friendly we'll map the values onto the culture being aligned - falling back to the default language -
+            // instead of performing a hard reset of the property values (which would likely be the most correct thing to
+            // do from a data point of view).
             item.Values = _blockEditorVarianceHandler.AlignPropertyVarianceAsync(item.Values, culture).GetAwaiter().GetResult();
             foreach (BlockPropertyValue blockPropertyValue in item.Values)
             {

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -294,7 +294,7 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
     {
         MapBlockItemDataToEditor(property, blockValue.ContentData, culture, segment);
         MapBlockItemDataToEditor(property, blockValue.SettingsData, culture, segment);
-        _blockEditorVarianceHandler.AlignExposeVariance(blockValue);
+        _blockEditorVarianceHandler.AlignExposeVariance(blockValue, culture);
     }
 
     protected IEnumerable<Guid> ConfiguredElementTypeKeys(IBlockConfiguration configuration)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
@@ -91,20 +91,8 @@ public sealed class BlockEditorConverter
         var propertyValues = new Dictionary<string, object?>();
         foreach (BlockPropertyValue alignedProperty in alignedProperties)
         {
-            if (!propertyTypesByAlias.TryGetValue(alignedProperty.Alias, out IPublishedPropertyType? propertyType))
-            {
-                continue;
-            }
-
-            var expectedCulture = owner.ContentType.VariesByCulture() && publishedContentType.VariesByCulture() && propertyType.VariesByCulture()
-                ? variationContext.Culture
-                : null;
-            var expectedSegment = owner.ContentType.VariesBySegment() && publishedContentType.VariesBySegment() && propertyType.VariesBySegment()
-                ? variationContext.Segment
-                : null;
-
-            if (alignedProperty.Culture.NullOrWhiteSpaceAsNull().InvariantEquals(expectedCulture.NullOrWhiteSpaceAsNull())
-                && alignedProperty.Segment.NullOrWhiteSpaceAsNull().InvariantEquals(expectedSegment.NullOrWhiteSpaceAsNull()))
+            if (propertyTypesByAlias.TryGetValue(alignedProperty.Alias, out IPublishedPropertyType? propertyType)
+                && IsRenderedVariation(alignedProperty, propertyType, owner, publishedContentType, variationContext))
             {
                 propertyValues[alignedProperty.Alias] = alignedProperty.Value;
             }
@@ -144,4 +132,26 @@ public sealed class BlockEditorConverter
 
         return typeof(IPublishedElement);
     }
+
+    /// <summary>
+    /// Determines whether a block property value is the one to render for the current variation context.
+    /// </summary>
+    private static bool IsRenderedVariation(
+        BlockPropertyValue blockPropertyValue,
+        IPublishedPropertyType propertyType,
+        IPublishedElement owner,
+        IPublishedContentType elementType,
+        VariationContext variationContext)
+    {
+        var expectedCulture = owner.ContentType.VariesByCulture() && elementType.VariesByCulture() && propertyType.VariesByCulture()
+            ? variationContext.Culture
+            : null;
+        var expectedSegment = owner.ContentType.VariesBySegment() && elementType.VariesBySegment() && propertyType.VariesBySegment()
+            ? variationContext.Segment
+            : null;
+
+        return blockPropertyValue.Culture.NullOrWhiteSpaceAsNull().InvariantEquals(expectedCulture.NullOrWhiteSpaceAsNull())
+               && blockPropertyValue.Segment.NullOrWhiteSpaceAsNull().InvariantEquals(expectedSegment.NullOrWhiteSpaceAsNull());
+    }
+
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
@@ -51,7 +51,22 @@ public sealed class BlockEditorConverter
     /// <returns>
     /// An <see cref="IPublishedElement"/> representing the converted block if the conversion is successful and the data is valid; otherwise, <c>null</c> if the content type is not found, is not an element type, or the key is missing or invalid.
     /// </returns>
+    [Obsolete("Please use the overload that states whether the owning property varies by culture. Scheduled for removal in Umbraco 19.")]
     public IPublishedElement? ConvertToElement(IPublishedElement owner, BlockItemData data, PropertyCacheLevel referenceCacheLevel, bool preview)
+        => ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyVariesByCulture: false);
+
+    /// <summary>
+    /// Converts a <see cref="BlockItemData"/> instance into an <see cref="IPublishedElement"/> for use in the block editor.
+    /// </summary>
+    /// <param name="owner">The parent <see cref="IPublishedElement"/> that owns the block element, used for context such as culture and segment variations.</param>
+    /// <param name="data">The <see cref="BlockItemData"/> representing the block to convert.</param>
+    /// <param name="referenceCacheLevel">The <see cref="PropertyCacheLevel"/> to use for resolving references during conversion.</param>
+    /// <param name="preview">If <c>true</c>, conversion is performed in preview mode; otherwise, in published mode.</param>
+    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture, in which case <paramref name="data"/> was loaded from the stored value for the current culture.</param>
+    /// <returns>
+    /// An <see cref="IPublishedElement"/> representing the converted block if the conversion is successful and the data is valid; otherwise, <c>null</c> if the content type is not found, is not an element type, or the key is missing or invalid.
+    /// </returns>
+    public IPublishedElement? ConvertToElement(IPublishedElement owner, BlockItemData data, PropertyCacheLevel referenceCacheLevel, bool preview, bool owningPropertyVariesByCulture)
     {
         // Only convert element types - content types will cause an exception when PublishedModelFactory creates the model
         IPublishedContentType? publishedContentType = _publishedContentTypeCache.Get(PublishedItemType.Element, data.ContentTypeKey);
@@ -61,6 +76,10 @@ public sealed class BlockEditorConverter
         }
 
         VariationContext variationContext = _variationContextAccessor.VariationContext ?? new VariationContext();
+
+        // When the owning property varies by culture, the block value being converted was loaded from the stored value
+        // for the rendering culture, so that is the culture its block property values belong to.
+        var owningPropertyCulture = owningPropertyVariesByCulture ? variationContext.Culture : null;
 
         var propertyTypesByAlias = publishedContentType
             .PropertyTypes
@@ -77,7 +96,7 @@ public sealed class BlockEditorConverter
             // if case changes have been made to the content or element type variation since the parent content was published,
             // we need to align those changes for the block properties - unlike for root level properties, where these
             // things are handled when a content type is saved.
-            BlockPropertyValue? alignedProperty = _blockEditorVarianceHandler.AlignedPropertyVarianceAsync(property, propertyType, owner).GetAwaiter().GetResult();
+            BlockPropertyValue? alignedProperty = _blockEditorVarianceHandler.AlignedPropertyVarianceAsync(property, propertyType, owner, owningPropertyCulture).GetAwaiter().GetResult();
             if (alignedProperty is null)
             {
                 continue;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
@@ -51,9 +51,9 @@ public sealed class BlockEditorConverter
     /// <returns>
     /// An <see cref="IPublishedElement"/> representing the converted block if the conversion is successful and the data is valid; otherwise, <c>null</c> if the content type is not found, is not an element type, or the key is missing or invalid.
     /// </returns>
-    [Obsolete("Please use the overload that states whether the owning property varies by culture. Scheduled for removal in Umbraco 19.")]
+    [Obsolete("Please use the overload that takes the culture of the owning property value. Scheduled for removal in Umbraco 19.")]
     public IPublishedElement? ConvertToElement(IPublishedElement owner, BlockItemData data, PropertyCacheLevel referenceCacheLevel, bool preview)
-        => ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyVariesByCulture: false);
+        => ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyCulture: null);
 
     /// <summary>
     /// Converts a <see cref="BlockItemData"/> instance into an <see cref="IPublishedElement"/> for use in the block editor.
@@ -62,11 +62,11 @@ public sealed class BlockEditorConverter
     /// <param name="data">The <see cref="BlockItemData"/> representing the block to convert.</param>
     /// <param name="referenceCacheLevel">The <see cref="PropertyCacheLevel"/> to use for resolving references during conversion.</param>
     /// <param name="preview">If <c>true</c>, conversion is performed in preview mode; otherwise, in published mode.</param>
-    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture, in which case <paramref name="data"/> was loaded from the stored value for the current culture.</param>
+    /// <param name="owningPropertyCulture">The culture of the stored property value <paramref name="data"/> was loaded from, or <c>null</c> when the property holding the block value does not vary by culture.</param>
     /// <returns>
     /// An <see cref="IPublishedElement"/> representing the converted block if the conversion is successful and the data is valid; otherwise, <c>null</c> if the content type is not found, is not an element type, or the key is missing or invalid.
     /// </returns>
-    public IPublishedElement? ConvertToElement(IPublishedElement owner, BlockItemData data, PropertyCacheLevel referenceCacheLevel, bool preview, bool owningPropertyVariesByCulture)
+    public IPublishedElement? ConvertToElement(IPublishedElement owner, BlockItemData data, PropertyCacheLevel referenceCacheLevel, bool preview, string? owningPropertyCulture)
     {
         // Only convert element types - content types will cause an exception when PublishedModelFactory creates the model
         IPublishedContentType? publishedContentType = _publishedContentTypeCache.Get(PublishedItemType.Element, data.ContentTypeKey);
@@ -77,27 +77,21 @@ public sealed class BlockEditorConverter
 
         VariationContext variationContext = _variationContextAccessor.VariationContext ?? new VariationContext();
 
-        // When the owning property varies by culture, the block value being converted was loaded from the stored value
-        // for the rendering culture, so that is the culture its block property values belong to.
-        var owningPropertyCulture = owningPropertyVariesByCulture ? variationContext.Culture : null;
-
         var propertyTypesByAlias = publishedContentType
             .PropertyTypes
             .ToDictionary(propertyType => propertyType.Alias);
 
-        var propertyValues = new Dictionary<string, object?>();
-        foreach (BlockPropertyValue property in data.Values)
-        {
-            if (!propertyTypesByAlias.TryGetValue(property.Alias, out IPublishedPropertyType? propertyType))
-            {
-                continue;
-            }
+        // if changes have been made to the content or element type variation since the parent content was published,
+        // we need to align those changes for the block properties - unlike for root level properties, where these
+        // things are handled when a content type is saved.
+        IList<BlockPropertyValue> alignedProperties = _blockEditorVarianceHandler
+            .AlignedPropertyVarianceAsync(data.Values, publishedContentType, owner, owningPropertyCulture)
+            .GetAwaiter().GetResult();
 
-            // if case changes have been made to the content or element type variation since the parent content was published,
-            // we need to align those changes for the block properties - unlike for root level properties, where these
-            // things are handled when a content type is saved.
-            BlockPropertyValue? alignedProperty = _blockEditorVarianceHandler.AlignedPropertyVarianceAsync(property, propertyType, owner, owningPropertyCulture).GetAwaiter().GetResult();
-            if (alignedProperty is null)
+        var propertyValues = new Dictionary<string, object?>();
+        foreach (BlockPropertyValue alignedProperty in alignedProperties)
+        {
+            if (!propertyTypesByAlias.TryGetValue(alignedProperty.Alias, out IPublishedPropertyType? propertyType))
             {
                 continue;
             }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
@@ -62,7 +62,16 @@ public sealed class BlockEditorVarianceHandler
 
         foreach (IGrouping<(string Alias, string? Segment), BlockPropertyValue> group in collapsingValues)
         {
-            BlockPropertyValue? valueToRetain = ValueToRetain(blockPropertyValues, group, culture, defaultIsoCode);
+            // An explicitly invariant value is the one matching the current schema, so it takes precedence over the
+            // culture specific leftovers - see axiom 3 in block-element-level-variation.md, structure over data.
+            var hasInvariantValue = blockPropertyValues.Any(blockPropertyValue
+                => blockPropertyValue.Alias == group.Key.Alias
+                   && blockPropertyValue.Segment == group.Key.Segment
+                   && VariesByCulture(blockPropertyValue) is false);
+
+            BlockPropertyValue? valueToRetain = hasInvariantValue
+                ? null
+                : ValueToRetain(group, culture, defaultIsoCode);
             foreach (BlockPropertyValue blockPropertyValue in group)
             {
                 if (blockPropertyValue == valueToRetain)
@@ -86,65 +95,85 @@ public sealed class BlockEditorVarianceHandler
     /// <param name="propertyType">The underlying property type.</param>
     /// <param name="owner">The containing block element.</param>
     /// <returns>A task representing the asynchronous operation. The task result contains the aligned <see cref="BlockPropertyValue"/>, or <c>null</c> if alignment is not applicable.</returns>
-    [Obsolete("Please use the overload that takes the culture of the owning property value. Scheduled for removal in Umbraco 19.")]
-    public Task<BlockPropertyValue?> AlignedPropertyVarianceAsync(BlockPropertyValue blockPropertyValue, IPublishedPropertyType propertyType, IPublishedElement owner)
-        => AlignedPropertyVarianceAsync(blockPropertyValue, propertyType, owner, culture: null);
-
-    /// <summary>
-    /// Aligns a block property value for variance changes.
-    /// </summary>
-    /// <param name="blockPropertyValue">The block property value to align.</param>
-    /// <param name="propertyType">The underlying property type.</param>
-    /// <param name="owner">The containing block element.</param>
-    /// <param name="culture">The culture of the owning property value, or <c>null</c> when the owning property does not vary by culture.</param>
-    /// <returns>A task representing the asynchronous operation. The task result contains the aligned <see cref="BlockPropertyValue"/>, or <c>null</c> if alignment is not applicable.</returns>
-    /// <remarks>
-    /// <para>Used for aligning variance changes when rendering content.</para>
-    /// <para>
-    /// When the owning property varies by culture, each culture is stored separately, so the block property values that
-    /// belong to <paramref name="culture"/> are the ones that represent the block. Otherwise all cultures share a single
-    /// stored value, and the default language is the one that survives becoming invariant.
-    /// </para>
-    /// </remarks>
-    public async Task<BlockPropertyValue?> AlignedPropertyVarianceAsync(BlockPropertyValue blockPropertyValue, IPublishedPropertyType propertyType, IPublishedElement owner, string? culture)
+    [Obsolete("Please use the overload that aligns all property values of a block element. Scheduled for removal in Umbraco 19.")]
+    public async Task<BlockPropertyValue?> AlignedPropertyVarianceAsync(BlockPropertyValue blockPropertyValue, IPublishedPropertyType propertyType, IPublishedElement owner)
     {
-        ContentVariation propertyTypeVariation = owner.ContentType.Variations & propertyType.Variations;
-        if (propertyTypeVariation.VariesByCulture() == VariesByCulture(blockPropertyValue))
+        var defaultCulture = await _languageService.GetDefaultIsoCodeAsync();
+        ContentVariation variation = owner.ContentType.Variations & propertyType.Variations;
+        if (variation.VariesByCulture() == VariesByCulture(blockPropertyValue))
         {
             return blockPropertyValue;
         }
 
-        // mismatch in culture variation for published content:
-        // - if the property type varies by culture, assign the default culture
-        // - if the property type does not vary by culture:
-        //   - if the property value culture is the one representing the block, assign a null value for it to be rendered as the invariant value
-        //   - otherwise return null (not applicable for rendering)
+        return variation.VariesByCulture()
+            ? WithCulture(blockPropertyValue, defaultCulture)
+            : defaultCulture.InvariantEquals(blockPropertyValue.Culture)
+                ? WithCulture(blockPropertyValue, null)
+                : null;
+    }
+
+    /// <summary>
+    /// Aligns the property values of a block element for variance changes.
+    /// </summary>
+    /// <param name="blockPropertyValues">The block property values to align.</param>
+    /// <param name="elementType">The published element type the values belong to.</param>
+    /// <param name="owner">The owner element, which is either the content for block properties at the content level or the parent element for nested block properties.</param>
+    /// <param name="culture">The culture of the owning property value, or <c>null</c> when the owning property does not vary by culture.</param>
+    /// <returns>A task representing the asynchronous operation, with a result containing the aligned block property values.</returns>
+    /// <remarks>
+    /// <para>Used for aligning variance changes when rendering content.</para>
+    /// <para>
+    /// This applies the same rule as <see cref="AlignPropertyVarianceAsync"/> does when editing: a property type that has
+    /// become culture variant adopts <paramref name="culture"/>, and a property type that has become culture invariant
+    /// retains a single value per alias and segment - an explicitly invariant value first, then the value for
+    /// <paramref name="culture"/>, then the value for the default language.
+    /// </para>
+    /// <para>The supplied values are never modified; realigned values are returned as new instances.</para>
+    /// </remarks>
+    public async Task<IList<BlockPropertyValue>> AlignedPropertyVarianceAsync(
+        IList<BlockPropertyValue> blockPropertyValues,
+        IPublishedContentType elementType,
+        IPublishedElement owner,
+        string? culture)
+    {
         var defaultCulture = await _languageService.GetDefaultIsoCodeAsync();
-        if (propertyTypeVariation.VariesByCulture())
+        var alignmentCulture = culture ?? defaultCulture;
+
+        var alignedValues = new List<BlockPropertyValue>();
+        foreach (IGrouping<(string Alias, string? Segment), BlockPropertyValue> group in blockPropertyValues
+                     .GroupBy(blockPropertyValue => (blockPropertyValue.Alias, blockPropertyValue.Segment)))
         {
-            return new BlockPropertyValue
+            IPublishedPropertyType? propertyType = elementType.GetPropertyType(group.Key.Alias);
+            if (propertyType is null)
             {
-                Alias = blockPropertyValue.Alias,
-                Culture = defaultCulture,
-                Segment = blockPropertyValue.Segment,
-                Value = blockPropertyValue.Value,
-                PropertyType = blockPropertyValue.PropertyType
-            };
+                alignedValues.AddRange(group);
+                continue;
+            }
+
+            ContentVariation variation = owner.ContentType.Variations & propertyType.Variations;
+            if (variation.VariesByCulture())
+            {
+                alignedValues.AddRange(group.Select(blockPropertyValue => VariesByCulture(blockPropertyValue)
+                    ? blockPropertyValue
+                    : WithCulture(blockPropertyValue, alignmentCulture)));
+                continue;
+            }
+
+            // the property type no longer varies by culture, so only a single value can survive
+            alignedValues.AddRange(group.Where(blockPropertyValue => VariesByCulture(blockPropertyValue) is false));
+            if (group.Any(blockPropertyValue => VariesByCulture(blockPropertyValue) is false))
+            {
+                continue;
+            }
+
+            BlockPropertyValue? valueToRetain = ValueToRetain(group, alignmentCulture, defaultCulture);
+            if (valueToRetain is not null)
+            {
+                alignedValues.Add(WithCulture(valueToRetain, null));
+            }
         }
 
-        if ((culture ?? defaultCulture).InvariantEquals(blockPropertyValue.Culture))
-        {
-            return new BlockPropertyValue
-            {
-                Alias = blockPropertyValue.Alias,
-                Culture = null,
-                Segment = blockPropertyValue.Segment,
-                Value = blockPropertyValue.Value,
-                PropertyType = blockPropertyValue.PropertyType
-            };
-        }
-
-        return null;
+        return alignedValues;
     }
 
     /// <summary>
@@ -274,6 +303,9 @@ public sealed class BlockEditorVarianceHandler
 
         if (contentDataToAlign.Count > 0)
         {
+            var replacedVariations = blockValue.Expose
+                .Where(v => contentDataToAlign.Any(cd => cd.Key == v.ContentKey))
+                .ToList();
             blockValue.Expose.RemoveAll(v => contentDataToAlign.Any(cd => cd.Key == v.ContentKey));
             foreach (BlockItemData contentData in contentDataToAlign)
             {
@@ -286,10 +318,15 @@ public sealed class BlockEditorVarianceHandler
 
                 if (alignedVariations.Count == 0)
                 {
-                    alignedVariations.Add(new BlockItemVariation(
-                        contentData.Key,
-                        elementTypesByKey[contentData.ContentTypeKey].VariesByCulture() ? culture : null,
-                        null));
+                    // a block without property values has no value variance to align against, so keep it exposed for
+                    // the element type's variance, retaining the segments it was exposed for
+                    var alignedCulture = elementTypesByKey[contentData.ContentTypeKey].VariesByCulture() ? culture : null;
+                    alignedVariations.AddRange(replacedVariations
+                        .Where(v => v.ContentKey == contentData.Key)
+                        .Select(v => v.Segment)
+                        .DefaultIfEmpty(null)
+                        .Distinct()
+                        .Select(segment => new BlockItemVariation(contentData.Key, alignedCulture, segment)));
                 }
 
                 foreach (BlockItemVariation alignedVariation in alignedVariations)
@@ -305,21 +342,23 @@ public sealed class BlockEditorVarianceHandler
     private static bool VariesByCulture(BlockPropertyValue blockPropertyValue)
         => blockPropertyValue.Culture.IsNullOrWhiteSpace() is false;
 
+    /// <summary>
+    /// Determines which of a property's culture specific values survives the property type becoming culture invariant.
+    /// </summary>
     private static BlockPropertyValue? ValueToRetain(
-        IEnumerable<BlockPropertyValue> blockPropertyValues,
-        IGrouping<(string Alias, string? Segment), BlockPropertyValue> collapsingValues,
+        IEnumerable<BlockPropertyValue> cultureSpecificValues,
         string culture,
         string defaultIsoCode)
-    {
-        // an explicitly invariant value already covers the property, so the culture specific ones are leftovers
-        var hasInvariantValue = blockPropertyValues.Any(blockPropertyValue
-            => blockPropertyValue.Alias == collapsingValues.Key.Alias
-               && blockPropertyValue.Segment == collapsingValues.Key.Segment
-               && VariesByCulture(blockPropertyValue) is false);
+        => cultureSpecificValues.FirstOrDefault(blockPropertyValue => blockPropertyValue.Culture.InvariantEquals(culture))
+           ?? cultureSpecificValues.FirstOrDefault(blockPropertyValue => blockPropertyValue.Culture.InvariantEquals(defaultIsoCode));
 
-        return hasInvariantValue
-            ? null
-            : collapsingValues.FirstOrDefault(blockPropertyValue => blockPropertyValue.Culture.InvariantEquals(culture))
-              ?? collapsingValues.FirstOrDefault(blockPropertyValue => blockPropertyValue.Culture.InvariantEquals(defaultIsoCode));
-    }
+    private static BlockPropertyValue WithCulture(BlockPropertyValue blockPropertyValue, string? culture)
+        => new()
+        {
+            Alias = blockPropertyValue.Alias,
+            Culture = culture,
+            Segment = blockPropertyValue.Segment,
+            Value = blockPropertyValue.Value,
+            PropertyType = blockPropertyValue.PropertyType,
+        };
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
@@ -29,43 +29,54 @@ public sealed class BlockEditorVarianceHandler
     /// Aligns a collection of block property values for variance changes.
     /// </summary>
     /// <param name="blockPropertyValues">The block property values to align.</param>
-    /// <param name="culture">The culture being handled (null if invariant).</param>
+    /// <param name="culture">The culture of the property value being aligned (null if invariant).</param>
     /// <returns>A task that represents the asynchronous operation, containing the aligned block property values.</returns>
     /// <remarks>
-    /// Used for aligning variance changes when editing content.
+    /// <para>Used for aligning variance changes when editing content.</para>
+    /// <para>
+    /// A property type that has become culture variant adopts <paramref name="culture"/>. A property type that has
+    /// become culture invariant can only retain a single value per alias and segment; an explicitly invariant value
+    /// takes precedence, then the value for <paramref name="culture"/>, then the value for the default language.
+    /// </para>
     /// </remarks>
     public async Task<IList<BlockPropertyValue>> AlignPropertyVarianceAsync(IList<BlockPropertyValue> blockPropertyValues, string? culture)
     {
-        var defaultIsoCodeAsync = await _languageService.GetDefaultIsoCodeAsync();
-        culture ??= defaultIsoCodeAsync;
+        var defaultIsoCode = await _languageService.GetDefaultIsoCodeAsync();
+        culture ??= defaultIsoCode;
 
-        var valuesToRemove = new List<BlockPropertyValue>();
-        foreach (BlockPropertyValue blockPropertyValue in blockPropertyValues)
+        if (blockPropertyValues.Any(blockPropertyValue => blockPropertyValue.PropertyType is null))
         {
-            IPropertyType? propertyType = blockPropertyValue.PropertyType;
-            if (propertyType is null)
-            {
-                throw new ArgumentException("One or more block properties did not have a resolved property type. Block editor values must be resolved before attempting to map them to editor.", nameof(blockPropertyValues));
-            }
+            throw new ArgumentException("One or more block properties did not have a resolved property type. Block editor values must be resolved before attempting to map them to editor.", nameof(blockPropertyValues));
+        }
 
-            if (propertyType.VariesByCulture() == VariesByCulture(blockPropertyValue))
-            {
-                continue;
-            }
+        foreach (BlockPropertyValue blockPropertyValue in blockPropertyValues
+                     .Where(blockPropertyValue => blockPropertyValue.PropertyType!.VariesByCulture() && VariesByCulture(blockPropertyValue) is false))
+        {
+            blockPropertyValue.Culture = culture;
+        }
 
-            if (propertyType.VariesByCulture() is false && blockPropertyValue.Culture.InvariantEquals(defaultIsoCodeAsync) is false)
+        var valuesToRemove = new HashSet<BlockPropertyValue>();
+        IEnumerable<IGrouping<(string Alias, string? Segment), BlockPropertyValue>> collapsingValues = blockPropertyValues
+            .Where(blockPropertyValue => blockPropertyValue.PropertyType!.VariesByCulture() is false && VariesByCulture(blockPropertyValue))
+            .GroupBy(blockPropertyValue => (blockPropertyValue.Alias, blockPropertyValue.Segment));
+
+        foreach (IGrouping<(string Alias, string? Segment), BlockPropertyValue> group in collapsingValues)
+        {
+            BlockPropertyValue? valueToRetain = ValueToRetain(blockPropertyValues, group, culture, defaultIsoCode);
+            foreach (BlockPropertyValue blockPropertyValue in group)
             {
-                valuesToRemove.Add(blockPropertyValue);
-            }
-            else
-            {
-                blockPropertyValue.Culture = propertyType.VariesByCulture()
-                    ? culture
-                    : null;
+                if (blockPropertyValue == valueToRetain)
+                {
+                    blockPropertyValue.Culture = null;
+                }
+                else
+                {
+                    valuesToRemove.Add(blockPropertyValue);
+                }
             }
         }
 
-        return blockPropertyValues.Except(valuesToRemove).ToList();
+        return blockPropertyValues.Where(blockPropertyValue => valuesToRemove.Contains(blockPropertyValue) is false).ToList();
     }
 
     /// <summary>
@@ -75,10 +86,27 @@ public sealed class BlockEditorVarianceHandler
     /// <param name="propertyType">The underlying property type.</param>
     /// <param name="owner">The containing block element.</param>
     /// <returns>A task representing the asynchronous operation. The task result contains the aligned <see cref="BlockPropertyValue"/>, or <c>null</c> if alignment is not applicable.</returns>
+    [Obsolete("Please use the overload that takes the culture of the owning property value. Scheduled for removal in Umbraco 19.")]
+    public Task<BlockPropertyValue?> AlignedPropertyVarianceAsync(BlockPropertyValue blockPropertyValue, IPublishedPropertyType propertyType, IPublishedElement owner)
+        => AlignedPropertyVarianceAsync(blockPropertyValue, propertyType, owner, culture: null);
+
+    /// <summary>
+    /// Aligns a block property value for variance changes.
+    /// </summary>
+    /// <param name="blockPropertyValue">The block property value to align.</param>
+    /// <param name="propertyType">The underlying property type.</param>
+    /// <param name="owner">The containing block element.</param>
+    /// <param name="culture">The culture of the owning property value, or <c>null</c> when the owning property does not vary by culture.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the aligned <see cref="BlockPropertyValue"/>, or <c>null</c> if alignment is not applicable.</returns>
     /// <remarks>
-    /// Used for aligning variance changes when rendering content.
+    /// <para>Used for aligning variance changes when rendering content.</para>
+    /// <para>
+    /// When the owning property varies by culture, each culture is stored separately, so the block property values that
+    /// belong to <paramref name="culture"/> are the ones that represent the block. Otherwise all cultures share a single
+    /// stored value, and the default language is the one that survives becoming invariant.
+    /// </para>
     /// </remarks>
-    public async Task<BlockPropertyValue?> AlignedPropertyVarianceAsync(BlockPropertyValue blockPropertyValue, IPublishedPropertyType propertyType, IPublishedElement owner)
+    public async Task<BlockPropertyValue?> AlignedPropertyVarianceAsync(BlockPropertyValue blockPropertyValue, IPublishedPropertyType propertyType, IPublishedElement owner, string? culture)
     {
         ContentVariation propertyTypeVariation = owner.ContentType.Variations & propertyType.Variations;
         if (propertyTypeVariation.VariesByCulture() == VariesByCulture(blockPropertyValue))
@@ -89,7 +117,7 @@ public sealed class BlockEditorVarianceHandler
         // mismatch in culture variation for published content:
         // - if the property type varies by culture, assign the default culture
         // - if the property type does not vary by culture:
-        //   - if the property value culture equals the default culture, assign a null value for it to be rendered as the invariant value
+        //   - if the property value culture is the one representing the block, assign a null value for it to be rendered as the invariant value
         //   - otherwise return null (not applicable for rendering)
         var defaultCulture = await _languageService.GetDefaultIsoCodeAsync();
         if (propertyTypeVariation.VariesByCulture())
@@ -104,7 +132,7 @@ public sealed class BlockEditorVarianceHandler
             };
         }
 
-        if (defaultCulture.Equals(blockPropertyValue.Culture))
+        if ((culture ?? defaultCulture).InvariantEquals(blockPropertyValue.Culture))
         {
             return new BlockPropertyValue
             {
@@ -126,15 +154,27 @@ public sealed class BlockEditorVarianceHandler
     /// <param name="owner">The owner element, which is either the content for block properties at the content level or the parent element for nested block properties.</param>
     /// <param name="element">The block element containing the property.</param>
     /// <returns>A task representing the asynchronous operation, with a result containing the aligned <see cref="BlockItemVariation"/> instances for the specified block element.</returns>
+    [Obsolete("Please use the overload that takes the culture of the owning property value. Scheduled for removal in Umbraco 19.")]
+    public Task<IEnumerable<BlockItemVariation>> AlignedExposeVarianceAsync(BlockValue blockValue, IPublishedElement owner, IPublishedElement element)
+        => AlignedExposeVarianceAsync(blockValue, owner, element, culture: null);
+
+    /// <summary>
+    /// Aligns a block value for variance changes.
+    /// </summary>
+    /// <param name="blockValue">The block property value to align for variance.</param>
+    /// <param name="owner">The owner element, which is either the content for block properties at the content level or the parent element for nested block properties.</param>
+    /// <param name="element">The block element containing the property.</param>
+    /// <param name="culture">The culture of the owning property value, or <c>null</c> when the owning property does not vary by culture.</param>
+    /// <returns>A task representing the asynchronous operation, with a result containing the aligned <see cref="BlockItemVariation"/> instances for the specified block element.</returns>
     /// <remarks>
     /// <para>Used for aligning block item variations according to variance (such as culture or segment) when rendering content.</para>
     /// <para>In case of mismatch in culture variation for block value variation:</para>
     /// <list type="bullet">
     /// <item><description>If the expected variation is by culture but all expose entries are invariant, assign the default culture.</description></item>
-    /// <item><description>If the expected variation is invariant but all expose entries have cultures, use the default culture entry as invariant.</description></item>
+    /// <item><description>If the expected variation is invariant but all expose entries have cultures, use the entry for <paramref name="culture"/> as invariant, falling back to the one for the default culture.</description></item>
     /// </list>
     /// </remarks>
-    public async Task<IEnumerable<BlockItemVariation>> AlignedExposeVarianceAsync(BlockValue blockValue, IPublishedElement owner, IPublishedElement element)
+    public async Task<IEnumerable<BlockItemVariation>> AlignedExposeVarianceAsync(BlockValue blockValue, IPublishedElement owner, IPublishedElement element, string? culture)
     {
         BlockItemVariation[] blockVariations = blockValue.Expose.Where(v => v.ContentKey == element.Key).ToArray();
         if (blockVariations.Any() is false)
@@ -142,9 +182,6 @@ public sealed class BlockEditorVarianceHandler
             return blockVariations;
         }
 
-        // In case of mismatch in culture variation for block value variation:
-        // - if the expected variation is by culture but all expose entries are invariant, assign the default culture
-        // - if the expected variation is invariant but all expose entries have cultures, use the default culture entry as invariant
         ContentVariation exposeVariation = owner.ContentType.Variations & element.ContentType.Variations;
         if (exposeVariation.VariesByCulture() && blockVariations.All(v => v.Culture is null))
         {
@@ -155,8 +192,13 @@ public sealed class BlockEditorVarianceHandler
         if (exposeVariation.VariesByCulture() is false && blockVariations.All(v => v.Culture is not null))
         {
             var defaultCulture = await _languageService.GetDefaultIsoCodeAsync();
-            return blockVariations
-                .Where(v => v.Culture == defaultCulture)
+            BlockItemVariation[] retainedVariations = blockVariations.Where(v => v.Culture.InvariantEquals(culture ?? defaultCulture)).ToArray();
+            if (retainedVariations.Length == 0)
+            {
+                retainedVariations = blockVariations.Where(v => v.Culture.InvariantEquals(defaultCulture)).ToArray();
+            }
+
+            return retainedVariations
                 .Select(v => new BlockItemVariation(v.ContentKey, null, v.Segment))
                 .ToList();
         }
@@ -168,6 +210,15 @@ public sealed class BlockEditorVarianceHandler
     /// Aligns block value expose for variance changes.
     /// </summary>
     /// <param name="blockValue">The block value to align.</param>
+    [Obsolete("Please use the overload that takes the culture being aligned. Scheduled for removal in Umbraco 19.")]
+    public void AlignExposeVariance(BlockValue blockValue)
+        => AlignExposeVariance(blockValue, culture: null);
+
+    /// <summary>
+    /// Aligns block value expose for variance changes.
+    /// </summary>
+    /// <param name="blockValue">The block value to align.</param>
+    /// <param name="culture">The culture of the property value being aligned (null if invariant).</param>
     /// <remarks>
     /// <para>
     /// Used for aligning variance changes when editing content.
@@ -175,8 +226,12 @@ public sealed class BlockEditorVarianceHandler
     /// <para>
     /// This is expected to be invoked after all block values have been aligned for variance changes by <see cref="AlignPropertyVarianceAsync"/>.
     /// </para>
+    /// <para>
+    /// A block that holds no property values has no value variance to derive its expose entries from, so it is
+    /// exposed for <paramref name="culture"/> when its element type varies by culture, and invariantly when it does not.
+    /// </para>
     /// </remarks>
-    public void AlignExposeVariance(BlockValue blockValue)
+    public void AlignExposeVariance(BlockValue blockValue, string? culture)
     {
         var contentDataToAlign = new List<BlockItemData>();
         var elementTypesByKey = blockValue
@@ -205,7 +260,8 @@ public sealed class BlockEditorVarianceHandler
                 continue;
             }
 
-            if ((variation.Culture is null && contentData.Values.Any(v => v.Culture is not null)) ||
+            if (contentData.Values.Count == 0 ||
+                (variation.Culture is null && contentData.Values.Any(v => v.Culture is not null)) ||
                 (variation.Culture is not null && contentData.Values.All(v => v.Culture is null)))
             {
                 contentDataToAlign.Add(contentData);
@@ -222,11 +278,23 @@ public sealed class BlockEditorVarianceHandler
             foreach (BlockItemData contentData in contentDataToAlign)
             {
                 var omitNullCulture = contentData.Values.Any(v => v.Culture is not null);
-                foreach (BlockPropertyValue value in contentData.Values
+                var alignedVariations = contentData.Values
                     .Where(v => omitNullCulture is false || v.Culture is not null)
-                    .DistinctBy(v => v.Culture + v.Segment))
+                    .DistinctBy(v => v.Culture + v.Segment)
+                    .Select(v => new BlockItemVariation(contentData.Key, v.Culture, v.Segment))
+                    .ToList();
+
+                if (alignedVariations.Count == 0)
                 {
-                    blockValue.Expose.Add(new BlockItemVariation(contentData.Key, value.Culture, value.Segment));
+                    alignedVariations.Add(new BlockItemVariation(
+                        contentData.Key,
+                        elementTypesByKey[contentData.ContentTypeKey].VariesByCulture() ? culture : null,
+                        null));
+                }
+
+                foreach (BlockItemVariation alignedVariation in alignedVariations)
+                {
+                    blockValue.Expose.Add(alignedVariation);
                 }
             }
         }
@@ -236,4 +304,22 @@ public sealed class BlockEditorVarianceHandler
 
     private static bool VariesByCulture(BlockPropertyValue blockPropertyValue)
         => blockPropertyValue.Culture.IsNullOrWhiteSpace() is false;
+
+    private static BlockPropertyValue? ValueToRetain(
+        IEnumerable<BlockPropertyValue> blockPropertyValues,
+        IGrouping<(string Alias, string? Segment), BlockPropertyValue> collapsingValues,
+        string culture,
+        string defaultIsoCode)
+    {
+        // an explicitly invariant value already covers the property, so the culture specific ones are leftovers
+        var hasInvariantValue = blockPropertyValues.Any(blockPropertyValue
+            => blockPropertyValue.Alias == collapsingValues.Key.Alias
+               && blockPropertyValue.Segment == collapsingValues.Key.Segment
+               && VariesByCulture(blockPropertyValue) is false);
+
+        return hasInvariantValue
+            ? null
+            : collapsingValues.FirstOrDefault(blockPropertyValue => blockPropertyValue.Culture.InvariantEquals(culture))
+              ?? collapsingValues.FirstOrDefault(blockPropertyValue => blockPropertyValue.Culture.InvariantEquals(defaultIsoCode));
+    }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
@@ -149,7 +149,6 @@ public sealed class BlockEditorVarianceHandler
             IPublishedPropertyType? propertyType = elementType.GetPropertyType(group.Key.Alias);
             if (propertyType is null)
             {
-                alignedValues.AddRange(group);
                 continue;
             }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
@@ -105,11 +105,14 @@ public sealed class BlockEditorVarianceHandler
             return blockPropertyValue;
         }
 
-        return variation.VariesByCulture()
-            ? WithCulture(blockPropertyValue, defaultCulture)
-            : defaultCulture.InvariantEquals(blockPropertyValue.Culture)
-                ? WithCulture(blockPropertyValue, null)
-                : null;
+        if (variation.VariesByCulture())
+        {
+            return WithCulture(blockPropertyValue, defaultCulture);
+        }
+
+        return defaultCulture.InvariantEquals(blockPropertyValue.Culture)
+            ? WithCulture(blockPropertyValue, null)
+            : null;
     }
 
     /// <summary>
@@ -262,7 +265,6 @@ public sealed class BlockEditorVarianceHandler
     /// </remarks>
     public void AlignExposeVariance(BlockValue blockValue, string? culture)
     {
-        var contentDataToAlign = new List<BlockItemData>();
         var elementTypesByKey = blockValue
             .ContentData
             .Select(cd => cd.ContentTypeKey)
@@ -271,31 +273,11 @@ public sealed class BlockEditorVarianceHandler
             .WhereNotNull()
             .ToDictionary(c => c.Key);
 
-        foreach (BlockItemVariation variation in blockValue.Expose)
-        {
-            BlockItemData? contentData = blockValue.ContentData.FirstOrDefault(cd => cd.Key == variation.ContentKey);
-            if (contentData is null)
-            {
-                continue;
-            }
-
-            if (elementTypesByKey.TryGetValue(contentData.ContentTypeKey, out IContentType? elementType) is false)
-            {
-                continue;
-            }
-
-            if ((variation.Culture is not null) == elementType.VariesByCulture())
-            {
-                continue;
-            }
-
-            if (contentData.Values.Count == 0 ||
-                (variation.Culture is null && contentData.Values.Any(v => v.Culture is not null)) ||
-                (variation.Culture is not null && contentData.Values.All(v => v.Culture is null)))
-            {
-                contentDataToAlign.Add(contentData);
-            }
-        }
+        List<BlockItemData> contentDataToAlign = blockValue.Expose
+            .Select(variation => ContentDataToAlign(blockValue, elementTypesByKey, variation))
+            .WhereNotNull()
+            .DistinctBy(contentData => contentData.Key)
+            .ToList();
 
         // Remove expose entries that don't have matching entries in the block value's content data.
         var validContentKeys = blockValue.ContentData.Select(cd => cd.Key).ToHashSet();
@@ -303,33 +285,16 @@ public sealed class BlockEditorVarianceHandler
 
         if (contentDataToAlign.Count > 0)
         {
-            var replacedVariations = blockValue.Expose
-                .Where(v => contentDataToAlign.Any(cd => cd.Key == v.ContentKey))
+            var contentKeysToAlign = contentDataToAlign.Select(cd => cd.Key).ToHashSet();
+            List<BlockItemVariation> replacedVariations = blockValue.Expose
+                .Where(v => contentKeysToAlign.Contains(v.ContentKey))
                 .ToList();
-            blockValue.Expose.RemoveAll(v => contentDataToAlign.Any(cd => cd.Key == v.ContentKey));
+            blockValue.Expose.RemoveAll(v => contentKeysToAlign.Contains(v.ContentKey));
+
             foreach (BlockItemData contentData in contentDataToAlign)
             {
-                var omitNullCulture = contentData.Values.Any(v => v.Culture is not null);
-                var alignedVariations = contentData.Values
-                    .Where(v => omitNullCulture is false || v.Culture is not null)
-                    .DistinctBy(v => v.Culture + v.Segment)
-                    .Select(v => new BlockItemVariation(contentData.Key, v.Culture, v.Segment))
-                    .ToList();
-
-                if (alignedVariations.Count == 0)
-                {
-                    // a block without property values has no value variance to align against, so keep it exposed for
-                    // the element type's variance, retaining the segments it was exposed for
-                    var alignedCulture = elementTypesByKey[contentData.ContentTypeKey].VariesByCulture() ? culture : null;
-                    alignedVariations.AddRange(replacedVariations
-                        .Where(v => v.ContentKey == contentData.Key)
-                        .Select(v => v.Segment)
-                        .DefaultIfEmpty(null)
-                        .Distinct()
-                        .Select(segment => new BlockItemVariation(contentData.Key, alignedCulture, segment)));
-                }
-
-                foreach (BlockItemVariation alignedVariation in alignedVariations)
+                IContentType elementType = elementTypesByKey[contentData.ContentTypeKey];
+                foreach (BlockItemVariation alignedVariation in AlignedExposeVariations(contentData, elementType, replacedVariations, culture))
                 {
                     blockValue.Expose.Add(alignedVariation);
                 }
@@ -337,6 +302,61 @@ public sealed class BlockEditorVarianceHandler
         }
 
         blockValue.Expose = blockValue.Expose.DistinctBy(e => $"{e.ContentKey}.{e.Culture}.{e.Segment}").ToList();
+    }
+
+    /// <summary>
+    /// Determines whether an expose entry's block requires realignment, returning the block's content data when it does.
+    /// </summary>
+    private static BlockItemData? ContentDataToAlign(
+        BlockValue blockValue,
+        IReadOnlyDictionary<Guid, IContentType> elementTypesByKey,
+        BlockItemVariation variation)
+    {
+        BlockItemData? contentData = blockValue.ContentData.FirstOrDefault(cd => cd.Key == variation.ContentKey);
+        if (contentData is null
+            || elementTypesByKey.TryGetValue(contentData.ContentTypeKey, out IContentType? elementType) is false
+            || (variation.Culture is not null) == elementType.VariesByCulture())
+        {
+            return null;
+        }
+
+        var requiresAlignment = contentData.Values.Count == 0
+                                || (variation.Culture is null && contentData.Values.Any(v => v.Culture is not null))
+                                || (variation.Culture is not null && contentData.Values.All(v => v.Culture is null));
+
+        return requiresAlignment ? contentData : null;
+    }
+
+    /// <summary>
+    /// Builds the expose entries for a block, derived from the variance of its property values.
+    /// </summary>
+    private static IEnumerable<BlockItemVariation> AlignedExposeVariations(
+        BlockItemData contentData,
+        IContentType elementType,
+        IEnumerable<BlockItemVariation> replacedVariations,
+        string? culture)
+    {
+        var omitNullCulture = contentData.Values.Any(v => v.Culture is not null);
+        List<BlockItemVariation> alignedVariations = contentData.Values
+            .Where(v => omitNullCulture is false || v.Culture is not null)
+            .DistinctBy(v => v.Culture + v.Segment)
+            .Select(v => new BlockItemVariation(contentData.Key, v.Culture, v.Segment))
+            .ToList();
+
+        if (alignedVariations.Count > 0)
+        {
+            return alignedVariations;
+        }
+
+        // a block without property values has no value variance to align against, so keep it exposed for the element
+        // type's variance, retaining the segments it was exposed for
+        var alignedCulture = elementType.VariesByCulture() ? culture : null;
+        return replacedVariations
+            .Where(v => v.ContentKey == contentData.Key)
+            .Select(v => v.Segment)
+            .DefaultIfEmpty(null)
+            .Distinct()
+            .Select(segment => new BlockItemVariation(contentData.Key, alignedCulture, segment));
     }
 
     private static bool VariesByCulture(BlockPropertyValue blockPropertyValue)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorVarianceHandler.cs
@@ -155,19 +155,24 @@ public sealed class BlockEditorVarianceHandler
             ContentVariation variation = owner.ContentType.Variations & propertyType.Variations;
             if (variation.VariesByCulture())
             {
+                // The property type and the owning content both vary by culture, ensure culture variance accordingly.
                 alignedValues.AddRange(group.Select(blockPropertyValue => VariesByCulture(blockPropertyValue)
                     ? blockPropertyValue
                     : WithCulture(blockPropertyValue, alignmentCulture)));
                 continue;
             }
 
-            // the property type no longer varies by culture, so only a single value can survive
+            // Culture variance is not applicable, so it's safe to add the values that do not vary by culture.
             alignedValues.AddRange(group.Where(blockPropertyValue => VariesByCulture(blockPropertyValue) is false));
             if (group.Any(blockPropertyValue => VariesByCulture(blockPropertyValue) is false))
             {
+                // Nothing to align here.
                 continue;
             }
 
+            // A culture variation mismatch between the stored value and the current (effective) variance, likely caused
+            // by a schema change. Only a single value can survive; prioritize an exact culture match, fallback to the
+            // default culture.
             BlockPropertyValue? valueToRetain = ValueToRetain(group, alignmentCulture, defaultCulture);
             if (valueToRetain is not null)
             {

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
@@ -156,7 +156,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
                 }
 
                 var creator = new BlockGridPropertyValueCreator(_blockConverter, _variationContextAccessor, _propertyRenderingContextAccessor, _blockEditorVarianceHandler, _jsonSerializer, _constructorCache, _languageService);
-                return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, propertyType.VariesByCulture(), configuration.Blocks, configuration.GridColumns).GetAwaiter().GetResult();
+                return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, BlockPropertyVariance.OwningPropertyCulture(_variationContextAccessor, owner, propertyType), configuration.Blocks, configuration.GridColumns).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueConverter.cs
@@ -156,7 +156,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters
                 }
 
                 var creator = new BlockGridPropertyValueCreator(_blockConverter, _variationContextAccessor, _propertyRenderingContextAccessor, _blockEditorVarianceHandler, _jsonSerializer, _constructorCache, _languageService);
-                return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, configuration.Blocks, configuration.GridColumns).GetAwaiter().GetResult();
+                return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, propertyType.VariesByCulture(), configuration.Blocks, configuration.GridColumns).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
@@ -41,10 +41,11 @@ internal sealed class BlockGridPropertyValueCreator : BlockPropertyValueCreatorB
     /// <param name="referenceCacheLevel">The <see cref="PropertyCacheLevel"/> to use when resolving references within the block grid.</param>
     /// <param name="intermediateBlockModelValue">A string containing the intermediate (typically JSON) representation of the block grid's data.</param>
     /// <param name="preview">True if the model should be created in preview mode; otherwise, false.</param>
+    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture.</param>
     /// <param name="blockConfigurations">An array of <see cref="BlockGridConfiguration.BlockGridBlockConfiguration"/> objects that define the available block types and their settings.</param>
     /// <param name="gridColumns">The number of columns in the grid layout, or null to use the default configuration.</param>
     /// <returns>A <see cref="BlockGridModel"/> representing the structured block grid data for the given property and configuration.</returns>
-    public async Task<BlockGridModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, BlockGridConfiguration.BlockGridBlockConfiguration[] blockConfigurations, int? gridColumns)
+    public async Task<BlockGridModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, bool owningPropertyVariesByCulture, BlockGridConfiguration.BlockGridBlockConfiguration[] blockConfigurations, int? gridColumns)
     {
         BlockGridModel CreateEmptyModel() => BlockGridModel.Empty;
 
@@ -81,6 +82,7 @@ internal sealed class BlockGridPropertyValueCreator : BlockPropertyValueCreatorB
             referenceCacheLevel,
             intermediateBlockModelValue,
             preview,
+            owningPropertyVariesByCulture,
             blockConfigurations,
             CreateEmptyModel,
             CreateModel,

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
@@ -41,11 +41,11 @@ internal sealed class BlockGridPropertyValueCreator : BlockPropertyValueCreatorB
     /// <param name="referenceCacheLevel">The <see cref="PropertyCacheLevel"/> to use when resolving references within the block grid.</param>
     /// <param name="intermediateBlockModelValue">A string containing the intermediate (typically JSON) representation of the block grid's data.</param>
     /// <param name="preview">True if the model should be created in preview mode; otherwise, false.</param>
-    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture.</param>
+    /// <param name="owningPropertyCulture">The culture of the stored property value the block value was loaded from, or <c>null</c> when the property does not vary by culture.</param>
     /// <param name="blockConfigurations">An array of <see cref="BlockGridConfiguration.BlockGridBlockConfiguration"/> objects that define the available block types and their settings.</param>
     /// <param name="gridColumns">The number of columns in the grid layout, or null to use the default configuration.</param>
     /// <returns>A <see cref="BlockGridModel"/> representing the structured block grid data for the given property and configuration.</returns>
-    public async Task<BlockGridModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, bool owningPropertyVariesByCulture, BlockGridConfiguration.BlockGridBlockConfiguration[] blockConfigurations, int? gridColumns)
+    public async Task<BlockGridModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, string? owningPropertyCulture, BlockGridConfiguration.BlockGridBlockConfiguration[] blockConfigurations, int? gridColumns)
     {
         BlockGridModel CreateEmptyModel() => BlockGridModel.Empty;
 
@@ -82,7 +82,7 @@ internal sealed class BlockGridPropertyValueCreator : BlockPropertyValueCreatorB
             referenceCacheLevel,
             intermediateBlockModelValue,
             preview,
-            owningPropertyVariesByCulture,
+            owningPropertyCulture,
             blockConfigurations,
             CreateEmptyModel,
             CreateModel,

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -197,7 +197,7 @@ public class BlockListPropertyValueConverter : PropertyValueConverterBase, IDeli
             }
 
             var creator = new BlockListPropertyValueCreator(_blockConverter, _variationContextAccessor, _propertyRenderingContextAccessor, _blockEditorVarianceHandler, _jsonSerializer, _constructorCache, _languageService);
-            return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, propertyType.VariesByCulture(), configuration.Blocks).GetAwaiter().GetResult();
+            return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, BlockPropertyVariance.OwningPropertyCulture(_variationContextAccessor, owner, propertyType), configuration.Blocks).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueConverter.cs
@@ -197,7 +197,7 @@ public class BlockListPropertyValueConverter : PropertyValueConverterBase, IDeli
             }
 
             var creator = new BlockListPropertyValueCreator(_blockConverter, _variationContextAccessor, _propertyRenderingContextAccessor, _blockEditorVarianceHandler, _jsonSerializer, _constructorCache, _languageService);
-            return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, configuration.Blocks).GetAwaiter().GetResult();
+            return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, propertyType.VariesByCulture(), configuration.Blocks).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueCreator.cs
@@ -40,16 +40,16 @@ internal sealed class BlockListPropertyValueCreator : BlockPropertyValueCreatorB
     /// <param name="referenceCacheLevel">The cache level to use for property references during model creation.</param>
     /// <param name="intermediateBlockModelValue">A string containing the serialized intermediate value representing the block list.</param>
     /// <param name="preview">True if the model should be created in preview mode; otherwise, false.</param>
-    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture.</param>
+    /// <param name="owningPropertyCulture">The culture of the stored property value the block value was loaded from, or <c>null</c> when the property does not vary by culture.</param>
     /// <param name="blockConfigurations">An array of <see cref="BlockListConfiguration.BlockConfiguration"/> objects used to configure the blocks.</param>
     /// <returns>A <see cref="BlockListModel"/> instance representing the constructed block list.</returns>
-    public async Task<BlockListModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, bool owningPropertyVariesByCulture, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
+    public async Task<BlockListModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, string? owningPropertyCulture, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
     {
         BlockListModel CreateEmptyModel() => BlockListModel.Empty;
 
         BlockListModel CreateModel(IList<BlockListItem> items) => new BlockListModel(items);
 
-        BlockListModel blockModel = await CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, owningPropertyVariesByCulture, blockConfigurations, CreateEmptyModel, CreateModel);
+        BlockListModel blockModel = await CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, owningPropertyCulture, blockConfigurations, CreateEmptyModel, CreateModel);
 
         return blockModel;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueCreator.cs
@@ -40,15 +40,16 @@ internal sealed class BlockListPropertyValueCreator : BlockPropertyValueCreatorB
     /// <param name="referenceCacheLevel">The cache level to use for property references during model creation.</param>
     /// <param name="intermediateBlockModelValue">A string containing the serialized intermediate value representing the block list.</param>
     /// <param name="preview">True if the model should be created in preview mode; otherwise, false.</param>
+    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture.</param>
     /// <param name="blockConfigurations">An array of <see cref="BlockListConfiguration.BlockConfiguration"/> objects used to configure the blocks.</param>
     /// <returns>A <see cref="BlockListModel"/> instance representing the constructed block list.</returns>
-    public async Task<BlockListModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
+    public async Task<BlockListModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, bool owningPropertyVariesByCulture, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
     {
         BlockListModel CreateEmptyModel() => BlockListModel.Empty;
 
         BlockListModel CreateModel(IList<BlockListItem> items) => new BlockListModel(items);
 
-        BlockListModel blockModel = await CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, blockConfigurations, CreateEmptyModel, CreateModel);
+        BlockListModel blockModel = await CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, owningPropertyVariesByCulture, blockConfigurations, CreateEmptyModel, CreateModel);
 
         return blockModel;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockPropertyValueCreatorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockPropertyValueCreatorBase.cs
@@ -80,7 +80,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
         PropertyCacheLevel referenceCacheLevel,
         string intermediateBlockModelValue,
         bool preview,
-        bool owningPropertyVariesByCulture,
+        string? owningPropertyCulture,
         IEnumerable<TBlockConfiguration> blockConfigurations,
         CreateEmptyBlockModel createEmptyModel,
         CreateBlockModelFromItems createModelFromItems,
@@ -94,7 +94,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
 
         BlockEditorDataConverter<TBlockValue, TBlockLayoutItem> blockEditorDataConverter = CreateBlockEditorDataConverter();
         BlockEditorData<TBlockValue, TBlockLayoutItem> converted = blockEditorDataConverter.Deserialize(intermediateBlockModelValue);
-        return await CreateBlockModelAsync(owner, referenceCacheLevel, converted, preview, owningPropertyVariesByCulture, blockConfigurations, createEmptyModel, createModelFromItems, enrichBlockItem);
+        return await CreateBlockModelAsync(owner, referenceCacheLevel, converted, preview, owningPropertyCulture, blockConfigurations, createEmptyModel, createModelFromItems, enrichBlockItem);
     }
 
     protected async Task<TBlockModel> CreateBlockModelAsync(
@@ -102,7 +102,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
         PropertyCacheLevel referenceCacheLevel,
         TBlockValue blockValue,
         bool preview,
-        bool owningPropertyVariesByCulture,
+        string? owningPropertyCulture,
         IEnumerable<TBlockConfiguration> blockConfigurations,
         CreateEmptyBlockModel createEmptyModel,
         CreateBlockModelFromItems createModelFromItems,
@@ -110,7 +110,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
     {
         BlockEditorDataConverter<TBlockValue, TBlockLayoutItem> blockEditorDataConverter = CreateBlockEditorDataConverter();
         BlockEditorData<TBlockValue, TBlockLayoutItem> converted = blockEditorDataConverter.Convert(blockValue);
-        return await CreateBlockModelAsync(owner, referenceCacheLevel, converted, preview, owningPropertyVariesByCulture, blockConfigurations, createEmptyModel, createModelFromItems, enrichBlockItem);
+        return await CreateBlockModelAsync(owner, referenceCacheLevel, converted, preview, owningPropertyCulture, blockConfigurations, createEmptyModel, createModelFromItems, enrichBlockItem);
     }
 
     private async Task<TBlockModel> CreateBlockModelAsync(
@@ -118,7 +118,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
         PropertyCacheLevel referenceCacheLevel,
         BlockEditorData<TBlockValue, TBlockLayoutItem> converted,
         bool preview,
-        bool owningPropertyVariesByCulture,
+        string? owningPropertyCulture,
         IEnumerable<TBlockConfiguration> blockConfigurations,
         CreateEmptyBlockModel createEmptyModel,
         CreateBlockModelFromItems createModelFromItems,
@@ -149,7 +149,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
                 continue;
             }
 
-            IPublishedElement? element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyVariesByCulture);
+            IPublishedElement? element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyCulture);
             if (element == null)
             {
                 continue;
@@ -161,7 +161,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
                 converted.BlockValue,
                 owner,
                 element,
-                owningPropertyVariesByCulture ? variationContext.Culture : null);
+                owningPropertyCulture);
             var expectedBlockVariationCulture = owner.ContentType.VariesByCulture() && element.ContentType.VariesByCulture()
                 ? variationContext.Culture.NullOrWhiteSpaceAsNull()
                 : null;
@@ -183,7 +183,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
                 try
                 {
                     _variationContextAccessor.VariationContext = new VariationContext(resolvedCulture, originalContext?.Segment);
-                    element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyVariesByCulture);
+                    element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyCulture);
                     if (element is null)
                     {
                         continue;
@@ -215,7 +215,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
                 continue;
             }
 
-            IPublishedElement? element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyVariesByCulture);
+            IPublishedElement? element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyCulture);
             if (element is null)
             {
                 continue;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockPropertyValueCreatorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockPropertyValueCreatorBase.cs
@@ -80,6 +80,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
         PropertyCacheLevel referenceCacheLevel,
         string intermediateBlockModelValue,
         bool preview,
+        bool owningPropertyVariesByCulture,
         IEnumerable<TBlockConfiguration> blockConfigurations,
         CreateEmptyBlockModel createEmptyModel,
         CreateBlockModelFromItems createModelFromItems,
@@ -93,7 +94,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
 
         BlockEditorDataConverter<TBlockValue, TBlockLayoutItem> blockEditorDataConverter = CreateBlockEditorDataConverter();
         BlockEditorData<TBlockValue, TBlockLayoutItem> converted = blockEditorDataConverter.Deserialize(intermediateBlockModelValue);
-        return await CreateBlockModelAsync(owner, referenceCacheLevel, converted, preview, blockConfigurations, createEmptyModel, createModelFromItems, enrichBlockItem);
+        return await CreateBlockModelAsync(owner, referenceCacheLevel, converted, preview, owningPropertyVariesByCulture, blockConfigurations, createEmptyModel, createModelFromItems, enrichBlockItem);
     }
 
     protected async Task<TBlockModel> CreateBlockModelAsync(
@@ -101,6 +102,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
         PropertyCacheLevel referenceCacheLevel,
         TBlockValue blockValue,
         bool preview,
+        bool owningPropertyVariesByCulture,
         IEnumerable<TBlockConfiguration> blockConfigurations,
         CreateEmptyBlockModel createEmptyModel,
         CreateBlockModelFromItems createModelFromItems,
@@ -108,7 +110,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
     {
         BlockEditorDataConverter<TBlockValue, TBlockLayoutItem> blockEditorDataConverter = CreateBlockEditorDataConverter();
         BlockEditorData<TBlockValue, TBlockLayoutItem> converted = blockEditorDataConverter.Convert(blockValue);
-        return await CreateBlockModelAsync(owner, referenceCacheLevel, converted, preview, blockConfigurations, createEmptyModel, createModelFromItems, enrichBlockItem);
+        return await CreateBlockModelAsync(owner, referenceCacheLevel, converted, preview, owningPropertyVariesByCulture, blockConfigurations, createEmptyModel, createModelFromItems, enrichBlockItem);
     }
 
     private async Task<TBlockModel> CreateBlockModelAsync(
@@ -116,6 +118,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
         PropertyCacheLevel referenceCacheLevel,
         BlockEditorData<TBlockValue, TBlockLayoutItem> converted,
         bool preview,
+        bool owningPropertyVariesByCulture,
         IEnumerable<TBlockConfiguration> blockConfigurations,
         CreateEmptyBlockModel createEmptyModel,
         CreateBlockModelFromItems createModelFromItems,
@@ -146,7 +149,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
                 continue;
             }
 
-            IPublishedElement? element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview);
+            IPublishedElement? element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyVariesByCulture);
             if (element == null)
             {
                 continue;
@@ -154,7 +157,11 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
 
             // if case changes have been made to the content or element type variation since the content was published,
             // we need to align those changes for the exposed blocks.
-            IEnumerable<BlockItemVariation> expose = await _blockEditorVarianceHandler.AlignedExposeVarianceAsync(converted.BlockValue, owner, element);
+            IEnumerable<BlockItemVariation> expose = await _blockEditorVarianceHandler.AlignedExposeVarianceAsync(
+                converted.BlockValue,
+                owner,
+                element,
+                owningPropertyVariesByCulture ? variationContext.Culture : null);
             var expectedBlockVariationCulture = owner.ContentType.VariesByCulture() && element.ContentType.VariesByCulture()
                 ? variationContext.Culture.NullOrWhiteSpaceAsNull()
                 : null;
@@ -176,7 +183,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
                 try
                 {
                     _variationContextAccessor.VariationContext = new VariationContext(resolvedCulture, originalContext?.Segment);
-                    element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview);
+                    element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyVariesByCulture);
                     if (element is null)
                     {
                         continue;
@@ -208,7 +215,7 @@ internal abstract class BlockPropertyValueCreatorBase<TBlockModel, TBlockItemMod
                 continue;
             }
 
-            IPublishedElement? element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview);
+            IPublishedElement? element = BlockEditorConverter.ConvertToElement(owner, data, referenceCacheLevel, preview, owningPropertyVariesByCulture);
             if (element is null)
             {
                 continue;

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockPropertyVariance.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockPropertyVariance.cs
@@ -7,6 +7,9 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
+/// <summary>
+/// Helpers for resolving the effective variance of a property holding a block editor value.
+/// </summary>
 internal static class BlockPropertyVariance
 {
     /// <summary>
@@ -20,6 +23,10 @@ internal static class BlockPropertyVariance
     /// stored value and there is no owning culture.
     /// </para>
     /// </remarks>
+    /// <param name="variationContextAccessor">Accessor for the current variation context.</param>
+    /// <param name="owner">The content or element that owns the block property.</param>
+    /// <param name="propertyType">The property type holding the block value.</param>
+    /// <returns>The culture the stored property value belongs to, or <c>null</c> when the property does not vary by culture.</returns>
     public static string? OwningPropertyCulture(
         IVariationContextAccessor variationContextAccessor,
         IPublishedElement owner,

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockPropertyVariance.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockPropertyVariance.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+internal static class BlockPropertyVariance
+{
+    /// <summary>
+    /// Resolves the culture of the stored property value a block value was loaded from.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A block property only stores its cultures separately when it actually varies by culture, which is its own
+    /// variance narrowed by the variance of the content type it belongs to - <see cref="IPublishedPropertyType.Variations"/>
+    /// carries the property's own flag, unintersected. When the property does not vary, every culture shares a single
+    /// stored value and there is no owning culture.
+    /// </para>
+    /// </remarks>
+    public static string? OwningPropertyCulture(
+        IVariationContextAccessor variationContextAccessor,
+        IPublishedElement owner,
+        IPublishedPropertyType propertyType)
+        => (owner.ContentType.Variations & propertyType.Variations).VariesByCulture()
+            ? variationContextAccessor.VariationContext?.Culture
+            : null;
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
@@ -43,15 +43,16 @@ internal sealed class RichTextBlockPropertyValueCreator : BlockPropertyValueCrea
     /// <param name="referenceCacheLevel">The cache level to use for property references during model creation.</param>
     /// <param name="blockValue">The <see cref="RichTextBlockValue"/> representing the value to convert.</param>
     /// <param name="preview">True to create the model in preview mode; otherwise, false.</param>
+    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture.</param>
     /// <param name="blockConfigurations">An array of <see cref="RichTextConfiguration.RichTextBlockConfiguration"/> objects that define the configuration for each block type.</param>
     /// <returns>A <see cref="RichTextBlockModel"/> that represents the parsed and configured block content, or <see cref="RichTextBlockModel.Empty"/> if the value is invalid or empty.</returns>
-    public async Task<RichTextBlockModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, RichTextBlockValue blockValue, bool preview, RichTextConfiguration.RichTextBlockConfiguration[] blockConfigurations)
+    public async Task<RichTextBlockModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, RichTextBlockValue blockValue, bool preview, bool owningPropertyVariesByCulture, RichTextConfiguration.RichTextBlockConfiguration[] blockConfigurations)
     {
         RichTextBlockModel CreateEmptyModel() => RichTextBlockModel.Empty;
 
         RichTextBlockModel CreateModel(IList<RichTextBlockItem> items) => new RichTextBlockModel(items);
 
-        RichTextBlockModel blockModel = await CreateBlockModelAsync(owner, referenceCacheLevel, blockValue, preview, blockConfigurations, CreateEmptyModel, CreateModel);
+        RichTextBlockModel blockModel = await CreateBlockModelAsync(owner, referenceCacheLevel, blockValue, preview, owningPropertyVariesByCulture, blockConfigurations, CreateEmptyModel, CreateModel);
 
         return blockModel;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
@@ -43,16 +43,16 @@ internal sealed class RichTextBlockPropertyValueCreator : BlockPropertyValueCrea
     /// <param name="referenceCacheLevel">The cache level to use for property references during model creation.</param>
     /// <param name="blockValue">The <see cref="RichTextBlockValue"/> representing the value to convert.</param>
     /// <param name="preview">True to create the model in preview mode; otherwise, false.</param>
-    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture.</param>
+    /// <param name="owningPropertyCulture">The culture of the stored property value the block value was loaded from, or <c>null</c> when the property does not vary by culture.</param>
     /// <param name="blockConfigurations">An array of <see cref="RichTextConfiguration.RichTextBlockConfiguration"/> objects that define the configuration for each block type.</param>
     /// <returns>A <see cref="RichTextBlockModel"/> that represents the parsed and configured block content, or <see cref="RichTextBlockModel.Empty"/> if the value is invalid or empty.</returns>
-    public async Task<RichTextBlockModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, RichTextBlockValue blockValue, bool preview, bool owningPropertyVariesByCulture, RichTextConfiguration.RichTextBlockConfiguration[] blockConfigurations)
+    public async Task<RichTextBlockModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, RichTextBlockValue blockValue, bool preview, string? owningPropertyCulture, RichTextConfiguration.RichTextBlockConfiguration[] blockConfigurations)
     {
         RichTextBlockModel CreateEmptyModel() => RichTextBlockModel.Empty;
 
         RichTextBlockModel CreateModel(IList<RichTextBlockItem> items) => new RichTextBlockModel(items);
 
-        RichTextBlockModel blockModel = await CreateBlockModelAsync(owner, referenceCacheLevel, blockValue, preview, owningPropertyVariesByCulture, blockConfigurations, CreateEmptyModel, CreateModel);
+        RichTextBlockModel blockModel = await CreateBlockModelAsync(owner, referenceCacheLevel, blockValue, preview, owningPropertyCulture, blockConfigurations, CreateEmptyModel, CreateModel);
 
         return blockModel;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
@@ -329,7 +329,7 @@ public class RteBlockRenderingValueConverter : SimpleRichTextValueConverter, IDe
         }
 
         var creator = new RichTextBlockPropertyValueCreator(_blockEditorConverter, _variationContextAccessor, _propertyRenderingContextAccessor, _blockEditorVarianceHandler, _jsonSerializer, _constructorCache, _languageService);
-        return creator.CreateBlockModelAsync(owner, referenceCacheLevel, blocks, preview, propertyType.VariesByCulture(), configuration.Blocks).GetAwaiter().GetResult();
+        return creator.CreateBlockModelAsync(owner, referenceCacheLevel, blocks, preview, BlockPropertyVariance.OwningPropertyCulture(_variationContextAccessor, owner, propertyType), configuration.Blocks).GetAwaiter().GetResult();
     }
 
     private string RenderRichTextBlockModel(string source, RichTextBlockModel? richTextBlockModel)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
@@ -329,7 +329,7 @@ public class RteBlockRenderingValueConverter : SimpleRichTextValueConverter, IDe
         }
 
         var creator = new RichTextBlockPropertyValueCreator(_blockEditorConverter, _variationContextAccessor, _propertyRenderingContextAccessor, _blockEditorVarianceHandler, _jsonSerializer, _constructorCache, _languageService);
-        return creator.CreateBlockModelAsync(owner, referenceCacheLevel, blocks, preview, configuration.Blocks).GetAwaiter().GetResult();
+        return creator.CreateBlockModelAsync(owner, referenceCacheLevel, blocks, preview, propertyType.VariesByCulture(), configuration.Blocks).GetAwaiter().GetResult();
     }
 
     private string RenderRichTextBlockModel(string source, RichTextBlockModel? richTextBlockModel)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/SingleBlockPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/SingleBlockPropertyValueConverter.cs
@@ -150,7 +150,7 @@ public class SingleBlockPropertyValueConverter : PropertyValueConverterBase, IDe
 
 
             var creator = new SingleBlockPropertyValueCreator(_blockConverter, _variationContextAccessor, _propertyRenderingContextAccessor, _blockEditorVarianceHandler, _jsonSerializer, _constructorCache, _languageService);
-            return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, propertyType.VariesByCulture(), configuration.Blocks).GetAwaiter().GetResult();
+            return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, BlockPropertyVariance.OwningPropertyCulture(_variationContextAccessor, owner, propertyType), configuration.Blocks).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/SingleBlockPropertyValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/SingleBlockPropertyValueConverter.cs
@@ -150,7 +150,7 @@ public class SingleBlockPropertyValueConverter : PropertyValueConverterBase, IDe
 
 
             var creator = new SingleBlockPropertyValueCreator(_blockConverter, _variationContextAccessor, _propertyRenderingContextAccessor, _blockEditorVarianceHandler, _jsonSerializer, _constructorCache, _languageService);
-            return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, configuration.Blocks).GetAwaiter().GetResult();
+            return creator.CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, propertyType.VariesByCulture(), configuration.Blocks).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/SingleBlockPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/SingleBlockPropertyValueCreator.cs
@@ -42,15 +42,16 @@ internal sealed class SingleBlockPropertyValueCreator : BlockPropertyValueCreato
     /// <param name="referenceCacheLevel">The cache level to use for property references.</param>
     /// <param name="intermediateBlockModelValue">The intermediate block model value as a string, typically JSON.</param>
     /// <param name="preview">True if the model is being created for preview purposes; otherwise, false.</param>
+    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture.</param>
     /// <param name="blockConfigurations">An array of <see cref="BlockListConfiguration.BlockConfiguration"/> objects to use when creating the model.</param>
     /// <returns>A single <see cref="BlockListItem"/> representing the block model, or <c>null</c> if none could be created.</returns>
-    public async Task<BlockListItem?> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
+    public async Task<BlockListItem?> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, bool owningPropertyVariesByCulture, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
     {
         BlockListModel CreateEmptyModel() => BlockListModel.Empty;
 
         BlockListModel CreateModel(IList<BlockListItem> items) => new BlockListModel(items);
 
-        BlockListItem? blockModel = (await CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, blockConfigurations, CreateEmptyModel, CreateModel)).SingleOrDefault();
+        BlockListItem? blockModel = (await CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, owningPropertyVariesByCulture, blockConfigurations, CreateEmptyModel, CreateModel)).SingleOrDefault();
 
         return blockModel;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/SingleBlockPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/SingleBlockPropertyValueCreator.cs
@@ -42,16 +42,16 @@ internal sealed class SingleBlockPropertyValueCreator : BlockPropertyValueCreato
     /// <param name="referenceCacheLevel">The cache level to use for property references.</param>
     /// <param name="intermediateBlockModelValue">The intermediate block model value as a string, typically JSON.</param>
     /// <param name="preview">True if the model is being created for preview purposes; otherwise, false.</param>
-    /// <param name="owningPropertyVariesByCulture">Whether the property holding the block value varies by culture.</param>
+    /// <param name="owningPropertyCulture">The culture of the stored property value the block value was loaded from, or <c>null</c> when the property does not vary by culture.</param>
     /// <param name="blockConfigurations">An array of <see cref="BlockListConfiguration.BlockConfiguration"/> objects to use when creating the model.</param>
     /// <returns>A single <see cref="BlockListItem"/> representing the block model, or <c>null</c> if none could be created.</returns>
-    public async Task<BlockListItem?> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, bool owningPropertyVariesByCulture, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
+    public async Task<BlockListItem?> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, string? owningPropertyCulture, BlockListConfiguration.BlockConfiguration[] blockConfigurations)
     {
         BlockListModel CreateEmptyModel() => BlockListModel.Empty;
 
         BlockListModel CreateModel(IList<BlockListItem> items) => new BlockListModel(items);
 
-        BlockListItem? blockModel = (await CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, owningPropertyVariesByCulture, blockConfigurations, CreateEmptyModel, CreateModel)).SingleOrDefault();
+        BlockListItem? blockModel = (await CreateBlockModelAsync(owner, referenceCacheLevel, intermediateBlockModelValue, preview, owningPropertyCulture, blockConfigurations, CreateEmptyModel, CreateModel)).SingleOrDefault();
 
         return blockModel;
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
@@ -1466,9 +1466,11 @@ internal partial class BlockListElementLevelVariationTests
         });
     }
 
-    [TestCase("en-US", "Variant content in English", "Variant settings in English")]
-    [TestCase("da-DK", "Variant content in Danish", "Variant settings in Danish")]
-    public async Task Can_Turn_Variant_Element_Invariant_For_Variant_Block_Property(string culture, string expectedContentValue, string expectedSettingsValue)
+    [TestCase("en-US", "Variant content in English", "Variant settings in English", false)]
+    [TestCase("en-US", "Variant content in English", "Variant settings in English", true)]
+    [TestCase("da-DK", "Variant content in Danish", "Variant settings in Danish", false)]
+    [TestCase("da-DK", "Variant content in Danish", "Variant settings in Danish", true)]
+    public async Task Can_Turn_Variant_Element_Invariant_For_Variant_Block_Property(string culture, string expectedContentValue, string expectedSettingsValue, bool addCarriedPropertyValues)
     {
         var elementType = CreateElementType(ContentVariation.Culture);
         var blockListDataType = await CreateBlockListDataType(elementType);
@@ -1483,33 +1485,45 @@ internal partial class BlockListElementLevelVariationTests
             new[]
             {
                 new BlockProperty(
-                    new List<BlockPropertyValue>
-                    {
-                        new() { Alias = "invariantText", Value = "The invariant content value" },
-                        new() { Alias = "variantText", Value = "Variant content in English", Culture = "en-US" },
-                        new() { Alias = "variantText", Value = null, Culture = "da-DK" },
-                    },
-                    new List<BlockPropertyValue>
-                    {
-                        new() { Alias = "invariantText", Value = "The invariant settings value" },
-                        new() { Alias = "variantText", Value = "Variant settings in English", Culture = "en-US" },
-                        new() { Alias = "variantText", Value = null, Culture = "da-DK" },
-                    },
+                    new List<BlockPropertyValue>(
+                        new[]
+                        {
+                            new BlockPropertyValue { Alias = "invariantText", Value = "The invariant content value" },
+                            new BlockPropertyValue { Alias = "variantText", Value = "Variant content in English", Culture = "en-US" },
+                            addCarriedPropertyValues
+                                ? new BlockPropertyValue { Alias = "variantText", Value = "Carried content in Danish", Culture = "da-DK" }
+                                : null,
+                        }.WhereNotNull()),
+                    new List<BlockPropertyValue>(
+                        new[]
+                        {
+                            new BlockPropertyValue { Alias = "invariantText", Value = "The invariant settings value" },
+                            new BlockPropertyValue { Alias = "variantText", Value = "Variant settings in English", Culture = "en-US" },
+                            addCarriedPropertyValues
+                                ? new BlockPropertyValue { Alias = "variantText", Value = "Carried settings in Danish", Culture = "da-DK" }
+                                : null,
+                        }.WhereNotNull()),
                     "en-US",
                     null),
                 new BlockProperty(
-                    new List<BlockPropertyValue>
-                    {
-                        new() { Alias = "invariantText", Value = "The invariant content value" },
-                        new() { Alias = "variantText", Value = null, Culture = "en-US" },
-                        new() { Alias = "variantText", Value = "Variant content in Danish", Culture = "da-DK" },
-                    },
-                    new List<BlockPropertyValue>
-                    {
-                        new() { Alias = "invariantText", Value = "The invariant settings value" },
-                        new() { Alias = "variantText", Value = null, Culture = "en-US" },
-                        new() { Alias = "variantText", Value = "Variant settings in Danish", Culture = "da-DK" },
-                    },
+                    new List<BlockPropertyValue>(
+                        new[]
+                        {
+                            new BlockPropertyValue { Alias = "invariantText", Value = "The invariant content value" },
+                            new BlockPropertyValue { Alias = "variantText", Value = "Variant content in Danish", Culture = "da-DK" },
+                            addCarriedPropertyValues
+                                ? new BlockPropertyValue { Alias = "variantText", Value = "Carried content in English", Culture = "en-US" }
+                                : null,
+                        }.WhereNotNull()),
+                    new List<BlockPropertyValue>(
+                        new[]
+                        {
+                            new BlockPropertyValue { Alias = "invariantText", Value = "The settings content value" },
+                            new BlockPropertyValue { Alias = "variantText", Value = "Variant settings in Danish", Culture = "da-DK" },
+                            addCarriedPropertyValues
+                                ? new BlockPropertyValue { Alias = "variantText", Value = "Carried settings in English", Culture = "en-US" }
+                                : null,
+                        }.WhereNotNull()),
                     "da-DK",
                     null),
             },

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
@@ -1474,8 +1474,9 @@ internal partial class BlockListElementLevelVariationTests
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType, ContentVariation.Culture);
 
-        // each culture of a variant block property is stored separately. the client presets a value for every language
-        // when a block is created, so a culture's stored value also carries (empty) values for the other cultures.
+        // Each culture of this block property is stored as its own document, and a document can carry entries
+        // for cultures other than its own. The value retained must be the one for the culture being mapped,
+        // not the default language's.
         var content = CreateContent(
             contentType,
             elementType,

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
@@ -1518,7 +1518,7 @@ internal partial class BlockListElementLevelVariationTests
                     new List<BlockPropertyValue>(
                         new[]
                         {
-                            new BlockPropertyValue { Alias = "invariantText", Value = "The settings content value" },
+                            new BlockPropertyValue { Alias = "invariantText", Value = "The invariant settings value" },
                             new BlockPropertyValue { Alias = "variantText", Value = "Variant settings in Danish", Culture = "da-DK" },
                             addCarriedPropertyValues
                                 ? new BlockPropertyValue { Alias = "variantText", Value = "Carried settings in English", Culture = "en-US" }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
@@ -1466,6 +1466,88 @@ internal partial class BlockListElementLevelVariationTests
         });
     }
 
+    [TestCase("en-US", "Variant content in English", "Variant settings in English")]
+    [TestCase("da-DK", "Variant content in Danish", "Variant settings in Danish")]
+    public async Task Can_Turn_Variant_Element_Invariant_For_Variant_Block_Property(string culture, string expectedContentValue, string expectedSettingsValue)
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType, ContentVariation.Culture);
+
+        // each culture of a variant block property is stored separately. the client presets a value for every language
+        // when a block is created, so a culture's stored value also carries (empty) values for the other cultures.
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new[]
+            {
+                new BlockProperty(
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "The invariant content value" },
+                        new() { Alias = "variantText", Value = "Variant content in English", Culture = "en-US" },
+                        new() { Alias = "variantText", Value = null, Culture = "da-DK" }
+                    },
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "The invariant settings value" },
+                        new() { Alias = "variantText", Value = "Variant settings in English", Culture = "en-US" },
+                        new() { Alias = "variantText", Value = null, Culture = "da-DK" }
+                    },
+                    "en-US",
+                    null),
+                new BlockProperty(
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "The invariant content value" },
+                        new() { Alias = "variantText", Value = null, Culture = "en-US" },
+                        new() { Alias = "variantText", Value = "Variant content in Danish", Culture = "da-DK" }
+                    },
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "The invariant settings value" },
+                        new() { Alias = "variantText", Value = null, Culture = "en-US" },
+                        new() { Alias = "variantText", Value = "Variant settings in Danish", Culture = "da-DK" }
+                    },
+                    "da-DK",
+                    null)
+            },
+            false);
+
+        elementType.Variations = ContentVariation.Nothing;
+        elementType.PropertyTypes.First(p => p.Alias == "variantText").Variations = ContentVariation.Nothing;
+        ContentTypeService.Save(elementType);
+
+        // re-fetch content
+        content = ContentService.GetById(content.Key);
+
+        var valueEditor = (BlockListPropertyEditorBase.BlockListEditorPropertyValueEditor)blockListDataType.Editor!.GetValueEditor();
+
+        var blockListValue = valueEditor.ToEditor(content!.Properties["blocks"]!, culture) as BlockListValue;
+        Assert.IsNotNull(blockListValue);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, blockListValue.ContentData.Count);
+            Assert.AreEqual(2, blockListValue.ContentData.First().Values.Count);
+            var variantValue = blockListValue.ContentData.First().Values.First(value => value.Alias == "variantText");
+            Assert.IsNull(variantValue.Culture);
+            Assert.AreEqual(expectedContentValue, variantValue.Value);
+        });
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, blockListValue.SettingsData.Count);
+            Assert.AreEqual(2, blockListValue.SettingsData.First().Values.Count);
+            var variantValue = blockListValue.SettingsData.First().Values.First(value => value.Alias == "variantText");
+            Assert.IsNull(variantValue.Culture);
+            Assert.AreEqual(expectedSettingsValue, variantValue.Value);
+        });
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, blockListValue.Expose.Count);
+            Assert.IsNull(blockListValue.Expose.First().Culture);
+        });
+    }
+
     private async Task<IUser> CreateLimitedUser()
     {
         var userGroupService = GetRequiredService<IUserGroupService>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
@@ -1158,7 +1158,7 @@ internal partial class BlockListElementLevelVariationTests
             .WithVariations(ContentVariation.Nothing)
             .Done()
             .Build();
-        ContentTypeService.Save(rootElementType);
+        await ContentTypeService.CreateAsync(rootElementType, Constants.Security.SuperUserKey);
         var rootBlockListDataType = await CreateBlockListDataType(rootElementType);
         var contentType = CreateContentType(ContentVariation.Culture, rootBlockListDataType);
 
@@ -1310,7 +1310,7 @@ internal partial class BlockListElementLevelVariationTests
             false);
 
         contentType.Variations = ContentVariation.Culture;
-        ContentTypeService.Save(contentType);
+        await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);
 
         // re-fetch content
         content = ContentService.GetById(content.Key);
@@ -1369,7 +1369,7 @@ internal partial class BlockListElementLevelVariationTests
 
         elementType.Variations = ContentVariation.Culture;
         elementType.PropertyTypes.First(p => p.Alias == "variantText").Variations = ContentVariation.Culture;
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
 
         // re-fetch content
         content = ContentService.GetById(content.Key);
@@ -1430,7 +1430,7 @@ internal partial class BlockListElementLevelVariationTests
 
         elementType.Variations = ContentVariation.Nothing;
         elementType.PropertyTypes.First(p => p.Alias == "variantText").Variations = ContentVariation.Nothing;
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
 
         // re-fetch content
         content = ContentService.GetById(content.Key);
@@ -1486,13 +1486,13 @@ internal partial class BlockListElementLevelVariationTests
                     {
                         new() { Alias = "invariantText", Value = "The invariant content value" },
                         new() { Alias = "variantText", Value = "Variant content in English", Culture = "en-US" },
-                        new() { Alias = "variantText", Value = null, Culture = "da-DK" }
+                        new() { Alias = "variantText", Value = null, Culture = "da-DK" },
                     },
                     new List<BlockPropertyValue>
                     {
                         new() { Alias = "invariantText", Value = "The invariant settings value" },
                         new() { Alias = "variantText", Value = "Variant settings in English", Culture = "en-US" },
-                        new() { Alias = "variantText", Value = null, Culture = "da-DK" }
+                        new() { Alias = "variantText", Value = null, Culture = "da-DK" },
                     },
                     "en-US",
                     null),
@@ -1501,22 +1501,22 @@ internal partial class BlockListElementLevelVariationTests
                     {
                         new() { Alias = "invariantText", Value = "The invariant content value" },
                         new() { Alias = "variantText", Value = null, Culture = "en-US" },
-                        new() { Alias = "variantText", Value = "Variant content in Danish", Culture = "da-DK" }
+                        new() { Alias = "variantText", Value = "Variant content in Danish", Culture = "da-DK" },
                     },
                     new List<BlockPropertyValue>
                     {
                         new() { Alias = "invariantText", Value = "The invariant settings value" },
                         new() { Alias = "variantText", Value = null, Culture = "en-US" },
-                        new() { Alias = "variantText", Value = "Variant settings in Danish", Culture = "da-DK" }
+                        new() { Alias = "variantText", Value = "Variant settings in Danish", Culture = "da-DK" },
                     },
                     "da-DK",
-                    null)
+                    null),
             },
             false);
 
         elementType.Variations = ContentVariation.Nothing;
         elementType.PropertyTypes.First(p => p.Alias == "variantText").Variations = ContentVariation.Nothing;
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
 
         // re-fetch content
         content = ContentService.GetById(content.Key);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Indexing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Indexing.cs
@@ -310,7 +310,7 @@ internal partial class BlockListElementLevelVariationTests
             .WithVariations(ContentVariation.Nothing)
             .Done()
             .Build();
-        ContentTypeService.Save(rootElementType);
+        await ContentTypeService.CreateAsync(rootElementType, Constants.Security.SuperUserKey);
         var rootBlockListDataType = await CreateBlockListDataType(rootElementType);
         var contentType = CreateContentType(ContentVariation.Culture, rootBlockListDataType);
 
@@ -399,7 +399,7 @@ internal partial class BlockListElementLevelVariationTests
         if (initialVaryByCulture is false)
         {
             elementType.PropertyTypes.First(pt => pt.Alias == "variantText").Variations = ContentVariation.Nothing;
-            ContentTypeService.Save(elementType);
+            await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
         }
 
         var blockListDataType = await CreateBlockListDataType(elementType);
@@ -418,7 +418,7 @@ internal partial class BlockListElementLevelVariationTests
 
         // update the element type property according to the test case
         elementType.PropertyTypes.First(pt => pt.Alias == "variantText").Variations = initialVaryByCulture ? ContentVariation.Nothing : ContentVariation.Culture;
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
 
         var editor = blockListDataType.Editor!;
         var indexValues = editor.PropertyIndexValueFactory.GetIndexValues(

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Parsing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Parsing.cs
@@ -261,10 +261,10 @@ internal partial class BlockListElementLevelVariationTests
         // the content and element types are created invariant; now make them culture variant, and enable culture variance on the "variantText" property
         elementType.Variations = ContentVariation.Culture;
         elementType.PropertyTypes.First(pt => pt.Alias == "variantText").Variations = ContentVariation.Culture;
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
 
         contentType.Variations = ContentVariation.Culture;
-        ContentTypeService.Save(contentType);
+        await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);
 
         RefreshContentTypeCache(elementType, contentType);
 
@@ -349,11 +349,11 @@ internal partial class BlockListElementLevelVariationTests
         // the content and element types are created as variant; now update the element type according to the test case
         elementType.Variations = elementVariationAfterPublish;
         elementType.PropertyTypes.First(pt => pt.Alias == "variantText").Variations = elementVariationAfterPublish;
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
 
         // ...and make the content type invariant
         contentType.Variations = ContentVariation.Nothing;
-        ContentTypeService.Save(contentType);
+        await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);
 
         RefreshContentTypeCache(elementType, contentType);
 
@@ -501,12 +501,12 @@ internal partial class BlockListElementLevelVariationTests
                     new List<BlockPropertyValue>
                     {
                         new() { Alias = "invariantText", Value = "English invariant content value" },
-                        new() { Alias = "variantText", Value = "English variant content value", Culture = "en-US" }
+                        new() { Alias = "variantText", Value = "English variant content value", Culture = "en-US" },
                     },
                     new List<BlockPropertyValue>
                     {
                         new() { Alias = "invariantText", Value = "English invariant settings value" },
-                        new() { Alias = "variantText", Value = "English variant settings value", Culture = "en-US" }
+                        new() { Alias = "variantText", Value = "English variant settings value", Culture = "en-US" },
                     },
                     "en-US",
                     null),
@@ -514,15 +514,15 @@ internal partial class BlockListElementLevelVariationTests
                     new List<BlockPropertyValue>
                     {
                         new() { Alias = "invariantText", Value = "Danish invariant content value" },
-                        new() { Alias = "variantText", Value = "Danish variant content value", Culture = "da-DK" }
+                        new() { Alias = "variantText", Value = "Danish variant content value", Culture = "da-DK" },
                     },
                     new List<BlockPropertyValue>
                     {
                         new() { Alias = "invariantText", Value = "Danish invariant settings value" },
-                        new() { Alias = "variantText", Value = "Danish variant settings value", Culture = "da-DK" }
+                        new() { Alias = "variantText", Value = "Danish variant settings value", Culture = "da-DK" },
                     },
                     "da-DK",
-                    null)
+                    null),
             },
             true);
 
@@ -530,7 +530,7 @@ internal partial class BlockListElementLevelVariationTests
         // holds its own block value - which means every culture retains the values it was published with.
         elementType.Variations = ContentVariation.Nothing;
         elementType.PropertyTypes.First(pt => pt.Alias == "variantText").Variations = ContentVariation.Nothing;
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
 
         RefreshContentTypeCache(elementType);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Parsing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Parsing.cs
@@ -484,6 +484,90 @@ internal partial class BlockListElementLevelVariationTests
         });
     }
 
+    [TestCase("en-US", "English")]
+    [TestCase("da-DK", "Danish")]
+    public async Task Can_Become_Invariant_After_Publish_For_Variant_Block_Property(string culture, string expectedStartsWith)
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType, ContentVariation.Culture);
+
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new[]
+            {
+                new BlockProperty(
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "English invariant content value" },
+                        new() { Alias = "variantText", Value = "English variant content value", Culture = "en-US" }
+                    },
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "English invariant settings value" },
+                        new() { Alias = "variantText", Value = "English variant settings value", Culture = "en-US" }
+                    },
+                    "en-US",
+                    null),
+                new BlockProperty(
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "Danish invariant content value" },
+                        new() { Alias = "variantText", Value = "Danish variant content value", Culture = "da-DK" }
+                    },
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "Danish invariant settings value" },
+                        new() { Alias = "variantText", Value = "Danish variant settings value", Culture = "da-DK" }
+                    },
+                    "da-DK",
+                    null)
+            },
+            true);
+
+        // the element type is made invariant after publishing. the "blocks" property varies by culture, so each culture
+        // holds its own block value - which means every culture retains the values it was published with.
+        elementType.Variations = ContentVariation.Nothing;
+        elementType.PropertyTypes.First(pt => pt.Alias == "variantText").Variations = ContentVariation.Nothing;
+        ContentTypeService.Save(elementType);
+
+        RefreshContentTypeCache(elementType);
+
+        SetVariationContext(culture, null);
+
+        var publishedContent = GetPublishedContent(content.Key);
+
+        var value = publishedContent.GetProperty("blocks")!.GetValue() as BlockListModel;
+        Assert.IsNotNull(value);
+        Assert.AreEqual(1, value.Count);
+
+        var blockListItem = value.First();
+        Assert.AreEqual(2, blockListItem.Content.Properties.Count());
+        Assert.Multiple(() =>
+        {
+            var invariantProperty = blockListItem.Content.Properties.First();
+            Assert.AreEqual("invariantText", invariantProperty.Alias);
+            Assert.IsTrue(invariantProperty.GetValue()!.ToString()!.StartsWith(expectedStartsWith));
+
+            var variantProperty = blockListItem.Content.Properties.Last();
+            Assert.AreEqual("variantText", variantProperty.Alias);
+            Assert.IsTrue(variantProperty.GetValue()!.ToString()!.StartsWith(expectedStartsWith));
+        });
+
+        Assert.AreEqual(2, blockListItem.Settings.Properties.Count());
+        Assert.Multiple(() =>
+        {
+            var invariantProperty = blockListItem.Settings.Properties.First();
+            Assert.AreEqual("invariantText", invariantProperty.Alias);
+            Assert.IsTrue(invariantProperty.GetValue()!.ToString()!.StartsWith(expectedStartsWith));
+
+            var variantProperty = blockListItem.Settings.Properties.Last();
+            Assert.AreEqual("variantText", variantProperty.Alias);
+            Assert.IsTrue(variantProperty.GetValue()!.ToString()!.StartsWith(expectedStartsWith));
+        });
+    }
+
     [TestCase(ContentVariation.Culture, "en-US", "Segment1")]
     [TestCase(ContentVariation.Culture, "en-US", "Segment2")]
     [TestCase(ContentVariation.Culture, "da-DK", "Segment1")]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -292,7 +292,7 @@ internal partial class BlockListElementLevelVariationTests
             .WithVariations(ContentVariation.Nothing)
             .Done()
             .Build();
-        ContentTypeService.Save(rootElementType);
+        await ContentTypeService.CreateAsync(rootElementType, Constants.Security.SuperUserKey);
         var rootBlockListDataType = await CreateBlockListDataType(rootElementType);
         var contentType = CreateContentType(ContentVariation.Culture, rootBlockListDataType);
 
@@ -493,7 +493,7 @@ internal partial class BlockListElementLevelVariationTests
             .WithVariations(ContentVariation.Culture)
             .Done()
             .Build();
-        ContentTypeService.Save(rootElementType);
+        await ContentTypeService.CreateAsync(rootElementType, Constants.Security.SuperUserKey);
         var rootBlockListDataType = await CreateBlockListDataType(rootElementType);
         var contentType = CreateContentType(ContentVariation.Culture, rootBlockListDataType);
 
@@ -1632,7 +1632,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Can_Publish_Valid_Properties()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
 
@@ -1672,7 +1672,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Can_Publish_Valid_Properties_Specific_Culture_Only()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
 
@@ -1712,7 +1712,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Can_Publish_Valid_Properties_With_Wildcard_Culture()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
 
@@ -1753,7 +1753,7 @@ internal partial class BlockListElementLevelVariationTests
     [TestCase(false)]
     public async Task Cannot_Publish_Invalid_Invariant_Properties(bool invalidSettingsValue)
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
 
@@ -1797,7 +1797,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Cannot_Publish_Missing_Invariant_Properties()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
 
@@ -1840,7 +1840,7 @@ internal partial class BlockListElementLevelVariationTests
     [TestCase(false)]
     public async Task Cannot_Publish_Invalid_Variant_Properties(bool invalidSettingsValue)
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
 
@@ -1887,7 +1887,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Cannot_Publish_Missing_Variant_Properties()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
 
@@ -1953,7 +1953,7 @@ internal partial class BlockListElementLevelVariationTests
             .WithVariations(ContentVariation.Culture)
             .Done()
             .Build();
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.CreateAsync(elementType, Constants.Security.SuperUserKey);
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
 
@@ -2148,7 +2148,7 @@ internal partial class BlockListElementLevelVariationTests
             propertyType.Variations = ContentVariation.Nothing;
         }
 
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
         // RefreshContentTypeCache(elementType, contentType);
 
         // Verify element type properties are now invariant
@@ -2330,7 +2330,7 @@ internal partial class BlockListElementLevelVariationTests
             propertyType.Variations = ContentVariation.Culture;
         }
 
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
 
         // Verify element type properties are now variant
         var refreshedElementType = ContentTypeService.Get(elementType.Key);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Validation.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Validation.cs
@@ -14,7 +14,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Can_Validate_Invalid_Properties()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
         var blockListValue = BlockListPropertyValue(
@@ -183,7 +183,7 @@ internal partial class BlockListElementLevelVariationTests
 
     private async Task Can_Validate_Invalid_Properties_Specific_Culture_Only()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
         var blockListValue = BlockListPropertyValue(
@@ -238,7 +238,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Can_Validate_Invalid_Properties_With_Wildcard_Culture()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
         var blockListValue = BlockListPropertyValue(
@@ -292,7 +292,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Can_Validate_Missing_Properties()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
         var blockListValue = BlockListPropertyValue(
@@ -505,7 +505,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Does_Not_Validate_Unexposed_Blocks()
     {
-        var elementType = CreateElementTypeWithValidation();
+        var elementType = await CreateElementTypeWithValidationAsync();
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
         var blockListValue = BlockListPropertyValue(
@@ -555,7 +555,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Can_Validate_Properties_Variant_Blocks()
     {
-        var elementType = CreateElementTypeWithValidation(ContentVariation.Nothing);
+        var elementType = await CreateElementTypeWithValidationAsync(ContentVariation.Nothing);
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType, ContentVariation.Culture);
         var blockListValue = BlockListPropertyValue(
@@ -612,7 +612,7 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     public async Task Can_Validate_Missing_Properties_Variant_Blocks()
     {
-        var elementType = CreateElementTypeWithValidation(ContentVariation.Nothing);
+        var elementType = await CreateElementTypeWithValidationAsync(ContentVariation.Nothing);
         var blockListDataType = await CreateBlockListDataType(elementType);
         var contentType = CreateContentType(ContentVariation.Culture, blockListDataType, ContentVariation.Culture);
         var blockListValue = BlockListPropertyValue(

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
@@ -148,7 +147,7 @@ internal sealed partial class BlockListElementLevelVariationTests : BlockEditorE
         return GetPublishedContent(content.Key);
     }
 
-    private IContentType CreateElementTypeWithValidation(ContentVariation contentVariation = ContentVariation.Culture)
+    private async Task<IContentType> CreateElementTypeWithValidationAsync(ContentVariation contentVariation = ContentVariation.Culture)
     {
         var elementType = CreateElementType(contentVariation);
         foreach (var propertyType in elementType.PropertyTypes)
@@ -157,13 +156,13 @@ internal sealed partial class BlockListElementLevelVariationTests : BlockEditorE
             propertyType.ValidationRegExp = "^Valid.*$";
         }
 
-        ContentTypeService.Save(elementType);
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
         return elementType;
     }
 
     private async Task<(IContentType RootElementType, IContentType NestedElementType)> CreateElementTypeWithValidationAndNestedBlocksAsync()
     {
-        var nestedElementType = CreateElementTypeWithValidation();
+        var nestedElementType = await CreateElementTypeWithValidationAsync();
         var nestedBlockListDataType = await CreateBlockListDataType(nestedElementType);
 
         var rootElementType = new ContentTypeBuilder()
@@ -200,7 +199,7 @@ internal sealed partial class BlockListElementLevelVariationTests : BlockEditorE
             .WithVariations(ContentVariation.Nothing)
             .Done()
             .Build();
-        ContentTypeService.Save(rootElementType);
+        await ContentTypeService.CreateAsync(rootElementType, Constants.Security.SuperUserKey);
 
         return (rootElementType, nestedElementType);
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/RichTextElementLevelVariationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/RichTextElementLevelVariationTests.cs
@@ -674,8 +674,9 @@ internal sealed class RichTextElementLevelVariationTests : BlockEditorElementVar
 
         var contentElementKey = Guid.NewGuid();
 
-        // each culture of a variant block property is stored separately, and the client presets a value for every
-        // language when a block is created - so a culture's stored value also carries (empty) values for the others
+        // Each culture of this block property is stored as its own document, and a document can carry entries
+        // for cultures other than its own. The value retained must be the one for the culture being mapped,
+        // not the default language's.
         RichTextEditorValue RichTextValueFor(string valueCulture) => new()
         {
             Markup = $"""

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/RichTextElementLevelVariationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/RichTextElementLevelVariationTests.cs
@@ -664,6 +664,80 @@ internal sealed class RichTextElementLevelVariationTests : BlockEditorElementVar
         }
     }
 
+    [TestCase("en-US", "variantText value for en-US")]
+    [TestCase("da-DK", "variantText value for da-DK")]
+    public async Task Can_Become_Invariant_After_Publish_For_Variant_Block_Property(string culture, string expectedVariantValue)
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, rteDataType, ContentVariation.Culture);
+
+        var contentElementKey = Guid.NewGuid();
+
+        // each culture of a variant block property is stored separately, and the client presets a value for every
+        // language when a block is created - so a culture's stored value also carries (empty) values for the others
+        RichTextEditorValue RichTextValueFor(string valueCulture) => new()
+        {
+            Markup = $"""
+                      <p>Some text for {valueCulture}.</p>
+                      <umb-rte-block data-content-key="{contentElementKey:D}"><!--Umbraco-Block--></umb-rte-block>
+                      """,
+            Blocks = new RichTextBlockValue([new RichTextBlockLayoutItem(contentElementKey)])
+            {
+                ContentData =
+                [
+                    new(contentElementKey, elementType.Key, elementType.Alias)
+                    {
+                        Values =
+                        [
+                            new() { Alias = "invariantText", Value = "The invariant value" },
+                            new() { Alias = "variantText", Culture = "en-US", Value = valueCulture == "en-US" ? "variantText value for en-US" : null },
+                            new() { Alias = "variantText", Culture = "da-DK", Value = valueCulture == "da-DK" ? "variantText value for da-DK" : null },
+                        ],
+                    },
+                ],
+                SettingsData = [],
+                Expose =
+                [
+                    new(contentElementKey, "en-US", null),
+                    new(contentElementKey, "da-DK", null),
+                ],
+            },
+        };
+
+        var content = CreateContent(contentType);
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(RichTextValueFor("en-US")), "en-US");
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(RichTextValueFor("da-DK")), "da-DK");
+        ContentService.Save(content);
+
+        PublishContent(content, ["en-US", "da-DK"]);
+
+        // the element type is made invariant after publishing. the "blocks" property varies by culture, so each culture
+        // holds its own block value - which means every culture retains the value it was published with.
+        elementType.Variations = ContentVariation.Nothing;
+        elementType.PropertyTypes.First(pt => pt.Alias == "variantText").Variations = ContentVariation.Nothing;
+        await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
+
+        RefreshContentTypeCache(elementType);
+
+        SetVariationContext(culture, null);
+
+        var publishedContent = GetPublishedContent(content.Key);
+        var property = publishedContent.GetProperty("blocks");
+        Assert.IsNotNull(property);
+
+        var propertyValue = property.GetDeliveryApiValue(false, culture) as RichTextModel;
+        Assert.IsNotNull(propertyValue);
+
+        var blocks = propertyValue.Blocks.ToArray();
+        Assert.AreEqual(1, blocks.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("The invariant value", blocks[0].Content.Properties["invariantText"]);
+            Assert.AreEqual(expectedVariantValue, blocks[0].Content.Properties["variantText"]);
+        });
+    }
+
     private async Task<IDataType> CreateRichTextDataType(IContentType elementType)
         => await CreateBlockEditorDataType(
             Constants.PropertyEditors.Aliases.RichText,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/BlockEditorVarianceHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/BlockEditorVarianceHandlerTests.cs
@@ -129,6 +129,53 @@ public class BlockEditorVarianceHandlerTests
     }
 
     [Test]
+    public async Task AlignedExposeVarianceAsync_Retains_Owning_Property_Culture_When_Expected_Invariant()
+    {
+        var owner = PublishedElement(ContentVariation.Nothing);
+        var element = PublishedElement(ContentVariation.Culture);
+        var blockValue = new BlockListValue
+        {
+            Expose =
+            [
+                new() { ContentKey = element.Key, Culture = "da-DK", Segment = "danish" },
+                new() { ContentKey = element.Key, Culture = "en-US", Segment = "english" },
+            ],
+        };
+
+        var result = await ExecuteAlignedExposeVarianceAsync(owner, element, blockValue, "en-US");
+
+        var variation = result.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.IsNull(variation.Culture);
+            Assert.AreEqual("english", variation.Segment);
+        });
+    }
+
+    [Test]
+    public async Task AlignedExposeVarianceAsync_Falls_Back_To_Default_Culture_When_No_Entry_For_Owning_Property_Culture()
+    {
+        var owner = PublishedElement(ContentVariation.Nothing);
+        var element = PublishedElement(ContentVariation.Culture);
+        var blockValue = new BlockListValue
+        {
+            Expose =
+            [
+                new() { ContentKey = element.Key, Culture = "da-DK", Segment = "danish" },
+            ],
+        };
+
+        var result = await ExecuteAlignedExposeVarianceAsync(owner, element, blockValue, "en-US");
+
+        var variation = result.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.IsNull(variation.Culture);
+            Assert.AreEqual("danish", variation.Segment);
+        });
+    }
+
+    [Test]
     public async Task AlignedExposeVarianceAsync_Returns_Unchanged_When_Already_Variant()
     {
         var owner = PublishedElement(ContentVariation.Culture);
@@ -485,10 +532,11 @@ public class BlockEditorVarianceHandlerTests
     private static async Task<IEnumerable<BlockItemVariation>> ExecuteAlignedExposeVarianceAsync(
         IPublishedElement owner,
         IPublishedElement element,
-        BlockListValue blockValue)
+        BlockListValue blockValue,
+        string? culture = null)
     {
         var subject = BlockEditorVarianceHandler("da-DK", element);
-        return await subject.AlignedExposeVarianceAsync(blockValue, owner, element);
+        return await subject.AlignedExposeVarianceAsync(blockValue, owner, element, culture);
     }
 
     private static IPublishedElement PublishedElement(ContentVariation variation)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/BlockEditorVarianceHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/BlockEditorVarianceHandlerTests.cs
@@ -378,6 +378,27 @@ public class BlockEditorVarianceHandlerTests
     }
 
     [Test]
+    public void AlignExposeVariance_Retains_Segments_For_Block_Without_Values()
+    {
+        var owner = PublishedElement(ContentVariation.Nothing);
+        var contentDataKey = Guid.NewGuid();
+        var expose = CreateBlockItemVariations(
+            (contentDataKey, "da-DK", "segment-one"),
+            (contentDataKey, "da-DK", "segment-two"));
+        var blockValue = CreateBlockListValue(contentDataKey, owner.ContentType.Key, [], expose);
+
+        ExecuteAlignExposeVariance(owner, blockValue);
+
+        Assert.AreEqual(2, blockValue.Expose.Count);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(blockValue.Expose.All(e => e.Culture is null));
+            Assert.IsTrue(blockValue.Expose.Any(e => e.Segment == "segment-one"));
+            Assert.IsTrue(blockValue.Expose.Any(e => e.Segment == "segment-two"));
+        });
+    }
+
+    [Test]
     public void AlignExposeVariance_Aligns_Expose_For_Block_Without_Values_To_Variant_Element_Type()
     {
         var owner = PublishedElement(ContentVariation.Culture);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/BlockEditorVarianceHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/BlockEditorVarianceHandlerTests.cs
@@ -15,6 +15,8 @@ public class BlockEditorVarianceHandlerTests
 {
     private record BlockPropertyValueConfig(string Alias, string? Culture, string? Segment, object? Value);
 
+    private record AlignedPropertyValueConfig(ContentVariation Variation, string? Culture, string Alias, object? Value, string? Segment = null);
+
     [Test]
     public async Task AlignedPropertyVarianceAsync_Assigns_Default_Culture_When_Culture_Variance_Is_Enabled()
     {
@@ -248,6 +250,151 @@ public class BlockEditorVarianceHandlerTests
     }
 
     [Test]
+    public async Task AlignedPropertyVarianceAsync_Retains_Owning_Property_Culture_When_Culture_Variance_Is_Disabled()
+    {
+        var result = await ExecuteAlignedPropertyVarianceAsync(
+            ContentVariation.Nothing,
+            ContentVariation.Nothing,
+            new BlockPropertyValue { Culture = "en-US", Value = "English" },
+            culture: "en-US");
+
+        Assert.IsNotNull(result);
+        Assert.Multiple(() =>
+        {
+            Assert.IsNull(result.Culture);
+            Assert.AreEqual("English", result.Value);
+        });
+    }
+
+    [Test]
+    public async Task AlignedPropertyVarianceAsync_Ignores_Other_Cultures_Than_The_Owning_Property_Culture()
+    {
+        var result = await ExecuteAlignedPropertyVarianceAsync(
+            ContentVariation.Nothing,
+            ContentVariation.Nothing,
+            new BlockPropertyValue { Culture = "da-DK", Value = "Danish" },
+            culture: "en-US");
+
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void AlignExposeVariance_Retains_Expose_For_Block_Without_Values()
+    {
+        var owner = PublishedElement(ContentVariation.Nothing);
+        var contentDataKey = Guid.NewGuid();
+        var expose = CreateBlockItemVariations((contentDataKey, "da-DK", null));
+        var blockValue = CreateBlockListValue(contentDataKey, owner.ContentType.Key, [], expose);
+
+        ExecuteAlignExposeVariance(owner, blockValue);
+
+        Assert.AreEqual(1, blockValue.Expose.Count);
+        Assert.IsNull(blockValue.Expose.First().Culture);
+    }
+
+    [Test]
+    public void AlignExposeVariance_Aligns_Expose_For_Block_Without_Values_To_Variant_Element_Type()
+    {
+        var owner = PublishedElement(ContentVariation.Culture);
+        var contentDataKey = Guid.NewGuid();
+        var expose = CreateBlockItemVariations((contentDataKey, null, null));
+        var blockValue = CreateBlockListValue(contentDataKey, owner.ContentType.Key, [], expose);
+
+        ExecuteAlignExposeVariance(owner, blockValue, "en-US");
+
+        Assert.AreEqual(1, blockValue.Expose.Count);
+        Assert.AreEqual("en-US", blockValue.Expose.First().Culture);
+    }
+
+    [Test]
+    public async Task AlignPropertyVarianceAsync_Retains_Value_For_Aligned_Culture()
+    {
+        var propertyValues = CreatePropertyValues(
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "da-DK", "text", "Danish"),
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "en-US", "text", "English"));
+
+        var result = await ExecuteAlignPropertyVarianceAsync(ContentVariation.Culture, propertyValues, "en-US");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, result.Count);
+            Assert.IsNull(result.First().Culture);
+            Assert.AreEqual("English", result.First().Value);
+        });
+    }
+
+    [Test]
+    public async Task AlignPropertyVarianceAsync_Falls_Back_To_Default_Culture_When_No_Value_For_Aligned_Culture()
+    {
+        var propertyValues = CreatePropertyValues(
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "da-DK", "text", "Danish"));
+
+        var result = await ExecuteAlignPropertyVarianceAsync(ContentVariation.Culture, propertyValues, "en-US");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, result.Count);
+            Assert.IsNull(result.First().Culture);
+            Assert.AreEqual("Danish", result.First().Value);
+        });
+    }
+
+    [Test]
+    public async Task AlignPropertyVarianceAsync_Retains_Invariant_Value_Over_Culture_Values()
+    {
+        var propertyValues = CreatePropertyValues(
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, null, "text", "Invariant"),
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "da-DK", "text", "Danish"));
+
+        var result = await ExecuteAlignPropertyVarianceAsync(ContentVariation.Culture, propertyValues, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, result.Count);
+            Assert.IsNull(result.First().Culture);
+            Assert.AreEqual("Invariant", result.First().Value);
+        });
+    }
+
+    [Test]
+    public async Task AlignPropertyVarianceAsync_Aligns_Each_Property_Independently()
+    {
+        var propertyValues = CreatePropertyValues(
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "da-DK", "one", "One in Danish"),
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "en-US", "one", "One in English"),
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "da-DK", "two", "Two in Danish"),
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "en-US", "two", "Two in English"));
+
+        var result = await ExecuteAlignPropertyVarianceAsync(ContentVariation.Culture, propertyValues, "en-US");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("One in English", result.First(v => v.Alias == "one").Value);
+            Assert.AreEqual("Two in English", result.First(v => v.Alias == "two").Value);
+        });
+    }
+
+    [Test]
+    public async Task AlignPropertyVarianceAsync_Aligns_Each_Segment_Independently()
+    {
+        var propertyValues = CreatePropertyValues(
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "da-DK", "text", "Danish", "one"),
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "en-US", "text", "English", "one"),
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "da-DK", "text", "Danish", "two"),
+            new AlignedPropertyValueConfig(ContentVariation.Nothing, "en-US", "text", "English", "two"));
+
+        var result = await ExecuteAlignPropertyVarianceAsync(ContentVariation.Culture, propertyValues, "en-US");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("English", result.First(v => v.Segment == "one").Value);
+            Assert.AreEqual("English", result.First(v => v.Segment == "two").Value);
+        });
+    }
+
+    [Test]
     public void AlignExposeVariance_Removes_Exposed_Keys_When_Not_In_ContentData()
     {
         var owner = PublishedElement(ContentVariation.Culture);
@@ -323,14 +470,16 @@ public class BlockEditorVarianceHandlerTests
     private static async Task<BlockPropertyValue?> ExecuteAlignedPropertyVarianceAsync(
         ContentVariation ownerVariation,
         ContentVariation propertyTypeVariation,
-        BlockPropertyValue propertyValue)
+        BlockPropertyValue propertyValue,
+        string? culture = null)
     {
         var owner = PublishedElement(ownerVariation);
         var subject = BlockEditorVarianceHandler("da-DK", owner);
         return await subject.AlignedPropertyVarianceAsync(
             propertyValue,
             PublishedPropertyType(propertyTypeVariation),
-            owner);
+            owner,
+            culture);
     }
 
     private static async Task<IEnumerable<BlockItemVariation>> ExecuteAlignedExposeVarianceAsync(
@@ -408,10 +557,10 @@ public class BlockEditorVarianceHandlerTests
             Expose = expose,
         };
 
-    private static void ExecuteAlignExposeVariance(IPublishedElement owner, BlockListValue blockValue)
+    private static void ExecuteAlignExposeVariance(IPublishedElement owner, BlockListValue blockValue, string? culture = null)
     {
         var subject = BlockEditorVarianceHandler("da-DK", owner);
-        subject.AlignExposeVariance(blockValue);
+        subject.AlignExposeVariance(blockValue, culture);
     }
 
     private static List<BlockPropertyValue> CreatePropertyValues(params (ContentVariation variation, string? culture)[] configs) =>
@@ -419,6 +568,16 @@ public class BlockEditorVarianceHandlerTests
         {
             Culture = c.culture,
             PropertyType = CreatePropertyType(c.variation),
+        }).ToList();
+
+    private static List<BlockPropertyValue> CreatePropertyValues(params AlignedPropertyValueConfig[] configs) =>
+        configs.Select(c => new BlockPropertyValue
+        {
+            Alias = c.Alias,
+            Culture = c.Culture,
+            Segment = c.Segment,
+            Value = c.Value,
+            PropertyType = CreatePropertyType(c.Variation),
         }).ToList();
 
     private static IPropertyType CreatePropertyType(ContentVariation variation)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/BlockEditorVarianceHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/BlockEditorVarianceHandlerTests.cs
@@ -314,7 +314,7 @@ public class BlockEditorVarianceHandlerTests
     }
 
     [Test]
-    public async Task AlignedPropertyVarianceAsync_Ignores_Other_Cultures_Than_The_Owning_Property_Culture()
+    public async Task AlignedPropertyVarianceAsync_Falls_Back_To_Default_Culture_When_No_Value_For_Owning_Property_Culture()
     {
         var result = await ExecuteAlignedPropertyVarianceAsync(
             ContentVariation.Nothing,
@@ -322,7 +322,45 @@ public class BlockEditorVarianceHandlerTests
             new BlockPropertyValue { Culture = "da-DK", Value = "Danish" },
             culture: "en-US");
 
-        Assert.IsNull(result);
+        Assert.IsNotNull(result);
+        Assert.Multiple(() =>
+        {
+            Assert.IsNull(result.Culture);
+            Assert.AreEqual("Danish", result.Value);
+        });
+    }
+
+    [Test]
+    public async Task AlignedPropertyVarianceAsync_Prefers_Owning_Property_Culture_Over_Default_Culture()
+    {
+        IList<BlockPropertyValue> result = await ExecuteAlignedPropertyVarianceAsync(
+            ContentVariation.Nothing,
+            ContentVariation.Nothing,
+            [
+                new() { Alias = "text", Culture = "da-DK", Value = "Danish" },
+                new() { Alias = "text", Culture = "en-US", Value = "English" },
+            ],
+            culture: "en-US");
+
+        Assert.AreEqual(1, result.Count);
+        Assert.Multiple(() =>
+        {
+            Assert.IsNull(result.First().Culture);
+            Assert.AreEqual("English", result.First().Value);
+        });
+    }
+
+    [Test]
+    public async Task AlignedPropertyVarianceAsync_Assigns_Owning_Property_Culture_When_Culture_Variance_Is_Enabled()
+    {
+        var result = await ExecuteAlignedPropertyVarianceAsync(
+            ContentVariation.Culture,
+            ContentVariation.Culture,
+            new BlockPropertyValue { Culture = null, Value = "Shared" },
+            culture: "en-US");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("en-US", result.Culture);
     }
 
     [Test]
@@ -520,13 +558,36 @@ public class BlockEditorVarianceHandlerTests
         BlockPropertyValue propertyValue,
         string? culture = null)
     {
+        IList<BlockPropertyValue> result = await ExecuteAlignedPropertyVarianceAsync(
+            ownerVariation,
+            propertyTypeVariation,
+            [propertyValue],
+            culture);
+        return result.SingleOrDefault();
+    }
+
+    private static async Task<IList<BlockPropertyValue>> ExecuteAlignedPropertyVarianceAsync(
+        ContentVariation ownerVariation,
+        ContentVariation propertyTypeVariation,
+        IList<BlockPropertyValue> propertyValues,
+        string? culture = null)
+    {
         var owner = PublishedElement(ownerVariation);
         var subject = BlockEditorVarianceHandler("da-DK", owner);
         return await subject.AlignedPropertyVarianceAsync(
-            propertyValue,
-            PublishedPropertyType(propertyTypeVariation),
+            propertyValues,
+            PublishedContentType(propertyTypeVariation),
             owner,
             culture);
+    }
+
+    private static IPublishedContentType PublishedContentType(ContentVariation propertyTypeVariation)
+    {
+        var contentTypeMock = new Mock<IPublishedContentType>();
+        contentTypeMock
+            .Setup(m => m.GetPropertyType(It.IsAny<string>()))
+            .Returns(PublishedPropertyType(propertyTypeVariation));
+        return contentTypeMock.Object;
     }
 
     private static async Task<IEnumerable<BlockItemVariation>> ExecuteAlignedExposeVarianceAsync(


### PR DESCRIPTION
## Description

#23588 reports that turning **vary by culture off** on element types used inside a Block List leaves the secondary culture's blocks empty — the block rows are still listed, but their content is gone, and some blocks lose their published state.

Fixes #23588.

### What should *not* be expected to be retained

Turning off vary-by-culture on an element type is a genuine data-shape change, and some loss is unavoidable and intended.

When a Block List property is **invariant**, the whole block value is a single stored JSON document shared by every culture, with the per-culture data held inside it (this is the designed "element level variation" feature — see `tests/.../block-element-level-variation.md`). Making the element type invariant means each property can now hold only **one** value site-wide, so all but one culture's values must be discarded. Umbraco keeps the default language's value. That is correct and this PR does not change it.

So: **if your Block List property does not vary by culture, expect non-default cultures to lose their element-level values when you make the element type invariant.** There is nowhere for them to go.

### The gap this PR addresses

The reporter's setup is the *other* configuration: the **Block List property itself varies by culture**. There, each culture already has its own stored property value, each holding its own block JSON. Nothing needs to be discarded — every culture can simply collapse its own values to invariant and keep its content.

The alignment code didn't make that distinction. `BlockEditorVarianceHandler.AlignPropertyVarianceAsync` had two branches that disagreed about the reference culture:

```csharp
culture ??= defaultIsoCodeAsync;
...
if (propertyType.VariesByCulture() is false && blockPropertyValue.Culture.InvariantEquals(defaultIsoCodeAsync) is false)
    valuesToRemove.Add(blockPropertyValue);          // <- compares against the SITE DEFAULT
else
    blockPropertyValue.Culture = propertyType.VariesByCulture() ? culture : null;   // <- uses `culture`
```

`culture` is the culture of the stored property value being mapped — `ToEditor(property, propertyValue.Culture, …)` is called once per stored row. So for the Danish row `culture` is `da-DK`, its inner values are labelled `da-DK`, and the removal check asks whether they equal `en-US`. Every one is dropped.

The same wrong comparison existed on the render path, so the published site dropped the secondary culture's block values too.

### Changes

One rule now decides which value survives a property becoming culture invariant, and it is applied everywhere: **an explicitly invariant value first, then the value for the culture being aligned, then the value for the default language.**

- `AlignPropertyVarianceAsync` (editing) retains a single value per alias and segment using that rule. This also removes a latent duplicate that occurred when both an invariant and a default-culture value were present.
- The render path's per-value `AlignedPropertyVarianceAsync` is superseded by a collection overload applying the same rule. It needs the whole value set because the caller accumulates into a last-wins dictionary — a per-value "culture or default" fallback would make the winner depend on JSON ordering. Supplied values are never mutated; realigned values are returned as new instances.
- `AlignedExposeVarianceAsync` prefers the entry for the owning culture, falling back to the default language. Without this the block could be dropped from the rendered output entirely rather than merely rendering empty, depending on which cultures its stored `expose` entries carried.
- `AlignExposeVariance` takes the culture being aligned, and keeps an expose entry for a block that holds no property values — previously such a block silently stopped being published. Synthesised entries retain the segments the block was exposed for.
- The four block converters pass the owning property value's culture down through `BlockPropertyValueCreatorBase` and `BlockEditorConverter`, derived from the **effective** variance (`owner.ContentType.Variations & propertyType.Variations`) — `IPublishedPropertyType.Variations` carries the property's own flag, unintersected.

### Notes for reviewers

- **This is not a v17 regression.** The behaviour dates to **15.4.0** (#18804, commit `37035e6e7fb`), which introduced the removal to de-duplicate values and chose "keep the default culture" as the de-duplication key. v16 is affected as well and is not covered by this v17 base.
- **Already-damaged sites cannot be repaired by this change.** The alignment runs on the map-to-editor and render paths only; a content type save never rewrites block JSON. The stored data stays intact until an editor saves the affected content — at which point the loss becomes permanent. Sites that have already re-saved will need a backup or an earlier content version.

## Testing

### Automated

Unit and integration tests have been added to verify the fix and improve coverage.

### Manual

The setup deliberately uses **two pages sharing one element type**, so a single toggle exercises the fix and the control case together.

Schema:
1. Two languages, e.g. `en-US` (default) and `fr`.
2. An **element type** that varies by culture, with `invariantText` (invariant) and `variantText` (varies by culture).
3. A Block List data type using that element type.
4. **Page A** — document type varies by culture, with a Block List property that **also varies by culture**. ← the bug case
5. **Page B** — document type varies by culture, with an **invariant** Block List property. ← the control case

Content — create one page of each type, add a single block, and fill `variantText` in both languages. Save and publish both cultures. For Page A, note that each culture's stored value will also carry an empty placeholder for the other culture; that is what the backoffice writes, and it is what makes the symptom *blank* rather than English.

Steps:

| # | Step |
|---|---|
| 1 | Open Page A and Page B in both languages and confirm each shows its own language's text |
| 2 | Turn **Vary by culture OFF** on the element type **and** on its `variantText` property, and save |
| 3 | Reopen both pages in both languages — **do not save the pages** |
| 4 | Check the published front end in both languages |

Expected at steps 3 and 4:

| | `en-US` | `fr` |
|---|---|---|
| **Page A** before this PR | English text | **blank — `variantText` missing** |
| **Page A** after this PR | English text | **French text** ✅ |
| **Page B** before *and* after | English text | English text (by design) |

Page B losing the French text is the behaviour this PR deliberately does not change — one shared JSON document can only keep one value, and the default language wins. Confirming Page A is repaired **and** Page B is unchanged is what shows the fix is correctly scoped.

Two things to watch: do not save a page between steps 2 and 3 if you want to repeat the test, because saving persists the aligned value and the loss then becomes permanent; and on Page A the block itself still renders with only `variantText` missing rather than disappearing, since this document's `expose` entries carry both cultures.