### PR TITLE
Segments: Handle segment values for `IsPropertyValid`

### DIFF
--- a/src/Umbraco.Core/Services/IPropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/IPropertyValidationService.cs
@@ -18,6 +18,7 @@ public interface IPropertyValidationService
     /// <summary>
     ///     Gets a value indicating whether the property has valid values.
     /// </summary>
+    [Obsolete("Property level validation is not going to be supported moving forward. Please use content level validation with IsPropertyDataValid instead. Scheduled for removal in Umbraco 20.")]
     bool IsPropertyValid(IProperty property, PropertyValidationContext validationContext);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -183,6 +183,9 @@ public class PropertyValidationService : IPropertyValidationService
     }
 
     /// <inheritdoc />
+    // NOTE: we should make this internal rather than removing it entirely in V10, so the
+    //       referencing unit tests can continue to exercise this code.
+    [Obsolete("Property level validation is not going to be supported moving forward. Please use content level validation with IsPropertyDataValid instead. Scheduled for removal in Umbraco 20.")]
     public bool IsPropertyValid(IProperty property, PropertyValidationContext validationContext)
     {
         // NOTE - the pvalue and vvalues logic in here is borrowed directly from the Property.Values setter so if you are wondering what that's all about, look there.

--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -220,7 +220,7 @@ public class PropertyValidationService : IPropertyValidationService
         }
 
         // if the property varies by segment, make explicitly sure we validate mandatory against
-        // the non-segmented value (if present)
+        // the non-segmented value (or null, if not present)
         if (property.PropertyType.VariesBySegment())
         {
             IPropertyValue? defaultSegmentValue = property
@@ -298,10 +298,7 @@ public class PropertyValidationService : IPropertyValidationService
     }
 
     private static bool ShouldValidateAsRequired(IPropertyType propertyType, PropertyValidationContext validationContext)
-    {
-        var isRequired = propertyType.Mandatory && validationContext.Segment.IsNullOrWhiteSpace();
-        return isRequired;
-    }
+        => propertyType.Mandatory && validationContext.Segment.IsNullOrWhiteSpace();
 
     private IDataType? GetDataType(IPropertyType propertyType)
         => _dataTypeService.GetDataType(propertyType.DataTypeId);

--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -89,7 +89,7 @@ public class PropertyValidationService : IPropertyValidationService
             return [];
         }
 
-        var isRequired = propertyType.Mandatory && validationContext.Segment.IsNullOrWhiteSpace();
+        var isRequired = ShouldValidateAsRequired(propertyType, validationContext);
         return ValidatePropertyValue(dataEditor, dataType, postedValue, isRequired, propertyType.ValidationRegExp, propertyType.MandatoryMessage, propertyType.ValidationRegExpMessage, validationContext);
     }
 
@@ -219,6 +219,19 @@ public class PropertyValidationService : IPropertyValidationService
             return true;
         }
 
+        // if the property varies by segment, make explicitly sure we validate mandatory against
+        // the non-segmented value (if present)
+        if (property.PropertyType.VariesBySegment())
+        {
+            IPropertyValue? defaultSegmentValue = property
+                .Values
+                .FirstOrDefault(x => (culture == "*" || x.Culture.InvariantEquals(culture)) && x.Segment == null);
+            if (!IsValidPropertyValue(property, defaultSegmentValue?.EditedValue, PropertyValidationContext.CultureAndSegment(culture, null)))
+            {
+                return false;
+            }
+        }
+
         // if nothing else to validate, we are good
         if ((culture == null || culture == "*") && (segment == null || segment == "*") &&
             !property.PropertyType.VariesByCulture())
@@ -280,7 +293,14 @@ public class PropertyValidationService : IPropertyValidationService
         var configuration = GetDataType(propertyType)?.ConfigurationObject;
         IDataValueEditor valueEditor = editor.GetValueEditor(configuration);
 
-        return !valueEditor.Validate(value, propertyType.Mandatory, propertyType.ValidationRegExp, validationContext).Any();
+        var isRequired = ShouldValidateAsRequired(propertyType, validationContext);
+        return !valueEditor.Validate(value, isRequired, propertyType.ValidationRegExp, validationContext).Any();
+    }
+
+    private static bool ShouldValidateAsRequired(IPropertyType propertyType, PropertyValidationContext validationContext)
+    {
+        var isRequired = propertyType.Mandatory && validationContext.Segment.IsNullOrWhiteSpace();
+        return isRequired;
     }
 
     private IDataType? GetDataType(IPropertyType propertyType)

--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -226,7 +226,16 @@ public class PropertyValidationService : IPropertyValidationService
             IPropertyValue? defaultSegmentValue = property
                 .Values
                 .FirstOrDefault(x => (culture == "*" || x.Culture.InvariantEquals(culture)) && x.Segment == null);
-            if (!IsValidPropertyValue(property, defaultSegmentValue?.EditedValue, PropertyValidationContext.CultureAndSegment(culture, null)))
+            if (!IsValidPropertyValue(
+                    property,
+                    defaultSegmentValue?.EditedValue,
+                    new PropertyValidationContext
+                    {
+                        Culture = culture,
+                        Segment = null,
+                        CulturesBeingValidated = validationContext.CulturesBeingValidated,
+                        SegmentsBeingValidated = validationContext.SegmentsBeingValidated,
+                    }))
             {
                 return false;
             }
@@ -297,6 +306,13 @@ public class PropertyValidationService : IPropertyValidationService
         return !valueEditor.Validate(value, isRequired, propertyType.ValidationRegExp, validationContext).Any();
     }
 
+    /// <summary>
+    ///     Determines whether mandatory validation applies within the given validation context.
+    /// </summary>
+    /// <remarks>
+    ///     Values for non-default segments are optional overrides of the default segment value, so a mandatory
+    ///     property type is only enforced as required when validating the default (null) segment.
+    /// </remarks>
     private static bool ShouldValidateAsRequired(IPropertyType propertyType, PropertyValidationContext validationContext)
         => propertyType.Mandatory && validationContext.Segment.IsNullOrWhiteSpace();
 

--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -145,23 +145,30 @@ public class PropertyValidationService : IPropertyValidationService
             // impacts invariant = validate invariant property, invariant culture
             if (impact.ImpactsOnlyInvariantCulture)
             {
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
                 return !(propertyTypeVaries || IsPropertyValid(x, PropertyValidationContext.Empty()));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             // impacts all = validate property, all cultures (incl. invariant)
             if (impact.ImpactsAllCultures)
             {
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
                 return !IsPropertyValid(x, PropertyValidationContext.CultureAndSegment("*", null));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             // impacts explicit culture = validate variant property, explicit culture
             if (propertyTypeVaries)
             {
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
                 return !IsPropertyValid(x, PropertyValidationContext.CultureAndSegment(impact.Culture, null));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             if (impact.ImpactsExplicitCulture && GetDataEditor(x.PropertyType)?.CanMergePartialPropertyValues(x.PropertyType) is true)
             {
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
                 return !IsPropertyValid(x, new PropertyValidationContext
                 {
                     Culture = null,
@@ -169,6 +176,7 @@ public class PropertyValidationService : IPropertyValidationService
                     CulturesBeingValidated = [impact.Culture!],
                     SegmentsBeingValidated = []
                 });
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             // and, for explicit culture, we may also have to validate invariant property, invariant culture
@@ -176,15 +184,19 @@ public class PropertyValidationService : IPropertyValidationService
             // - it is impacted (default culture), or
             // - there is no published version of the content - maybe non-default culture, but no published version
             var alsoInvariant = impact.ImpactsAlsoInvariantProperties || !content.Published;
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
             return alsoInvariant && !IsPropertyValid(x, PropertyValidationContext.Empty());
+#pragma warning restore CS0618 // Type or member is obsolete
         }).ToArray();
 
         return invalidProperties.Length == 0;
     }
 
     /// <inheritdoc />
-    // NOTE: we should make this internal rather than removing it entirely in V10, so the
-    //       referencing unit tests can continue to exercise this code.
+    // TODO (V20): Make this internal rather than removing it entirely in V20, so the
+    // referencing unit tests can continue to exercise this code.
+    // Also remove the obsolete code warning suppressions added around the various
+    // callers to this method (including the unit tests).
     [Obsolete("Property level validation is not going to be supported moving forward. Please use content level validation with IsPropertyDataValid instead. Scheduled for removal in Umbraco 20.")]
     public bool IsPropertyValid(IProperty property, PropertyValidationContext validationContext)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
@@ -568,13 +568,19 @@ public class VariationTests
         Assert.IsNull(prop.GetValue(published: true));
         var propertyValidationService = GetPropertyValidationService();
 
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
         Assert.IsTrue(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.Empty()));
+#pragma warning restore CS0618 // Type or member is obsolete
 
         propertyType.Mandatory = true;
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
         Assert.IsTrue(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.Empty()));
+#pragma warning restore CS0618 // Type or member is obsolete
 
         prop.SetValue(null);
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
         Assert.IsFalse(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.Empty()));
+#pragma warning restore CS0618 // Type or member is obsolete
 
         // can publish, even though invalid
         prop.PublishValues();
@@ -606,13 +612,17 @@ public class VariationTests
         var prop = new Property(propertyType);
         var propertyValidationService = GetPropertyValidationService();
 
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
         // "no value" is valid for non-mandatory properties
         Assert.IsTrue(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.CultureAndSegment(culture, segment)));
+#pragma warning restore CS0618 // Type or member is obsolete
 
         propertyType.Mandatory = true;
 
         // "no value" is NOT valid for mandatory properties
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
         Assert.IsFalse(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.CultureAndSegment(culture, segment)));
+#pragma warning restore CS0618 // Type or member is obsolete
 
         // can publish, even though invalid
         prop.PublishValues();
@@ -640,8 +650,10 @@ public class VariationTests
 
         var propertyValidationService = GetPropertyValidationService();
 
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
         // property validation service ignores mandatory validation for segments
         Assert.IsTrue(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.CultureAndSegment(culture, "*")));
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     [TestCase(true)]
@@ -667,8 +679,10 @@ public class VariationTests
         var propertyValidationService = GetPropertyValidationService();
 
         // property validation service must apply mandatory validation to the default segment,
+#pragma warning disable CS0618 // Type or member is obsolete - IsPropertyValid() will be retained as internal after the obsoletion period.
         // even if a value exists for another segment
         Assert.IsFalse(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.CultureAndSegment(culture, "*")));
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private static Content CreateContent(IContentType contentType, int id = 1, string name = "content") =>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
@@ -618,6 +618,59 @@ public class VariationTests
         prop.PublishValues();
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SegmentValueIsNeverMandatoryTests(bool variesByCulture)
+    {
+        var variation = variesByCulture
+            ? ContentVariation.CultureAndSegment
+            : ContentVariation.Segment;
+
+        var culture = variesByCulture ? "en-US" : null;
+
+        var propertyType = new PropertyTypeBuilder()
+            .WithAlias("prop")
+            .WithSupportsPublishing(true)
+            .WithVariations(variation)
+            .WithMandatory(true)
+            .Build();
+
+        var prop = new Property(propertyType);
+        prop.SetValue("a", culture);
+
+        var propertyValidationService = GetPropertyValidationService();
+
+        // property validation service ignores mandatory validation for segments
+        Assert.IsTrue(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.CultureAndSegment(culture, "*")));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SegmentValueDoesNotSatisfyMandatoryTests(bool variesByCulture)
+    {
+        var variation = variesByCulture
+            ? ContentVariation.CultureAndSegment
+            : ContentVariation.Segment;
+
+        var culture = variesByCulture ? "en-US" : null;
+
+        var propertyType = new PropertyTypeBuilder()
+            .WithAlias("prop")
+            .WithSupportsPublishing(true)
+            .WithVariations(variation)
+            .WithMandatory(true)
+            .Build();
+
+        var prop = new Property(propertyType);
+        prop.SetValue("a", culture, "seg-1");
+
+        var propertyValidationService = GetPropertyValidationService();
+
+        // property validation service must apply mandatory validation to the default segment,
+        // even if a value exists for another segment
+        Assert.IsFalse(propertyValidationService.IsPropertyValid(prop, PropertyValidationContext.CultureAndSegment(culture, "*")));
+    }
+
     private static Content CreateContent(IContentType contentType, int id = 1, string name = "content") =>
         new ContentBuilder()
             .WithId(id)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is a follow-up for #23587, which amends two things in the `PropertyValidationService.IsPropertyValueValid()` method:

1. Ensures that the default (`null`) segment value is explicitly validated for segment variant property values, thus ensuring a missing default segment value will trigger a failed mandatory validation.
2. Omits the non-default segment values from mandatory validation, as they are always considered "optional overrides" to the default segment value.

### Testing

I have added unit tests to cover this.

As it turns out, this particular validation case is not reproducible by means of manual testing - at least, neither Claude nor myself have been able to trigger it. The code path _is_ exercised by the core, but not in this specific case.

It's still worth fixing, though, since `IsPropertyValueValid()` is part of the public interface.`IPropertyValidationService`.

Long story short: Visual inspection is the only feasible way of reviewing this PR.