### PR TITLE
Migrations: Resolve date default constraints by lookup rather than by convention (closes #23702)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNow.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNow.cs
@@ -11,6 +11,7 @@ public class SetDateDefaultsToUtcNow : UnscopedMigrationBase
 {
     private const string CreateDateColumnName = "createDate";
     private const string UpdateDateColumnName = "updateDate";
+
     private readonly IScopeProvider _scopeProvider;
 
     /// <summary>
@@ -21,6 +22,7 @@ public class SetDateDefaultsToUtcNow : UnscopedMigrationBase
     public SetDateDefaultsToUtcNow(IMigrationContext context, IScopeProvider scopeProvider)
         : base(context) => _scopeProvider = scopeProvider;
 
+    /// <inheritdoc/>
     protected override void Migrate()
     {
         if (DatabaseType == DatabaseType.SQLite)

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNow.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNow.cs
@@ -9,6 +9,8 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_0_0;
 /// </summary>
 public class SetDateDefaultsToUtcNow : UnscopedMigrationBase
 {
+    private const string CreateDateColumnName = "createDate";
+    private const string UpdateDateColumnName = "updateDate";
     private readonly IScopeProvider _scopeProvider;
 
     /// <summary>
@@ -46,25 +48,25 @@ public class SetDateDefaultsToUtcNow : UnscopedMigrationBase
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
         ScopeDatabase(scope);
 
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Access, "createDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Access, "updateDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.AccessRule, "createDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.AccessRule, "updateDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Access, CreateDateColumnName);
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Access, UpdateDateColumnName);
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.AccessRule, CreateDateColumnName);
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.AccessRule, UpdateDateColumnName);
         ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.AuditEntry, "eventDateUtc");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Consent, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Consent, CreateDateColumnName);
         ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.ContentVersion, "versionDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.CreatedPackageSchema, "updateDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.ExternalLogin, "createDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.ExternalLoginToken, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.CreatedPackageSchema, UpdateDateColumnName);
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.ExternalLogin, CreateDateColumnName);
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.ExternalLoginToken, CreateDateColumnName);
         ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.KeyValue, "updated");
         ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Log, "Datestamp");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Node, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Node, CreateDateColumnName);
         ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Relation, "datetime");
         ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Server, "registeredDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.User, "createDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.User, "updateDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.UserGroup, "createDate");
-        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.UserGroup, "updateDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.User, CreateDateColumnName);
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.User, UpdateDateColumnName);
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.UserGroup, CreateDateColumnName);
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.UserGroup, UpdateDateColumnName);
 
         Context.Complete();
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNow.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNow.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using NPoco;
 using Umbraco.Cms.Infrastructure.Scoping;
 
@@ -23,13 +24,11 @@ public class SetDateDefaultsToUtcNow : UnscopedMigrationBase
         if (DatabaseType == DatabaseType.SQLite)
         {
             MigrateSqlite();
-        }
-        else
-        {
-            MigrateSqlServer();
+            Context.Complete();
+            return;
         }
 
-        Context.Complete();
+        MigrateSqlServer();
     }
 
     private void MigrateSqlite()
@@ -47,35 +46,63 @@ public class SetDateDefaultsToUtcNow : UnscopedMigrationBase
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
         ScopeDatabase(scope);
 
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.Access, "createDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.Access, "updateDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.AccessRule, "createDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.AccessRule, "updateDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.AuditEntry, "eventDateUtc");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.Consent, "createDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.ContentVersion, "versionDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.CreatedPackageSchema, "updateDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.ExternalLogin, "createDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.ExternalLoginToken, "createDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.KeyValue, "updated");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.Log, "Datestamp");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.Node, "createDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.Relation, "datetime");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.Server, "registeredDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.User, "createDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.User, "updateDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.UserGroup, "createDate");
-        ModifySqlServerDefaultDateConstraint(scope, Core.Constants.DatabaseSchema.Tables.UserGroup, "updateDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Access, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Access, "updateDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.AccessRule, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.AccessRule, "updateDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.AuditEntry, "eventDateUtc");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Consent, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.ContentVersion, "versionDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.CreatedPackageSchema, "updateDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.ExternalLogin, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.ExternalLoginToken, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.KeyValue, "updated");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Log, "Datestamp");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Node, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Relation, "datetime");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.Server, "registeredDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.User, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.User, "updateDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.UserGroup, "createDate");
+        ModifySqlServerDefaultDateConstraint(Core.Constants.DatabaseSchema.Tables.UserGroup, "updateDate");
 
         Context.Complete();
 
         scope.Complete();
     }
 
-    private static void ModifySqlServerDefaultDateConstraint(IScope scope, string tableName, string columnName)
+    private void ModifySqlServerDefaultDateConstraint(string tableName, string columnName)
     {
-        var constraintName = $"DF_{tableName}_{columnName}";
-        scope.Database.Execute($"ALTER TABLE {tableName} DROP CONSTRAINT {constraintName}");
-        scope.Database.Execute($"ALTER TABLE {tableName} ADD CONSTRAINT {constraintName} DEFAULT GETUTCDATE() FOR {columnName}");
+        var quotedTableName = SqlSyntax.GetQuotedTableName(tableName);
+        var quotedColumnName = SqlSyntax.GetQuotedColumnName(columnName);
+        var expectedConstraintName = $"DF_{tableName}_{columnName}";
+
+        // A database whose schema was materialised outside of Umbraco can carry a system generated constraint name,
+        // or no default constraint at all, so the name we would generate for the column can't be assumed to be the
+        // one in use. Recreating under the expected name realigns the schema as a side effect.
+        if (SqlSyntax.TryGetDefaultConstraint(Database, tableName, columnName, out var existingConstraintName))
+        {
+            if (existingConstraintName.Equals(expectedConstraintName, StringComparison.Ordinal) is false)
+            {
+                Logger.LogInformation(
+                    "The default constraint on {TableName}.{ColumnName} is named {ExistingConstraintName} rather than {ExpectedConstraintName}. It will be recreated under the expected name.",
+                    tableName,
+                    columnName,
+                    existingConstraintName,
+                    expectedConstraintName);
+            }
+
+            Database.Execute(new Sql($"ALTER TABLE {quotedTableName} DROP CONSTRAINT {SqlSyntax.GetQuotedName(existingConstraintName)}"));
+        }
+        else
+        {
+            Logger.LogInformation(
+                "No default constraint was found on {TableName}.{ColumnName}. One will be created named {ExpectedConstraintName}.",
+                tableName,
+                columnName,
+                expectedConstraintName);
+        }
+
+        Database.Execute(new Sql($"ALTER TABLE {quotedTableName} ADD CONSTRAINT {SqlSyntax.GetQuotedName(expectedConstraintName)} DEFAULT GETUTCDATE() FOR {quotedColumnName}"));
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNowTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNowTests.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Infrastructure.Migrations;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_0_0;
 using Umbraco.Cms.Infrastructure.Persistence;
-using Umbraco.Cms.Persistence.SqlServer.Services;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -128,7 +127,7 @@ internal sealed class SetDateDefaultsToUtcNowTests : UmbracoIntegrationTest
         // go unnoticed here.
         Assert.That(result.Successful, Is.True, result.Exception?.ToString());
 
-        (string Name, string Definition)? constraint = GetDefaultConstraint();
+        DefaultConstraint? constraint = GetDefaultConstraint();
 
         Assert.Multiple(() =>
         {
@@ -147,20 +146,33 @@ internal sealed class SetDateDefaultsToUtcNowTests : UmbracoIntegrationTest
         return await upgrader.ExecuteAsync(MigrationPlanExecutor, ScopeProvider, Mock.Of<IKeyValueService>());
     }
 
-    private (string Name, string Definition)? GetDefaultConstraint()
+    // Queried directly rather than through the syntax provider, so that the assertion doesn't share a code path
+    // with the migration it is verifying.
+    private DefaultConstraint? GetDefaultConstraint()
     {
         using IUmbracoDatabase db = UmbracoDatabaseFactory.CreateDatabase();
-        var syntax = (SqlServerSyntaxProvider)db.SqlContext.SqlSyntax;
 
-        return syntax.GetDefaultConstraintsPerColumn(db)
-            .Where(x => x.Item1 == TableName && x.Item2 == ColumnName)
-            .Select(x => ((string Name, string Definition)?)(x.Item3, x.Item4))
-            .FirstOrDefault();
+        return db.Fetch<DefaultConstraint>(
+            @"SELECT dc.[name] AS [Name], dc.[definition] AS [Definition]
+FROM sys.default_constraints dc
+JOIN sys.tables tbl ON tbl.object_id = dc.parent_object_id
+JOIN sys.columns col ON col.object_id = dc.parent_object_id AND col.column_id = dc.parent_column_id
+JOIN sys.schemas s ON s.[schema_id] = tbl.[schema_id]
+WHERE s.[name] = SCHEMA_NAME() AND tbl.[name] = @0 AND col.[name] = @1;",
+            TableName,
+            ColumnName).FirstOrDefault();
     }
 
     private void ExecuteNonQuery(string sql)
     {
         using IUmbracoDatabase db = UmbracoDatabaseFactory.CreateDatabase();
         db.Execute(sql);
+    }
+
+    private sealed class DefaultConstraint
+    {
+        public string Name { get; set; } = null!;
+
+        public string Definition { get; set; } = null!;
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNowTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNowTests.cs
@@ -1,0 +1,166 @@
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_0_0;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V17_0_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class SetDateDefaultsToUtcNowTests : UmbracoIntegrationTest
+{
+    private const string TableName = "umbracoNode";
+    private const string ColumnName = "createDate";
+    private const string ExpectedConstraintName = "DF_umbracoNode_createDate";
+
+    private IMigrationBuilder MigrationBuilder => GetRequiredService<IMigrationBuilder>();
+
+    private IUmbracoDatabaseFactory UmbracoDatabaseFactory => GetRequiredService<IUmbracoDatabaseFactory>();
+
+    private IServiceScopeFactory ServiceScopeFactory => GetRequiredService<IServiceScopeFactory>();
+
+    private DistributedCache DistributedCache => GetRequiredService<DistributedCache>();
+
+    private IDatabaseCacheRebuilder DatabaseCacheRebuilder => GetRequiredService<IDatabaseCacheRebuilder>();
+
+    private IPublishedContentTypeFactory PublishedContentTypeFactory => GetRequiredService<IPublishedContentTypeFactory>();
+
+    private IMigrationPlanExecutor MigrationPlanExecutor => new MigrationPlanExecutor(
+        ScopeProvider,
+        ScopeAccessor,
+        LoggerFactory,
+        MigrationBuilder,
+        UmbracoDatabaseFactory,
+        DatabaseCacheRebuilder,
+        DistributedCache,
+        Mock.Of<IKeyValueService>(),
+        ServiceScopeFactory,
+        AppCaches.NoCache,
+        PublishedContentTypeFactory);
+
+    [Test]
+    public async Task Can_Migrate_When_Default_Constraint_Has_The_Expected_Name()
+    {
+        if (SkipOnSqlite())
+        {
+            return;
+        }
+
+        Assert.That(
+            GetDefaultConstraint()?.Name,
+            Is.EqualTo(ExpectedConstraintName),
+            "Arrange failed: a freshly created schema should carry the conventionally named constraint.");
+
+        ExecutedMigrationPlan result = await ExecuteMigration();
+
+        AssertMigratedToUtcDefault(result);
+    }
+
+    [Test]
+    public async Task Can_Migrate_When_Default_Constraint_Has_A_System_Generated_Name()
+    {
+        if (SkipOnSqlite())
+        {
+            return;
+        }
+
+        // Omitting the constraint name has SQL Server generate one, as happens on databases whose schema was
+        // materialised outside of Umbraco.
+        ExecuteNonQuery(
+            $"ALTER TABLE [{TableName}] DROP CONSTRAINT [{ExpectedConstraintName}];" +
+            $"ALTER TABLE [{TableName}] ADD DEFAULT (getdate()) FOR [{ColumnName}];");
+
+        Assert.That(
+            GetDefaultConstraint()?.Name,
+            Is.Not.Null.And.Not.EqualTo(ExpectedConstraintName),
+            "Arrange failed: the constraint should have been replaced by a system generated one.");
+
+        ExecutedMigrationPlan result = await ExecuteMigration();
+
+        AssertMigratedToUtcDefault(result);
+    }
+
+    [Test]
+    public async Task Can_Migrate_When_Default_Constraint_Is_Missing()
+    {
+        if (SkipOnSqlite())
+        {
+            return;
+        }
+
+        ExecuteNonQuery($"ALTER TABLE [{TableName}] DROP CONSTRAINT [{ExpectedConstraintName}];");
+
+        Assert.That(
+            GetDefaultConstraint(),
+            Is.Null,
+            "Arrange failed: the constraint should have been removed.");
+
+        ExecutedMigrationPlan result = await ExecuteMigration();
+
+        AssertMigratedToUtcDefault(result);
+    }
+
+    private static bool SkipOnSqlite()
+    {
+        if (BaseTestDatabase.IsSqlite() is false)
+        {
+            return false;
+        }
+
+        Assert.Ignore("Named default constraints are a SQL Server concept, so the migration is a no-op on SQLite.");
+        return true;
+    }
+
+    private void AssertMigratedToUtcDefault(ExecutedMigrationPlan result)
+    {
+        // The upgrader captures rather than throws migration exceptions, so a plan that failed would otherwise
+        // go unnoticed here.
+        Assert.That(result.Successful, Is.True, result.Exception?.ToString());
+
+        (string Name, string Definition)? constraint = GetDefaultConstraint();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(constraint?.Name, Is.EqualTo(ExpectedConstraintName));
+            Assert.That(constraint?.Definition, Does.Contain("getutcdate").IgnoreCase);
+        });
+    }
+
+    private async Task<ExecutedMigrationPlan> ExecuteMigration()
+    {
+        var upgrader = new Upgrader(
+            new MigrationPlan("SetDateDefaultsToUtcNowTest")
+                .From(string.Empty)
+                .To<SetDateDefaultsToUtcNow>("done"));
+
+        return await upgrader.ExecuteAsync(MigrationPlanExecutor, ScopeProvider, Mock.Of<IKeyValueService>());
+    }
+
+    private (string Name, string Definition)? GetDefaultConstraint()
+    {
+        using IUmbracoDatabase db = UmbracoDatabaseFactory.CreateDatabase();
+        var syntax = (SqlServerSyntaxProvider)db.SqlContext.SqlSyntax;
+
+        return syntax.GetDefaultConstraintsPerColumn(db)
+            .Where(x => x.Item1 == TableName && x.Item2 == ColumnName)
+            .Select(x => ((string Name, string Definition)?)(x.Item3, x.Item4))
+            .FirstOrDefault();
+    }
+
+    private void ExecuteNonQuery(string sql)
+    {
+        using IUmbracoDatabase db = UmbracoDatabaseFactory.CreateDatabase();
+        db.Execute(sql);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNowTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/SetDateDefaultsToUtcNowTests.cs
@@ -146,12 +146,12 @@ internal sealed class SetDateDefaultsToUtcNowTests : UmbracoIntegrationTest
         return await upgrader.ExecuteAsync(MigrationPlanExecutor, ScopeProvider, Mock.Of<IKeyValueService>());
     }
 
-    // Queried directly rather than through the syntax provider, so that the assertion doesn't share a code path
-    // with the migration it is verifying.
     private DefaultConstraint? GetDefaultConstraint()
     {
         using IUmbracoDatabase db = UmbracoDatabaseFactory.CreateDatabase();
 
+        // Queried directly rather than through the syntax provider, so that the assertion doesn't share a code path
+        // with the migration it is verifying.
         return db.Fetch<DefaultConstraint>(
             @"SELECT dc.[name] AS [Name], dc.[definition] AS [Definition]
 FROM sys.default_constraints dc


### PR DESCRIPTION
## Description

`V_17_0_0.SetDateDefaultsToUtcNow` swaps the date defaults from `GETDATE()` to `GETUTCDATE()`, which on SQL Server means dropping and re-adding the default constraint. It derived the constraint name from the `DF_{table}_{column}` convention and dropped it unconditionally across 20 columns, so the upgrade aborted on the first column where reality didn't match:

> 'DF_umbracoAccess_createDate' is not a constraint. Could not drop constraint.

Two variants are being reported — the constraint present under a SQL Server generated name such as `DF__umbracoAc__creat__4D4A6ED8` ([forum thread](https://forum.umbraco.com/t/upgrade-13-5-2-17-1-0/7251)), and the constraint absent altogether ([Stephan's 13 → 17 write-up](https://www.zpqrtbnk.net/posts/umbraco-13-to-17/)). Either way the site is blocked until the database is patched by hand, and `sp_rename` scripts are now circulating in the community.

Umbraco has never emitted an unnamed default on SQL Server — `FormatConstraint` has supplied `DF_{table}_{column}` unchanged since `release-7.0.4`. The drift comes from how these particular databases were materialised (most plausibly a SQL CE or MySQL → SQL Server rebuild, neither of which has named default constraints), so the name in the catalogue simply isn't something a migration can assume.

The migration now reads the current name via `ISqlSyntaxProvider.TryGetDefaultConstraint`, drops it only when one exists, and recreates it under the expected name — so it is name-agnostic, tolerant of a missing constraint, and leaves the upgraded database on the canonical names.

Fixes #23702.

## Testing

### Automated

A new SQL Server integration test fixture covers a system generated name, a missing constraint and the already-canonical happy path; the first two fail against the previous implementation with SQL error 3728.

### Manual

**Must be SQL Server.** The migration is a documented no-op on SQLite, so nothing is exercised there.

#### Setup

1. A v13 site on SQL Server (LocalDB is fine), booted at least once so the schema is complete.
2. Take a backup — you'll want to run the "before" and "after" passes from the same starting point.
3. Induce the drift with one of the two variants below. `umbracoNode.createDate` is the easiest to watch, but applying it to several tables (`umbracoAccess`, `umbracoAccessRule`, `umbracoLog`, `umbracoRelation`, `umbracoServer`) reproduces the reported case more faithfully.

**Variant A — constraint present under a system-generated name** (the forum report). Omitting the name has SQL Server generate one, e.g. `DF__umbracoNo__creat__5D80D6A1`:

```sql
ALTER TABLE umbracoNode DROP CONSTRAINT DF_umbracoNode_createDate;
ALTER TABLE umbracoNode ADD DEFAULT (getdate()) FOR createDate;
```

**Variant B — constraint missing entirely** (Stephan's report):

```sql
ALTER TABLE umbracoNode DROP CONSTRAINT DF_umbracoNode_createDate;
```

Confirm the drift landed before upgrading:

```sql
SELECT t.name AS TableName, c.name AS ColumnName, dc.name AS ConstraintName, dc.definition
FROM sys.default_constraints dc
JOIN sys.tables t ON t.object_id = dc.parent_object_id
JOIN sys.columns c ON c.object_id = dc.parent_object_id AND c.column_id = dc.parent_column_id
WHERE t.name = 'umbracoNode' AND c.name = 'createDate';
```

Variant A shows a `DF__…` name; variant B returns no rows.

#### Before (current 17.x)

Point a 17.x site at the database and run the upgrade.

**Expected failure** — the upgrade screen reports:

> The database failed to upgrade. ERROR: The database configuration failed with the following message: 'DF_umbracoNode_createDate' is not a constraint. Could not drop constraint.

(SQL error 3728. Variant B produces the same message — SQL Server reports a missing constraint and a wrongly-named one identically.) The site stays in the upgrade state.

The migration runs in a single transaction, so the failed attempt leaves the database untouched. You can point the fixed build at the *same* database without restoring the backup.

#### After (this PR)

Run the upgrade again on a build containing the fix.

**Expected:** the upgrade completes and the site boots.

Re-run the query above — for both variants it should now return exactly:

| ConstraintName | definition |
|---|---|
| `DF_umbracoNode_createDate` | `(getutcdate())` |

Widen it to check the full set of 20 columns the migration touches — every one should be named `DF_<table>_<column>` with a `(getutcdate())` definition:

```sql
SELECT t.name AS TableName, c.name AS ColumnName, dc.name AS ConstraintName, dc.definition
FROM sys.default_constraints dc
JOIN sys.tables t ON t.object_id = dc.parent_object_id
JOIN sys.columns c ON c.object_id = dc.parent_object_id AND c.column_id = dc.parent_column_id
WHERE t.name IN (
    'umbracoAccess', 'umbracoAccessRule', 'umbracoAudit', 'umbracoConsent',
    'umbracoContentVersion', 'umbracoCreatedPackageSchema', 'umbracoExternalLogin',
    'umbracoExternalLoginToken', 'umbracoKeyValue', 'umbracoLog', 'umbracoNode',
    'umbracoRelation', 'umbracoServer', 'umbracoUser', 'umbracoUserGroup')
ORDER BY t.name, c.name;
```

The upgrade log should also record what was healed, at Information level:

- Variant A — `The default constraint on umbracoNode.createDate is named DF__umbracoNo__creat__5D80D6A1 rather than DF_umbracoNode_createDate. It will be recreated under the expected name.`
- Variant B — `No default constraint was found on umbracoNode.createDate. One will be created named DF_umbracoNode_createDate.`

