### PR TITLE
Migrations: Don't rebuild the published cache after a failed migration plan (closes #23612)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -159,8 +159,21 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
         // If any completed migration requires us to rebuild cache we'll do that.
         if (_rebuildCache)
         {
-            _logger.LogInformation("Starts rebuilding the cache. This can be a long running operation");
-            await RebuildCache();
+            if (result.Successful)
+            {
+                _logger.LogInformation("Starts rebuilding the cache. This can be a long running operation");
+                await RebuildCache();
+            }
+            else
+            {
+                // A rebuild may depend on infrastructure that migrations part way through the plan put in place so
+                // attempting one on a failed plan could also error and mask the migration failure (#23612).
+                // The warning is necessary as even if the problem is fixed and the plan runs successfully to completion
+                // on a second attempt, the step that requested the rebuild may have completed and will not be run again.
+                _logger.LogWarning(
+                    "Skipping the cache rebuild requested by plan {PlanName} as it did not run to completion. Rebuild the published cache once the upgrade has completed successfully.",
+                    plan.Name);
+            }
         }
 
         // If any completed migration requires us to sign out the user we'll do that.

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -171,7 +171,7 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
                 // The warning is necessary as even if the problem is fixed and the plan runs successfully to completion
                 // on a second attempt, the step that requested the rebuild may have completed and will not be run again.
                 _logger.LogWarning(
-                    "Skipping the cache rebuild requested by plan {PlanName} as it did not run to completion. Rebuild the published cache once the upgrade has completed successfully.",
+                    "Skipping the cache rebuild requested by plan {PlanName} as it did not run to completion - the published cache should be rebuilt manually once the upgrade completes",
                     plan.Name);
             }
         }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/MigrationPlanExecutorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/MigrationPlanExecutorTests.cs
@@ -73,6 +73,27 @@ internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
         Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(2));
     }
 
+    // A rebuild depends on infrastructure that migrations part way through the plan put in place, so a plan that
+    // stopped before reaching it should not attempt one (it will fail, and mask the migration failure, #23612).
+    [Test]
+    public async Task Cannot_Rebuild_Cache_For_Plan_That_Did_Not_Complete()
+    {
+        MigrationPlanExecutor executor = CreateExecutor();
+
+        MigrationPlan plan = new MigrationPlan("failing")
+            .From(string.Empty)
+            .To<RebuildCacheMigration>("rebuild-requested")
+            .To<FailingMigration>("done");
+
+        ExecutedMigrationPlan result = await executor.ExecutePlanAsync(plan, string.Empty);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Successful, Is.False);
+            Assert.That(_databaseCacheRebuilder.RebuildCount, Is.EqualTo(0));
+        });
+    }
+
     private static async Task ExecutePlanAsync<TMigration>(MigrationPlanExecutor executor, string name)
         where TMigration : AsyncMigrationBase
     {
@@ -126,6 +147,16 @@ internal sealed class MigrationPlanExecutorTests : UmbracoIntegrationTest
         }
 
         protected override Task MigrateAsync() => Task.CompletedTask;
+    }
+
+    public class FailingMigration : AsyncMigrationBase
+    {
+        public FailingMigration(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        protected override Task MigrateAsync() => throw new InvalidOperationException("Migration failed.");
     }
 
     private sealed class CountingDatabaseCacheRebuilder : IDatabaseCacheRebuilder


### PR DESCRIPTION
## Description

`MigrationPlanExecutor.ExecutePlanAsync` ran the post-plan cache rebuild without checking whether the plan had actually completed. `RunMigrationPlanAsync` swallows a migration failure into the returned `ExecutedMigrationPlan` rather than throwing, so a plan that stopped part way still went on to rebuild the cache.

That rebuild takes the `LongRunningOperations` lock (`-344`) and writes to `umbracoLongRunningOperation`, neither of which exists until `V_16_2_0.AddLongRunningOperations`. On a v13 → v17 upgrade the rebuild is requested much earlier — both `V_14_0_0.MigrateDataTypeConfigurations` and `V_15_0_0.ConvertLocalLinks` set it — so any migration failing between 14.0 and 16.2 ended up throwing `LockObject with id=-344 does not exist`.

That `ArgumentException` escapes `ExecutePlanAsync` and is caught by the outer `try` in `DatabaseBuilder.UpgradeSchemaAndDataAsync`, so the `result.Successful is false` branch that reports the *real* migration exception is never reached. The reported error is a red herring: it replaces the actual cause of the failed upgrade, which is only visible in the log on the preceding `Plan Umbraco.Core failed at step {guid}` line.

The rebuild is now attempted only when the plan ran to completion, and a warning is logged when one is requested but skipped. - `_rebuildCache` only lives in memory, so a plan that fails and is later resumed won't rebuild the cache at all: the migrations that asked for it have already completed and won't re-run. That's the reason for the warning being logged.

Fixes #23612

For the specific situation of the reporter: this stops the misleading error, but it does not fix whatever migration was failing underneath it on the reporter's site. That will now be reported correctly instead.

## Testing

### Automatic

A new integration test `Cannot_Rebuild_Cache_For_Plan_That_Did_Not_Complete`, was verified failing before the fix and passing afterwards.

### Manual

Set up a 13 database for migration using attended upgrades and add a breaking migration by modifying `MigrateTinyMceToTiptap` to throw an exception.  Prior to this fix you should see the reported error of "LockObject with id=-344 does not exist".

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6211f1eb-fc89-46ae-8522-af53d82a9f43" />

After the fix, the added error in `MigrateTinyMceToTiptap` should be reported, and the cache update not run. 

<img width="400" src="https://github.com/user-attachments/assets/bee494f7-0042-45b2-af1e-9f8cbce97292" />

