### PR TITLE
oEmbed: Fix HttpClient initialization race in OEmbedProviderBase (closes #23697)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
@@ -68,7 +68,7 @@ public class NewsDashboardService : INewsDashboardService
     /// <param name="backOfficeSecurityAccessor">Accessor for back office security context and operations.</param>
     /// <param name="globalSettings">The global settings configuration options for the application.</param>
     /// <param name="newsCacheDurationProvider">Provides the duration for which news content is cached.</param>
-    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19")]
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
     public NewsDashboardService(
         AppCaches appCaches,
         IUmbracoVersion umbracoVersion,
@@ -98,7 +98,7 @@ public class NewsDashboardService : INewsDashboardService
     /// <param name="logger">The logger used for logging diagnostic and operational information.</param>
     /// <param name="backOfficeSecurityAccessor">Accessor for back office security context and operations.</param>
     /// <param name="globalSettings">The global settings configuration options for the application.</param>
-    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19")]
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
     public NewsDashboardService(
         AppCaches appCaches,
         IUmbracoVersion umbracoVersion,
@@ -141,7 +141,7 @@ public class NewsDashboardService : INewsDashboardService
 
         try
         {
-            HttpClient httpClient = _httpClientFactory.CreateClient(Constants.HttpClients.NewsDashboard);
+            HttpClient httpClient = _httpClientFactory.CreateClient(Constants.HttpClients.News);
             var json = await httpClient.GetStringAsync(url);
 
             if (TryMapModel(json, out NewsDashboardResponseModel? model))

--- a/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
@@ -25,12 +25,19 @@ public class NewsDashboardService : INewsDashboardService
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
     private readonly GlobalSettings _globalSettings;
     private readonly INewsCacheDurationProvider _newsCacheDurationProvider;
-
-    private static readonly HttpClient _httpClient = new();
+    private readonly IHttpClientFactory _httpClientFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NewsDashboardService"/> class.
     /// </summary>
+    /// <param name="appCaches">Provides access to application-level caching mechanisms.</param>
+    /// <param name="umbracoVersion">Provides information about the current Umbraco version.</param>
+    /// <param name="siteIdentifierService">Service used to retrieve or manage the unique site identifier.</param>
+    /// <param name="logger">The logger used for logging diagnostic and operational information.</param>
+    /// <param name="backOfficeSecurityAccessor">Accessor for back office security context and operations.</param>
+    /// <param name="globalSettings">The global settings configuration options for the application.</param>
+    /// <param name="newsCacheDurationProvider">Provides the duration for which news content is cached.</param>
+    /// <param name="httpClientFactory">The factory used to create the client requesting the news content.</param>
     public NewsDashboardService(
         AppCaches appCaches,
         IUmbracoVersion umbracoVersion,
@@ -38,7 +45,8 @@ public class NewsDashboardService : INewsDashboardService
         ILogger<NewsDashboardService> logger,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
         IOptions<GlobalSettings> globalSettings,
-        INewsCacheDurationProvider newsCacheDurationProvider)
+        INewsCacheDurationProvider newsCacheDurationProvider,
+        IHttpClientFactory httpClientFactory)
     {
         _appCaches = appCaches;
         _umbracoVersion = umbracoVersion;
@@ -47,6 +55,38 @@ public class NewsDashboardService : INewsDashboardService
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
         _globalSettings = globalSettings.Value;
         _newsCacheDurationProvider = newsCacheDurationProvider;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NewsDashboardService"/> class.
+    /// </summary>
+    /// <param name="appCaches">Provides access to application-level caching mechanisms.</param>
+    /// <param name="umbracoVersion">Provides information about the current Umbraco version.</param>
+    /// <param name="siteIdentifierService">Service used to retrieve or manage the unique site identifier.</param>
+    /// <param name="logger">The logger used for logging diagnostic and operational information.</param>
+    /// <param name="backOfficeSecurityAccessor">Accessor for back office security context and operations.</param>
+    /// <param name="globalSettings">The global settings configuration options for the application.</param>
+    /// <param name="newsCacheDurationProvider">Provides the duration for which news content is cached.</param>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19")]
+    public NewsDashboardService(
+        AppCaches appCaches,
+        IUmbracoVersion umbracoVersion,
+        ISiteIdentifierService siteIdentifierService,
+        ILogger<NewsDashboardService> logger,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IOptions<GlobalSettings> globalSettings,
+        INewsCacheDurationProvider newsCacheDurationProvider)
+        : this(
+            appCaches,
+            umbracoVersion,
+            siteIdentifierService,
+            logger,
+            backOfficeSecurityAccessor,
+            globalSettings,
+            newsCacheDurationProvider,
+            StaticServiceProvider.Instance.GetRequiredService<IHttpClientFactory>())
+    {
     }
 
     /// <summary>
@@ -66,14 +106,16 @@ public class NewsDashboardService : INewsDashboardService
         ILogger<NewsDashboardService> logger,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
         IOptions<GlobalSettings> globalSettings)
+#pragma warning disable CS0618 // Type or member is obsolete
         : this(
-        appCaches,
-        umbracoVersion,
-        siteIdentifierService,
-        logger,
-        backOfficeSecurityAccessor,
-        globalSettings,
-        StaticServiceProvider.Instance.GetRequiredService<INewsCacheDurationProvider>())
+            appCaches,
+            umbracoVersion,
+            siteIdentifierService,
+            logger,
+            backOfficeSecurityAccessor,
+            globalSettings,
+            StaticServiceProvider.Instance.GetRequiredService<INewsCacheDurationProvider>())
+#pragma warning restore CS0618 // Type or member is obsolete
     {
     }
 
@@ -99,7 +141,8 @@ public class NewsDashboardService : INewsDashboardService
 
         try
         {
-            var json = await _httpClient.GetStringAsync(url);
+            HttpClient httpClient = _httpClientFactory.CreateClient(Constants.HttpClients.NewsDashboard);
+            var json = await httpClient.GetStringAsync(url);
 
             if (TryMapModel(json, out NewsDashboardResponseModel? model))
             {

--- a/src/Umbraco.Core/CLAUDE.md
+++ b/src/Umbraco.Core/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **Umbraco.Core** is the foundational layer of Umbraco CMS, containing the core domain models, services interfaces, events/notifications system, and essential abstractions. This project has NO database implementation and minimal external dependencies - it focuses on defining contracts and business logic.
 
-**Package ID**: `Umbraco.Cms.Core`  
+**Package ID**: `Umbraco.Cms.Core`
 **Namespace**: `Umbraco.Cms.Core`
 
 ### What Lives Here vs. Other Projects
@@ -162,10 +162,10 @@ public class MyComposer : IComposer
     {
         // Register services
         builder.Services.AddSingleton<IMyService, MyService>();
-        
+
         // Add to collections
         builder.PropertyEditors().Add<MyPropertyEditor>();
-        
+
         // Register notification handlers
         builder.AddNotificationHandler<ContentSavedNotification, MyHandler>();
     }
@@ -202,14 +202,14 @@ IEntity                     - Base: Id, Key, CreateDate, UpdateDate
 public class MyService
 {
     private readonly ICoreScopeProvider _scopeProvider;
-    
+
     public void DoWork()
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
-        
+
         // Do database work
         // Access repositories
-        
+
         scope.Complete(); // Commit transaction
     }
 }
@@ -229,12 +229,12 @@ Property editors define how data is edited and stored:
 public class MyPropertyEditor : IDataEditor
 {
     public string Alias => "My.PropertyEditor";
-    
+
     public IDataValueEditor GetValueEditor()
     {
         return new MyDataValueEditor();
     }
-    
+
     public IConfigurationEditor GetConfigurationEditor()
     {
         return new MyConfigurationEditor();
@@ -257,12 +257,12 @@ public class MyEntityCacheRefresher : CacheRefresherBase<MyEntityCacheRefresher>
 {
     public override Guid RefresherUniqueId => new Guid("...");
     public override string Name => "My Entity Cache Refresher";
-    
+
     public override void RefreshAll()
     {
         // Clear all cache
     }
-    
+
     public override void Refresh(int id)
     {
         // Clear cache for specific entity
@@ -387,7 +387,7 @@ public class MyContentHandler : INotificationHandler<ContentSavingNotification>
         {
             // Validate, modify, or react
         }
-        
+
         // Cancel if needed (for cancellable notifications)
         // notification.Cancel = true;
     }
@@ -407,7 +407,7 @@ public class MyPropertyEditor : DataEditor
     public MyPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
         : base(dataValueEditorFactory)
     { }
-    
+
     protected override IDataValueEditor CreateValueEditor()
     {
         return DataValueEditorFactory.Create<MyValueEditor>(Attribute!);
@@ -425,21 +425,21 @@ public class MyService
 {
     private readonly IContentService _contentService;
     private readonly ICoreScopeProvider _scopeProvider;
-    
+
     public async Task UpdateContentAsync(Guid key)
     {
         using var scope = _scopeProvider.CreateCoreScope();
-        
+
         IContent? content = _contentService.GetById(key);
         if (content == null)
             return;
-        
+
         // Modify content
         content.SetValue("propertyAlias", "new value");
-        
+
         // Save (triggers notifications)
         var result = _contentService.Save(content);
-        
+
         scope.Complete();
     }
 }
@@ -519,6 +519,7 @@ Internal types are accessible in test projects for more thorough testing.
 7. **Published vs Draft** - `IContent` is draft, `IPublishedContent` is published
 8. **Constants** - Use constants instead of magic strings (property editor aliases, etc.)
 9. **Distributed-cache-only publishers skip plain handlers** - handlers doing durable work (e.g. DB writes) must implement `IDistributedCacheNotificationHandler` / `IDistributedCacheAsyncNotificationHandler<T>`, or they won't fire under Umbraco Deploy and similar restricted scopes.
+10. **Outbound HTTP** - new code injects `IHttpClientFactory` and uses a named client from `AddHttpClients()`; `SharedHttpClient` is only a shim for call sites that can't take that dependency without a breaking change. Never publish an `HttpClient` before configuring it, or mutate a shared one's `DefaultRequestHeaders` after first use - `HttpHeaders` isn't thread safe.
 
 ## Navigation Tips
 

--- a/src/Umbraco.Core/Constants-HttpClients.cs
+++ b/src/Umbraco.Core/Constants-HttpClients.cs
@@ -22,6 +22,11 @@ public static partial class Constants
         public const string WebhookFiring = "Umbraco:HttpClients:WebhookFiring";
 
         /// <summary>
+        ///     Name for http client which requests the back office news dashboard content.
+        /// </summary>
+        public const string NewsDashboard = "Umbraco:HttpClients:NewsDashboard";
+
+        /// <summary>
         ///     Contains HTTP header constants for Umbraco HTTP clients.
         /// </summary>
         public static class Headers

--- a/src/Umbraco.Core/Constants-HttpClients.cs
+++ b/src/Umbraco.Core/Constants-HttpClients.cs
@@ -24,7 +24,7 @@ public static partial class Constants
         /// <summary>
         ///     Name for http client which requests the back office news dashboard content.
         /// </summary>
-        public const string NewsDashboard = "Umbraco:HttpClients:NewsDashboard";
+        public const string News = "Umbraco:HttpClients:News";
 
         /// <summary>
         ///     Contains HTTP header constants for Umbraco HTTP clients.

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/BaseHttpHeaderCheck.cs
@@ -3,6 +3,7 @@
 
 using System.Text.RegularExpressions;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
@@ -13,7 +14,6 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security;
 /// </summary>
 public abstract class BaseHttpHeaderCheck : HealthCheck
 {
-    private static HttpClient? _httpClient;
     private readonly string _header;
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly string _localizedTextPrefix;
@@ -56,7 +56,7 @@ public abstract class BaseHttpHeaderCheck : HealthCheck
     /// </summary>
     protected abstract string ReadMoreLink { get; }
 
-    private static HttpClient HttpClient => _httpClient ??= new HttpClient();
+    private static HttpClient HttpClient => SharedHttpClient.Instance;
 
     /// <inheritdoc />
     public override async Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/ExcessiveHeadersCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/ExcessiveHeadersCheck.cs
@@ -2,6 +2,7 @@
 // See LICENSE for more details.
 
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
@@ -17,7 +18,6 @@ namespace Umbraco.Cms.Core.HealthChecks.Checks.Security;
     Group = "Security")]
 public class ExcessiveHeadersCheck : HealthCheck
 {
-    private static HttpClient? httpClient;
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly ILocalizedTextService _textService;
 
@@ -30,7 +30,7 @@ public class ExcessiveHeadersCheck : HealthCheck
         _hostingEnvironment = hostingEnvironment;
     }
 
-    private static HttpClient HttpClient => httpClient ??= new HttpClient();
+    private static HttpClient HttpClient => SharedHttpClient.Instance;
 
     /// <inheritdoc />
     public override async Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()

--- a/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
+++ b/src/Umbraco.Core/Media/EmbedProviders/OEmbedProviderBase.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Xml;
+using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.Media.EmbedProviders;
@@ -10,7 +11,8 @@ namespace Umbraco.Cms.Core.Media.EmbedProviders;
 /// </summary>
 public abstract class OEmbedProviderBase : IEmbedProvider
 {
-    private static HttpClient? _httpClient;
+    private static readonly TimeSpan _requestTimeout = TimeSpan.FromSeconds(20);
+
     private readonly IJsonSerializer _jsonSerializer;
 
     /// <summary>
@@ -78,6 +80,18 @@ public abstract class OEmbedProviderBase : IEmbedProvider
     }
 
     /// <summary>
+    ///     Gets the <see cref="HttpClient"/> used to request the OEmbed response.
+    /// </summary>
+    /// <returns>The <see cref="HttpClient"/> to use.</returns>
+    /// <remarks>
+    ///     Returns a shared, process-wide instance which must not be mutated - do not assign
+    ///     <see cref="HttpClient.Timeout"/>, <see cref="HttpClient.BaseAddress"/> or default headers on it.
+    ///     A derived provider that needs its own configuration should override this and return a client
+    ///     obtained from <c>IHttpClientFactory</c>.
+    /// </remarks>
+    protected virtual HttpClient GetHttpClient() => SharedHttpClient.Instance;
+
+    /// <summary>
     ///     Downloads the response content from the specified URL.
     /// </summary>
     /// <param name="url">The URL to download from.</param>
@@ -85,17 +99,15 @@ public abstract class OEmbedProviderBase : IEmbedProvider
     /// <returns>A task that represents the asynchronous operation, containing the response content as a string.</returns>
     public virtual async Task<string> DownloadResponseAsync(string url, CancellationToken cancellationToken)
     {
-        if (_httpClient == null)
-        {
-            _httpClient = new HttpClient();
-            _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(Constants.HttpClients.Headers.UserAgentProductName);
-        }
+        // The timeout is applied per request rather than via HttpClient.Timeout, as the client is shared
+        // with other callers that need a more forgiving timeout, and Timeout cannot be changed once the
+        // client has been used.
+        using var timeoutCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCancellation.CancelAfter(_requestTimeout);
 
-        using (var request = new HttpRequestMessage(HttpMethod.Get, url))
-        {
-            using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-            return await response.Content.ReadAsStringAsync(cancellationToken);
-        }
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        using HttpResponseMessage response = await GetHttpClient().SendAsync(request, timeoutCancellation.Token);
+        return await response.Content.ReadAsStringAsync(timeoutCancellation.Token);
     }
 
     /// <summary>
@@ -128,7 +140,7 @@ public abstract class OEmbedProviderBase : IEmbedProvider
         {
             DtdProcessing = DtdProcessing.Prohibit,
             XmlResolver = null,
-            CloseInput = true
+            CloseInput = true,
         };
         using var reader = XmlReader.Create(new StringReader(response), settings);
         doc.Load(reader);

--- a/src/Umbraco.Core/Net/SharedHttpClient.cs
+++ b/src/Umbraco.Core/Net/SharedHttpClient.cs
@@ -1,0 +1,52 @@
+namespace Umbraco.Cms.Core.Net;
+
+/// <summary>
+/// Provides a correctly configured, process-wide <see cref="HttpClient"/> for Umbraco's own outbound
+/// requests from code that cannot take an <c>IHttpClientFactory</c> dependency.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>New code should not use this.</b> Inject <c>IHttpClientFactory</c> and resolve a named client
+/// registered in <c>AddHttpClients()</c> instead. That is the supported approach: it gives consumers a
+/// configuration point, and it keeps the calling code testable.
+/// </para>
+/// <para>
+/// This type exists for the call sites that predate that guidance and cannot adopt it without a breaking
+/// change - a public abstract base class whose constructor signature is part of the contract for
+/// third-party implementations, or a type instantiated outside the DI container. It is a narrowly scoped
+/// shim, not a general-purpose alternative.
+/// </para>
+/// <para>
+/// The instance is created through a static initializer so that all configuration - in particular the
+/// default request headers - completes before any thread can observe it. Mutating
+/// <see cref="HttpClient.DefaultRequestHeaders"/> once a request is in flight is not thread safe and can
+/// fault the request writer (#23697).
+/// </para>
+/// <para>
+/// Because the instance is shared, callers must treat it as immutable: do not assign
+/// <see cref="HttpClient.Timeout"/>, <see cref="HttpClient.BaseAddress"/> or default headers on it. Apply
+/// a per-request timeout with a linked <see cref="CancellationTokenSource"/> instead.
+/// </para>
+/// </remarks>
+internal static class SharedHttpClient
+{
+    private static readonly TimeSpan _connectionLifetime = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Gets the shared <see cref="HttpClient"/> instance.
+    /// </summary>
+    internal static HttpClient Instance { get; } = Create();
+
+    private static HttpClient Create()
+    {
+        // A pooled connection lifetime is required because this client lives for the lifetime of the
+        // process; without it, DNS changes are never picked up. This mirrors what IHttpClientFactory does
+        // by rotating its handlers.
+        var handler = new SocketsHttpHandler { PooledConnectionLifetime = _connectionLifetime };
+
+        var client = new HttpClient(handler);
+        client.DefaultRequestHeaders.UserAgent.TryParseAdd(Constants.HttpClients.Headers.UserAgentProductName);
+
+        return client;
+    }
+}

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -255,7 +255,7 @@ public static partial class UmbracoBuilderExtensions
             var productVersion = services.GetRequiredService<IUmbracoVersion>().SemanticVersion.ToSemanticStringWithoutBuild();
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(Constants.HttpClients.Headers.UserAgentProductName, productVersion));
         });
-        builder.Services.AddHttpClient(Constants.HttpClients.NewsDashboard, client =>
+        builder.Services.AddHttpClient(Constants.HttpClients.News, client =>
         {
             client.DefaultRequestHeaders.UserAgent.TryParseAdd(Constants.HttpClients.Headers.UserAgentProductName);
             client.Timeout = TimeSpan.FromSeconds(20);

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -255,6 +255,11 @@ public static partial class UmbracoBuilderExtensions
             var productVersion = services.GetRequiredService<IUmbracoVersion>().SemanticVersion.ToSemanticStringWithoutBuild();
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(Constants.HttpClients.Headers.UserAgentProductName, productVersion));
         });
+        builder.Services.AddHttpClient(Constants.HttpClients.NewsDashboard, client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.TryParseAdd(Constants.HttpClients.Headers.UserAgentProductName);
+            client.Timeout = TimeSpan.FromSeconds(20);
+        });
         return builder;
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Conventions/HttpClientConventionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Conventions/HttpClientConventionTests.cs
@@ -1,15 +1,10 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
 using System.Reflection;
 using NUnit.Framework;
 
-namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.CoreThings;
+namespace Umbraco.Cms.Tests.UnitTests.Conventions;
 
 [TestFixture]
 public class HttpClientConventionTests
@@ -37,8 +32,7 @@ public class HttpClientConventionTests
         Assert.That(
             offenders,
             Is.Empty,
-            "Static HttpClient fields must be readonly and fully configured on assignment. Use SharedHttpClient "
-            + "for existing call sites that cannot take a dependency, or inject IHttpClientFactory in new code.");
+            "Static HttpClient fields must be readonly and fully configured on assignment. Use SharedHttpClient for existing call sites that cannot take a dependency, or inject IHttpClientFactory in new code.");
     }
 
     private static Assembly[] GetUmbracoAssemblies()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/HttpClientConventionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/HttpClientConventionTests.cs
@@ -3,28 +3,26 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using NUnit.Framework;
-using Umbraco.Cms.Api.Management.Services.NewsDashboard;
-using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.CoreThings;
 
 [TestFixture]
 public class HttpClientConventionTests
 {
-    private static readonly Assembly[] Assemblies =
-    [
-        typeof(Constants).Assembly,
-        typeof(NewsDashboardService).Assembly,
-    ];
-
     [Test]
     public void Cannot_Declare_Mutable_Static_HttpClient_Field()
     {
-        var offenders = Assemblies
+        Assembly[] assemblies = GetUmbracoAssemblies();
+
+        // Guard against the discovery silently covering nothing if the output layout ever changes.
+        Assert.That(assemblies, Is.Not.Empty, "No Umbraco assemblies were discovered to check.");
+
+        var offenders = assemblies
             .SelectMany(GetLoadableTypes)
             .SelectMany(type => type.GetFields(
                 BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
@@ -41,6 +39,26 @@ public class HttpClientConventionTests
             Is.Empty,
             "Static HttpClient fields must be readonly and fully configured on assignment. Use SharedHttpClient "
             + "for existing call sites that cannot take a dependency, or inject IHttpClientFactory in new code.");
+    }
+
+    private static Assembly[] GetUmbracoAssemblies()
+        => Directory
+            .EnumerateFiles(AppContext.BaseDirectory, "Umbraco.*.dll")
+            .Where(path => Path.GetFileName(path).StartsWith("Umbraco.Tests.", StringComparison.Ordinal) is false)
+            .Select(TryLoad)
+            .Where(assembly => assembly is not null)
+            .ToArray()!;
+
+    private static Assembly? TryLoad(string path)
+    {
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch (Exception exception) when (exception is BadImageFormatException or FileLoadException)
+        {
+            return null;
+        }
     }
 
     private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/HttpClientConventionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/CoreThings/HttpClientConventionTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Services.NewsDashboard;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.CoreThings;
+
+[TestFixture]
+public class HttpClientConventionTests
+{
+    private static readonly Assembly[] Assemblies =
+    [
+        typeof(Constants).Assembly,
+        typeof(NewsDashboardService).Assembly,
+    ];
+
+    [Test]
+    public void Cannot_Declare_Mutable_Static_HttpClient_Field()
+    {
+        var offenders = Assemblies
+            .SelectMany(GetLoadableTypes)
+            .SelectMany(type => type.GetFields(
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            .Where(field => field.FieldType == typeof(HttpClient) && field.IsInitOnly is false)
+            .Select(field => $"{field.DeclaringType?.FullName}.{field.Name}")
+            .OrderBy(name => name)
+            .ToArray();
+
+        // A mutable static field is assigned lazily and then configured, so another thread can observe the
+        // client before its default request headers are complete. HttpHeaders is not thread safe, so the
+        // in-flight request faults while writing them (#23697).
+        Assert.That(
+            offenders,
+            Is.Empty,
+            "Static HttpClient fields must be readonly and fully configured on assignment. Use SharedHttpClient "
+            + "for existing call sites that cannot take a dependency, or inject IHttpClientFactory in new code.");
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            return exception.Types.Where(type => type is not null)!;
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Media/EmbedProviders/OEmbedProviderHttpClientTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Media/EmbedProviders/OEmbedProviderHttpClientTests.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Media.EmbedProviders;
 public class OEmbedProviderHttpClientTests
 {
     [Test]
-    public void GetHttpClient_Returns_The_Shared_Instance_By_Default()
+    public void Can_Get_Default_Shared_HttpClient_Instance()
     {
         var provider = new TestOEmbedProvider(Mock.Of<IJsonSerializer>());
 
@@ -26,7 +26,7 @@ public class OEmbedProviderHttpClientTests
     }
 
     [Test]
-    public void GetHttpClient_Can_Be_Overridden_By_A_Provider()
+    public void Can_Override_HttpClient_In_Provider()
     {
         using var httpClient = new HttpClient();
         var provider = new CustomHttpClientOEmbedProvider(Mock.Of<IJsonSerializer>(), httpClient);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Media/EmbedProviders/OEmbedProviderHttpClientTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Media/EmbedProviders/OEmbedProviderHttpClientTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Media.EmbedProviders;
+using Umbraco.Cms.Core.Net;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Media.EmbedProviders;
+
+[TestFixture]
+public class OEmbedProviderHttpClientTests
+{
+    [Test]
+    public void GetHttpClient_Returns_The_Shared_Instance_By_Default()
+    {
+        var provider = new TestOEmbedProvider(Mock.Of<IJsonSerializer>());
+
+        Assert.That(provider.ResolvedHttpClient, Is.SameAs(SharedHttpClient.Instance));
+    }
+
+    [Test]
+    public void GetHttpClient_Can_Be_Overridden_By_A_Provider()
+    {
+        using var httpClient = new HttpClient();
+        var provider = new CustomHttpClientOEmbedProvider(Mock.Of<IJsonSerializer>(), httpClient);
+
+        Assert.That(provider.ResolvedHttpClient, Is.SameAs(httpClient));
+    }
+
+    private class TestOEmbedProvider : OEmbedProviderBase
+    {
+        public TestOEmbedProvider(IJsonSerializer jsonSerializer)
+            : base(jsonSerializer)
+        {
+        }
+
+        public override string ApiEndpoint => "http://test.local/oembed";
+
+        public override string[] UrlSchemeRegex => [@"^https?://test\.local/"];
+
+        public override Dictionary<string, string> RequestParams => new();
+
+        public HttpClient ResolvedHttpClient => GetHttpClient();
+
+        public override Task<string?> GetMarkupAsync(string url, int? maxWidth, int? maxHeight, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+
+    private class CustomHttpClientOEmbedProvider : TestOEmbedProvider
+    {
+        private readonly HttpClient _httpClient;
+
+        public CustomHttpClientOEmbedProvider(IJsonSerializer jsonSerializer, HttpClient httpClient)
+            : base(jsonSerializer) => _httpClient = httpClient;
+
+        protected override HttpClient GetHttpClient() => _httpClient;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Net/SharedHttpClientTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Net/SharedHttpClientTests.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Net;
 public class SharedHttpClientTests
 {
     [Test]
-    public void Instance_Is_Configured_With_The_Umbraco_User_Agent()
+    public void Can_Get_Instance_Configured_With_Umbraco_User_Agent()
     {
         HttpClient client = SharedHttpClient.Instance;
 
@@ -25,5 +25,5 @@ public class SharedHttpClientTests
     }
 
     [Test]
-    public void Instance_Is_Reused() => Assert.That(SharedHttpClient.Instance, Is.SameAs(SharedHttpClient.Instance));
+    public void Can_Reuse_Same_Instance() => Assert.That(SharedHttpClient.Instance, Is.SameAs(SharedHttpClient.Instance));
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Net/SharedHttpClientTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Net/SharedHttpClientTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Linq;
+using System.Net.Http;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Net;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Net;
+
+[TestFixture]
+public class SharedHttpClientTests
+{
+    [Test]
+    public void Instance_Is_Configured_With_The_Umbraco_User_Agent()
+    {
+        HttpClient client = SharedHttpClient.Instance;
+
+        // The headers must be in place before any caller can observe the instance; configuring them
+        // afterwards is what caused #23697.
+        Assert.That(
+            client.DefaultRequestHeaders.UserAgent.Select(userAgent => userAgent.Product?.Name),
+            Does.Contain(Constants.HttpClients.Headers.UserAgentProductName));
+    }
+
+    [Test]
+    public void Instance_Is_Reused() => Assert.That(SharedHttpClient.Instance, Is.SameAs(SharedHttpClient.Instance));
+}


### PR DESCRIPTION
## Description

A race condition can be demonstrated in the construction and configuration of an `HttpClient` used for the OEmbed providers, as shown and discussed in #23697.

### The cause

It can happen as `OEmbedProviderBase` lazily create its shared `HttpClient` and configures it *after* publishing the reference:

```csharp
if (_httpClient == null)
{
    _httpClient = new HttpClient();                                   // visible to all threads from here
    _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(...);     // mutated while another thread sends
}
```

`HttpHeaders` is not thread safe, and `DefaultRequestHeaders` must be fully configured before the first request. So when two first-ever oEmbed lookups race, thread B can call `SendAsync` and begin serialising the header collection while thread A is still adding the user-agent, faulting the request writer:

```
System.NullReferenceException
   at System.Net.Http.HttpConnection.WriteHeaderCollection(HttpHeaders headers, String cookiesFromContainer)
   ...
   at Umbraco.Cms.Core.Media.EmbedProviders.OEmbedProviderBase.DownloadResponse(String url)
```

This matches the reporter's observation that it only bites shortly after a restart and never once the site is warm.

Worth distinguishing from the benign version of this pattern: two threads both constructing a client, with one instance orphaned, only leaks a handler. The defect here is specifically the *mutation after publication*, which is why the same lazy-static shape elsewhere in the codebase cannot produce this exception.

### The fix

A new `SharedHttpClient` in `Umbraco.Core/Net`, created through a static initialiser. CLR type initialisation is thread safe and orders every configuration write before any thread can observe the instance, so there is no lock in the request path. It also sets `PooledConnectionLifetime`, so a client that lives as long as the process still picks up DNS changes — the same thing `IHttpClientFactory` achieves by rotating handlers.

The fix is deliberately **not** constructor injection of `IHttpClientFactory`. The race is in a static field read by `DownloadResponseAsync`, not in a constructor, so correcting the initialisation fixes every caller — in this case and importantly **including third-party providers that subclass `OEmbedProviderBase`** and never change a line. Injecting the factory would reach only callers that adopt a new constructor, and would still need a correct static fallback for direct instantiation, so it is additive surface rather than the fix.

Alongside the reported bug, this brings the other shared `HttpClient` usages into line:

| Site | Change |
|---|---|
| `OEmbedProviderBase` | Uses the shared client. New `protected virtual GetHttpClient()` seam, and the request timeout is applied per call. |
| `BaseHttpHeaderCheck`, `ExcessiveHeadersCheck` | Same lazy-static shape (no header mutation, so they could not produce the exception, but they could duplicate a handler and had no connection lifetime). Now use the shared client. |
| `NewsDashboardService` | Moves to a named `IHttpClientFactory` client. This is the pattern new code should follow; `SharedHttpClient` is documented as a shim for call sites that cannot take that dependency without a breaking change. |

Left alone deliberately:

- `GetHelpController` creates a client per request and never disposes it, but the controller is already `[Obsolete]`, unused by the backoffice and scheduled for removal in V19.
- `HttpsCheck` needs a bespoke certificate-validation handler per request and disposes correctly, so it is neither a thread-safety nor a leak concern.
- The concrete embed providers' constructors — see the reasoning above.

### Behaviour changes

Small, but observable, so calling them out explicitly:

- oEmbed requests time out after 20 seconds rather than `HttpClient`'s 100-second default. A dead oEmbed endpoint currently hangs the backoffice embed dialog for the full 100 seconds.
- The two security health checks now send `User-Agent: Umbraco-Cms`; they previously sent no user-agent at all.
- News dashboard requests time out after 20 seconds and go through a pooled, rotating handler.
- Connections on these clients are recycled every two minutes, so DNS changes are picked up rather than pinned for the process lifetime.

## Testing

### Automated

- `HttpClientConventionTests` asserts that no type declares a mutable `static HttpClient` field. This fails against the pre-fix code, reporting exactly the three offending fields, and passes with the fix — so it genuinely catches the bug rather than merely documenting it, and it guards against the pattern returning.
- `SharedHttpClientTests` asserts the shared client is fully configured on first access, guarding against a revert to the configure-after-publish shape.
- `OEmbedProviderHttpClientTests` covers the new `GetHttpClient()` seam, both the default and an override.

The race itself is not reliably unit-testable — a concurrency stress test would be flaky in both directions and prove little. The guarantee here is structural, from type initialisation; the tests above cover the shape that caused the defect.

### Manual

1. **oEmbed** — in the rich text editor, insert an embed and paste a YouTube URL (for example `https://youtu.be/dQw4w9WgXcQ`). The preview and resulting markup should render as before. Failures surface as a "could not embed" message rather than an exception, since `OEmbedService` returns a failed `Attempt`.
2. **News dashboard** — restart the site first: `GetItemsAsync` reads `RuntimeCache` before making the request, so a warm cache renders without exercising the new named client. Then open the Content dashboard and confirm news items appear. Note that failures here are swallowed and render as an *empty* dashboard, so also check the log for `Error getting dashboard content from`.
3. **Health checks** — Settings → Health Check → run the Security group. `Excessive Headers`, `Click-Jacking`, `CSP`, `HSTS`, `No Sniff` and `XSS Protection` should report the same results as before. These require an application URL to be resolvable; without one they return an Info status and never make a request, so the changed path would not be exercised.

## Credit

Diagnosed by @bme-novaware, who correctly identified both the cause and the location, with analysis from @abjerner in the issue thread.
