### PR TITLE
TipTap RTE: Remove toolbar shadow before scroll (closes #23710)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -11,6 +11,7 @@ import {
 	customElement,
 	html,
 	property,
+	query,
 	repeat,
 	state,
 	unsafeCSS,
@@ -117,6 +118,12 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	@state()
 	private _statusbar: UmbTiptapStatusbarValue = [[], []];
 
+	@query('#editor')
+	private _editorElement?: HTMLDivElement;
+
+	@query('umb-tiptap-toolbar')
+	private _toolbarElement?: HTMLElement;
+
 	constructor() {
 		super();
 
@@ -132,12 +139,15 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		this.#observeStylesheetRootPath();
 		await this.#loadExtensions();
 		await this.#loadEditor();
+		await this.updateComplete;
+		this.#syncToolbarScrolling();
 	}
 
 	protected override updated(changedProperties: Map<string, unknown>) {
 		super.updated(changedProperties);
 		if (changedProperties.has('readonly')) {
 			this._editor?.setEditable(!this.readonly);
+			this.#syncToolbarScrolling();
 		}
 	}
 
@@ -263,12 +273,20 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		this.#context.setEditor(this._editor);
 	}
 
+	#onEditorScroll = () => this.#syncToolbarScrolling();
+
+	#syncToolbarScrolling() {
+		const toolbar = this._toolbarElement;
+		if (!toolbar) return;
+		toolbar.toggleAttribute('scrolling', (this._editorElement?.scrollTop ?? 0) > 0);
+	}
+
 	override render() {
 		const loading = !this._editor && !this._extensions?.length;
 		return html`
 			${when(loading, () => html`<div id="loader"><uui-loader></uui-loader></div>`)}
 			${when(!loading, () => html`${this.#renderStyles()}${this.#renderToolbar()}`)}
-			<div id="editor" data-mark="input:tiptap-rte" ?data-loaded=${!loading}></div>
+			<div id="editor" data-mark="input:tiptap-rte" ?data-loaded=${!loading} @scroll=${this.#onEditorScroll}></div>
 			${when(!loading, () => this.#renderStatusbar())}
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -118,11 +118,20 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	@state()
 	private _statusbar: UmbTiptapStatusbarValue = [[], []];
 
-	@query('#editor')
-	private _editorElement?: HTMLDivElement;
+	@state()
+	private _scrolling = false;
 
 	@query('umb-tiptap-toolbar')
 	private _toolbarElement?: HTMLElement;
+
+	// Detects the toolbar sticking by watching it drop below full visibility,
+	// regardless of which ancestor is the one actually scrolling.
+	#scrollObserver = new IntersectionObserver(
+		([entry]) => {
+			this._scrolling = entry.intersectionRatio < 1;
+		},
+		{ threshold: 1 },
+	);
 
 	constructor() {
 		super();
@@ -140,14 +149,13 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		await this.#loadExtensions();
 		await this.#loadEditor();
 		await this.updateComplete;
-		this.#syncToolbarScrolling();
+		if (this._toolbarElement) this.#scrollObserver.observe(this._toolbarElement);
 	}
 
 	protected override updated(changedProperties: Map<string, unknown>) {
 		super.updated(changedProperties);
 		if (changedProperties.has('readonly')) {
 			this._editor?.setEditable(!this.readonly);
-			this.#syncToolbarScrolling();
 		}
 	}
 
@@ -273,20 +281,12 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		this.#context.setEditor(this._editor);
 	}
 
-	#onEditorScroll = () => this.#syncToolbarScrolling();
-
-	#syncToolbarScrolling() {
-		const toolbar = this._toolbarElement;
-		if (!toolbar) return;
-		toolbar.toggleAttribute('scrolling', (this._editorElement?.scrollTop ?? 0) > 0);
-	}
-
 	override render() {
 		const loading = !this._editor && !this._extensions?.length;
 		return html`
 			${when(loading, () => html`<div id="loader"><uui-loader></uui-loader></div>`)}
 			${when(!loading, () => html`${this.#renderStyles()}${this.#renderToolbar()}`)}
-			<div id="editor" data-mark="input:tiptap-rte" ?data-loaded=${!loading} @scroll=${this.#onEditorScroll}></div>
+			<div id="editor" data-mark="input:tiptap-rte" ?data-loaded=${!loading}></div>
 			${when(!loading, () => this.#renderStatusbar())}
 		`;
 	}
@@ -316,7 +316,8 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				data-mark="tiptap-toolbar"
 				.toolbar=${this._toolbar}
 				.editor=${this._editor}
-				.configuration=${this.configuration}>
+				.configuration=${this.configuration}
+				.scrolling=${this._scrolling}>
 			</umb-tiptap-toolbar>
 		`;
 	}
@@ -337,6 +338,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	override destroy(): void {
 		this._editor?.destroy();
 		this._editor = undefined;
+		this.#scrollObserver.disconnect();
 	}
 
 	static override readonly styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/tiptap-toolbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/tiptap-toolbar.element.ts
@@ -37,6 +37,9 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 	@property({ attribute: false })
 	toolbar: UmbTiptapToolbarValue = [[[]]];
 
+	@property({ type: Boolean, reflect: true })
+	scrolling = false;
+
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.#attached = true;
@@ -124,7 +127,9 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 			right: 0;
 			padding: var(--uui-size-3);
 			z-index: 9999999;
+		}
 
+		:host([scrolling]) {
 			box-shadow:
 				0 2px 2px -2px rgba(34, 47, 62, 0.1),
 				0 8px 8px -4px rgba(34, 47, 62, 0.07);


### PR DESCRIPTION
Fixes #23710

The TipTap toolbar always rendered with a shadow, even when the editor was at the top and no content had been scrolled yet.

**Root cause:** `tiptap-toolbar.element.ts` applied the shadow unconditionally in the toolbar’s base CSS. The toolbar had no notion of whether the editor content below it had actually been scrolled.

**Fix:**
- `tiptap-toolbar.element.ts`: moved the shadow behind a reflected `scrolling` attribute so the shadow is only present in the scrolled state.
- `input-tiptap.element.ts`: listens to the editor container’s scroll position and toggles the toolbar’s `scrolling` attribute when `#editor.scrollTop > 0`.

At the top:
<img width="1365" height="381" alt="image" src="https://github.com/user-attachments/assets/2982e690-f222-430f-995e-ccacbee10b93" />

After scrolling:
<img width="1363" height="372" alt="image" src="https://github.com/user-attachments/assets/4cd7ddfc-2f33-41c5-9c67-af9b0164d427" />

## Testing
1. Configure a Rich Text Editor data type with a fixed height so the editor can scroll
2. Open a content node using that editor
3. Verify the toolbar has no shadow when the editor is at the top
4. Scroll the editor content down
5. Verify the toolbar gains a shadow only after scrolling