### PR TITLE
Dependencies: Pin vulnerable transitive dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -102,7 +102,8 @@
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.3" />
     <!-- Microsoft.Data.Sqlite/Microsoft.EntityFrameworkCore.Sqlite bring in a vulnerable version of SQLitePCLRaw.lib.e_sqlite3 -->
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.13" />
-    <!-- Microsoft.CodeAnalysis.Workspaces.MSBuild brings in a vulnerable version of Microsoft.Build.Tasks.Core -->
+    <!-- Microsoft.CodeAnalysis.Workspaces.MSBuild brings in a vulnerable version of Microsoft.Build.Tasks.Core (MSBuild ships these as a version-matched set, so keep Microsoft.Build aligned) -->
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.43" />
+    <PackageVersion Include="Microsoft.Build" Version="17.8.43" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,7 +87,7 @@
     <!-- Dazinator.Extensions.FileProviders brings in a vulnerable version of System.Net.Http -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <!-- Examine brings in a vulnerable version of System.Security.Cryptography.Xml -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <!-- Both Dazinator.Extensions.FileProviders and MiniProfiler.AspNetCore.Mvc bring in a vulnerable version of System.Text.RegularExpressions -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <!-- Both OpenIddict.AspNetCore, Npoco.SqlServer and Microsoft.EntityFrameworkCore.SqlServer bring in a vulnerable version of Microsoft.IdentityModel.JsonWebTokens -->
@@ -100,5 +100,9 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <!-- Both Microsoft.EntityFrameworkCore.SqlServer and NPoco.SqlServer bring in a vulnerable version of Microsoft.Data.SqlClient -->
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.3" />
+    <!-- Microsoft.Data.Sqlite/Microsoft.EntityFrameworkCore.Sqlite bring in a vulnerable version of SQLitePCLRaw.lib.e_sqlite3 -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.13" />
+    <!-- Microsoft.CodeAnalysis.Workspaces.MSBuild brings in a vulnerable version of Microsoft.Build.Tasks.Core -->
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.8.43" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Umbraco.Cms.Persistence.EFCore.Sqlite.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Umbraco.Cms.Persistence.EFCore.Sqlite.csproj
@@ -6,6 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <!-- Take top-level dependency on SQLitePCLRaw.lib.e_sqlite3, because Microsoft.EntityFrameworkCore.Sqlite depends on a vulnerable version -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
+++ b/src/Umbraco.Cms.Persistence.EFCore/Umbraco.Cms.Persistence.EFCore.csproj
@@ -15,6 +15,9 @@
     <!-- Both Microsoft.EntityFrameworkCore.SqlServer and NPoco.SqlServer bring in a vulnerable version of Microsoft.Data.SqlClient -->
     <PackageReference Include="Microsoft.Data.SqlClient" />
 
+    <!-- Take top-level dependency on SQLitePCLRaw.lib.e_sqlite3, because Microsoft.EntityFrameworkCore.Sqlite depends on a vulnerable version -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
+
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" />

--- a/src/Umbraco.Cms.Persistence.Sqlite/Umbraco.Cms.Persistence.Sqlite.csproj
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Umbraco.Cms.Persistence.Sqlite.csproj
@@ -6,6 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <!-- Take top-level dependency on SQLitePCLRaw.lib.e_sqlite3, because Microsoft.Data.Sqlite depends on a vulnerable version -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -47,6 +47,8 @@
     <!-- Take top-level dependency on these Microsoft.CodeAnalysis.* packages due to conflicts when installing Microsoft.EntityFrameworkCore.Design -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <!-- Take top-level dependency on Microsoft.Build.Tasks.Core, because Microsoft.CodeAnalysis.Workspaces.MSBuild depends on a vulnerable version -->
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -49,6 +49,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     <!-- Take top-level dependency on Microsoft.Build.Tasks.Core, because Microsoft.CodeAnalysis.Workspaces.MSBuild depends on a vulnerable version -->
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <!-- Take top-level dependency on Microsoft.Build too, to keep the version-matched MSBuild assembly set aligned -->
+    <PackageReference Include="Microsoft.Build" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
Pin three transitive dependencies to non-vulnerable versions via CPM, following the existing "Transitive pinned versions" pattern:

- System.Security.Cryptography.Xml 8.0.3 -> 8.0.4 (via Examine)
- SQLitePCLRaw.lib.e_sqlite3 -> 2.1.13 (via Microsoft.Data.Sqlite)
- Microsoft.Build.Tasks.Core -> 17.8.43 (via Microsoft.CodeAnalysis.Workspaces.MSBuild)
## Testing
- `dotnet list package --vulnerable --include-transitive` no longer reports these three.
<!-- Thanks for contributing to Umbraco CMS! -->
