### PR TITLE
Block Rich Text Editor Impl.: cleanup & deprecate

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-manager.context.ts
@@ -3,9 +3,9 @@ import type { UmbBlockRteLayoutModel, UmbBlockRteTypeModel } from '../types.js';
 import type { UmbBlockDataModel } from '../../block/types.js';
 import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbBlockManagerContext } from '@umbraco-cms/backoffice/block';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 import '../components/block-rte-entry/index.js';
-import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
  * A implementation of the Block Manager specifically for the Rich Text Editor.
@@ -86,7 +86,7 @@ export class UmbBlockRteManagerContext<
 	}
 
 	/**
-	 * @deprecated Use removeOneContent instead. This method will be removed in a future version.
+	 * @deprecated Use `removeOneContent` instead. Scheduled for removal in Umbraco 20.
 	 * @param {string} contentKey - The content key of the layout element to delete.
 	 * @internal
 	 */

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-manager.context.ts
@@ -5,6 +5,7 @@ import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbBlockManagerContext } from '@umbraco-cms/backoffice/block';
 
 import '../components/block-rte-entry/index.js';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
  * A implementation of the Block Manager specifically for the Rich Text Editor.
@@ -85,10 +86,16 @@ export class UmbBlockRteManagerContext<
 	}
 
 	/**
+	 * @deprecated Use removeOneContent instead. This method will be removed in a future version.
 	 * @param {string} contentKey - The content key of the layout element to delete.
 	 * @internal
 	 */
 	public deleteLayoutElement(contentKey: string) {
-		this.removeBlockKey(contentKey);
+		new UmbDeprecation({
+			deprecated: 'deleteLayoutElement is deprecated.',
+			removeInVersion: '20.0.0',
+			solution: 'Use removeOneContent instead.',
+		}).warn();
+		this.removeOneContent(contentKey);
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
@@ -32,6 +32,7 @@ export type UmbBlockDataObjectModel<LayoutEntryType extends UmbBlockLayoutBaseMo
 	content: UmbBlockDataModel;
 	settings?: UmbBlockDataModel;
 };
+
 export abstract class UmbBlockManagerContext<
 	BlockType extends UmbBlockTypeBaseModel = UmbBlockTypeBaseModel,
 	BlockLayoutType extends UmbBlockLayoutBaseModel = UmbBlockLayoutBaseModel,
@@ -623,7 +624,7 @@ export abstract class UmbBlockManagerContext<
 	}
 
 	/**
-	 * @deprecated Use removeOneContent instead. This method will be removed in a future version.
+	 * @deprecated Use `removeOneContent` instead. Scheduled for removal in Umbraco 20.
 	 * @param {string} contentKey - The content key of the layout element to delete.
 	 * @internal
 	 */

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
@@ -18,7 +18,7 @@ import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UmbBlockTypeBaseModel } from '@umbraco-cms/backoffice/block-type';
-import { UmbReadOnlyVariantGuardManager } from '@umbraco-cms/backoffice/utils';
+import { UmbDeprecation, UmbReadOnlyVariantGuardManager } from '@umbraco-cms/backoffice/utils';
 import {
 	UmbPropertyValuePresetVariantBuilderController,
 	type UmbPropertyTypePresetModel,
@@ -622,7 +622,17 @@ export abstract class UmbBlockManagerContext<
 		}
 	}
 
+	/**
+	 * @deprecated Use removeOneContent instead. This method will be removed in a future version.
+	 * @param {string} contentKey - The content key of the layout element to delete.
+	 * @internal
+	 */
 	protected removeBlockKey(contentKey: string) {
-		this.#contents.removeOne(contentKey);
+		new UmbDeprecation({
+			deprecated: 'removeBlockKey is deprecated.',
+			removeInVersion: '20.0.0',
+			solution: 'Use removeOneContent instead.',
+		}).warn();
+		this.removeOneContent(contentKey);
 	}
 }


### PR DESCRIPTION
Deprecate unused methods; these two are duplicates of other methods and unused by our code. Not very likely anyone would have used it in their package, but deprecating them properly.