### PR TITLE
OpenIddict: Compare ConsentType and ApplicationType only when the descriptor sets them (follow-up to #23599)

### DIFF
--- a/src/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBase.cs
+++ b/src/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBase.cs
@@ -194,11 +194,11 @@ public abstract class OpenIdDictApplicationManagerBase
         ImmutableDictionary<CultureInfo, string> displayNames = await ApplicationManager.GetDisplayNamesAsync(client, cancellationToken);
         ImmutableDictionary<string, JsonElement> properties = await ApplicationManager.GetPropertiesAsync(client, cancellationToken);
 
-        // These two are compared only when the descriptor specifies a value: the store substitutes its
-        // own default when none was set, so an unset descriptor value cannot be told apart from a
-        // cleared one, and comparing against the default would report a change on every call. Clearing
-        // them is therefore not expressible. The other three are stored as given, so an absent value
-        // there is a genuine removal and is compared as one.
+        // ConsentType and ApplicationType are compared only when the descriptor specifies a value: the
+        // store substitutes its own default when none was set, so an unset descriptor value cannot be
+        // told apart from a cleared one, and comparing against the default would report a change on
+        // every call. Clearing those two is therefore not expressible. Requirements, DisplayNames and
+        // Properties are stored as given, so an absent value there is a genuine removal.
         return (clientDescriptor.ConsentType is null
                 || string.Equals(consentType, clientDescriptor.ConsentType, StringComparison.OrdinalIgnoreCase))
                && (clientDescriptor.ApplicationType is null

--- a/src/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBase.cs
+++ b/src/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBase.cs
@@ -192,8 +192,15 @@ public abstract class OpenIdDictApplicationManagerBase
         ImmutableDictionary<CultureInfo, string> displayNames = await ApplicationManager.GetDisplayNamesAsync(client, cancellationToken);
         ImmutableDictionary<string, JsonElement> properties = await ApplicationManager.GetPropertiesAsync(client, cancellationToken);
 
-        return string.Equals(consentType, clientDescriptor.ConsentType, StringComparison.OrdinalIgnoreCase)
-               && string.Equals(applicationType, clientDescriptor.ApplicationType, StringComparison.OrdinalIgnoreCase)
+        // Compared only when the descriptor actually specifies a value. OpenIddict stores a default
+        // for both of these and returns it, "explicit" and "web", so a descriptor that leaves them
+        // unset is not asking for a change and comparing null against that default would never
+        // match. That is not hypothetical: it made MatchesAsync always false, so every registration
+        // wrote and the concurrency token rotated exactly as it did before this fix.
+        return (clientDescriptor.ConsentType is null
+                || string.Equals(consentType, clientDescriptor.ConsentType, StringComparison.OrdinalIgnoreCase))
+               && (clientDescriptor.ApplicationType is null
+                   || string.Equals(applicationType, clientDescriptor.ApplicationType, StringComparison.OrdinalIgnoreCase))
                && SetEquals(requirements, clientDescriptor.Requirements)
                && DictionaryEquals(displayNames, clientDescriptor.DisplayNames, string.Equals)
                && DictionaryEquals(properties, clientDescriptor.Properties, JsonElementEquals);

--- a/src/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBase.cs
+++ b/src/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBase.cs
@@ -141,7 +141,9 @@ public abstract class OpenIdDictApplicationManagerBase
     /// skipping it would silently discard a rotated one. <see cref="OpenIddictApplicationDescriptor.JsonWebKeySet"/> has no value
     /// equality, and comparing a serialised form would be sensitive to key ordering and formatting.
     /// Everything else the descriptor carries is readable through the manager and is compared, so
-    /// clearing a value is recognised as a change rather than skipped.
+    /// clearing a value is recognised as a change rather than skipped — except where the store
+    /// substitutes a default for a value that was never set, which makes a removal indistinguishable
+    /// from an unset value and so leaves it out of scope for comparison.
     /// </remarks>
     private static bool HasStateThatCannotBeCompared(OpenIddictApplicationDescriptor clientDescriptor)
         => clientDescriptor.ClientSecret is not null || clientDescriptor.JsonWebKeySet is not null;
@@ -180,9 +182,9 @@ public abstract class OpenIdDictApplicationManagerBase
     /// Compares the descriptor state that is readable but not part of the core registration.
     /// </summary>
     /// <remarks>
-    /// Compared rather than assumed to match, so a descriptor that clears one of these is recognised
-    /// as a change. Treating an unset value as "nothing to compare" would leave the stored value in
-    /// place and silently ignore the removal.
+    /// Read back from the store and compared, so a descriptor that clears one of these is recognised
+    /// as a change rather than silently ignored. Values for which the store substitutes a default are
+    /// the exception, and are compared only when the descriptor specifies one; see below.
     /// </remarks>
     private async Task<bool> MatchesMetadataAsync(object client, OpenIddictApplicationDescriptor clientDescriptor, CancellationToken cancellationToken)
     {
@@ -192,11 +194,11 @@ public abstract class OpenIdDictApplicationManagerBase
         ImmutableDictionary<CultureInfo, string> displayNames = await ApplicationManager.GetDisplayNamesAsync(client, cancellationToken);
         ImmutableDictionary<string, JsonElement> properties = await ApplicationManager.GetPropertiesAsync(client, cancellationToken);
 
-        // Compared only when the descriptor actually specifies a value. OpenIddict stores a default
-        // for both of these and returns it, "explicit" and "web", so a descriptor that leaves them
-        // unset is not asking for a change and comparing null against that default would never
-        // match. That is not hypothetical: it made MatchesAsync always false, so every registration
-        // wrote and the concurrency token rotated exactly as it did before this fix.
+        // These two are compared only when the descriptor specifies a value: the store substitutes its
+        // own default when none was set, so an unset descriptor value cannot be told apart from a
+        // cleared one, and comparing against the default would report a change on every call. Clearing
+        // them is therefore not expressible. The other three are stored as given, so an absent value
+        // there is a genuine removal and is compared as one.
         return (clientDescriptor.ConsentType is null
                 || string.Equals(consentType, clientDescriptor.ConsentType, StringComparison.OrdinalIgnoreCase))
                && (clientDescriptor.ApplicationType is null

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Security/MemberApplicationManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Security/MemberApplicationManagerTests.cs
@@ -74,10 +74,10 @@ public class MemberApplicationManagerTests
             .ReturnsAsync(ImmutableDictionary<string, string>.Empty);
         _mockApplicationManager
             .Setup(x => x.GetConsentTypeAsync(_storedApplication, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
+            .ReturnsAsync(OpenIddictConstants.ConsentTypes.Explicit);
         _mockApplicationManager
             .Setup(x => x.GetApplicationTypeAsync(_storedApplication, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
+            .ReturnsAsync(OpenIddictConstants.ApplicationTypes.Web);
         _mockApplicationManager
             .Setup(x => x.GetRequirementsAsync(_storedApplication, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ImmutableArray<string>.Empty);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManagerTests.cs
@@ -562,10 +562,10 @@ public class BackOfficeApplicationManagerTests
             .ReturnsAsync(ImmutableDictionary<string, string>.Empty);
         _mockApplicationManager
             .Setup(x => x.GetConsentTypeAsync(mockApplication, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
+            .ReturnsAsync(OpenIddictConstants.ConsentTypes.Explicit);
         _mockApplicationManager
             .Setup(x => x.GetApplicationTypeAsync(mockApplication, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
+            .ReturnsAsync(OpenIddictConstants.ApplicationTypes.Web);
         _mockApplicationManager
             .Setup(x => x.GetRequirementsAsync(mockApplication, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ImmutableArray<string>.Empty);
@@ -633,10 +633,10 @@ public class BackOfficeApplicationManagerTests
             .ReturnsAsync(ImmutableDictionary<string, string>.Empty);
         _mockApplicationManager
             .Setup(x => x.GetConsentTypeAsync(storedApplication, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
+            .ReturnsAsync(OpenIddictConstants.ConsentTypes.Explicit);
         _mockApplicationManager
             .Setup(x => x.GetApplicationTypeAsync(storedApplication, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
+            .ReturnsAsync(OpenIddictConstants.ApplicationTypes.Web);
         _mockApplicationManager
             .Setup(x => x.GetRequirementsAsync(storedApplication, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ImmutableArray<string>.Empty);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBaseTests.cs
@@ -83,11 +83,12 @@ public class OpenIdDictApplicationManagerBaseTests
     }
 
     /// <summary>
-    /// A descriptor that clears a value the store still holds is a change, so it must be written.
+    /// A descriptor asking for a value the store does not hold is a change, so it must be written.
     /// </summary>
     /// <remarks>
-    /// Treating an unset value as "nothing to compare" leaves the stored value in place and ignores
-    /// the removal, which is silent because the caller sees a successful call either way.
+    /// Only the descriptor-specifies-a-value direction is asserted. The store substitutes a default
+    /// for an unset consent type, so a descriptor that leaves it unset is not expressing a removal
+    /// and there is no cleared case to assert.
     /// </remarks>
     [TestCase(null, OpenIddictConstants.ConsentTypes.Explicit, TestName = "ConsentType added")]
     public async Task CreateOrUpdate_ConsentTypeDiffersFromStored_Updates(string? stored, string? descriptorValue)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/OpenIdDictApplicationManagerBaseTests.cs
@@ -63,11 +63,11 @@ public class OpenIdDictApplicationManagerBaseTests
 
         _mockApplicationManager
             .Setup(x => x.GetConsentTypeAsync(_storedApplication, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
+            .ReturnsAsync(OpenIddictConstants.ConsentTypes.Explicit);
 
         _mockApplicationManager
             .Setup(x => x.GetApplicationTypeAsync(_storedApplication, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
+            .ReturnsAsync(OpenIddictConstants.ApplicationTypes.Web);
 
         _mockApplicationManager
             .Setup(x => x.GetRequirementsAsync(_storedApplication, It.IsAny<CancellationToken>()))
@@ -89,7 +89,6 @@ public class OpenIdDictApplicationManagerBaseTests
     /// Treating an unset value as "nothing to compare" leaves the stored value in place and ignores
     /// the removal, which is silent because the caller sees a successful call either way.
     /// </remarks>
-    [TestCase(OpenIddictConstants.ConsentTypes.Explicit, null, TestName = "ConsentType cleared")]
     [TestCase(null, OpenIddictConstants.ConsentTypes.Explicit, TestName = "ConsentType added")]
     public async Task CreateOrUpdate_ConsentTypeDiffersFromStored_Updates(string? stored, string? descriptorValue)
     {
@@ -167,7 +166,8 @@ public class OpenIdDictApplicationManagerBaseTests
 
     private static IEnumerable<TestCaseData> MetadataHeldByTheDescriptorButNotTheStore()
     {
-        yield return Case("ApplicationType", d => d.ApplicationType = OpenIddictConstants.ApplicationTypes.Web);
+        // Native rather than Web: the store defaults to Web, so asking for Web is not a change.
+        yield return Case("ApplicationType", d => d.ApplicationType = OpenIddictConstants.ApplicationTypes.Native);
         yield return Case("Requirements", d => d.Requirements.Add(OpenIddictConstants.Requirements.Features.ProofKeyForCodeExchange));
         yield return Case("DisplayNames", d => d.DisplayNames[CultureInfo.GetCultureInfo("da-DK")] = "Testprogram");
         yield return Case("Properties", d => d.Properties["custom"] = JsonDocument.Parse("\"value\"").RootElement);


### PR DESCRIPTION
Follow-up to #23599, which I broke while responding to review on it. It merged before I could get this in, so it needs a separate PR. Sorry, @AndyButland.

## What is wrong on v17/dev

The metadata comparison I added in the review response compares `ConsentType` and `ApplicationType` against the descriptor, treating an unset descriptor value as a request to clear. The store does not answer `null` for those. Probed against the real store after a registration:

```
ConsentType=[explicit]  ApplicationType=[web]
```

OpenIddict stores a default for both and returns it. No Umbraco descriptor sets either, so the comparison is `string.Equals("explicit", null)`, false every time. `MatchesAsync` therefore never returns true, every registration writes, and the concurrency token rotates exactly as it did before the fix.

The net effect is that #23599 as merged does not fix #23544. It reads as a fix and behaves as a no-op.

## Evidence

`EnsureBackOfficeApplicationAsync_UnchangedRegistration_DoesNotWrite` fails on `v17/dev` at the merge commit, and passes with this change. Bisecting the five comparisons, `ConsentType` and `ApplicationType` were each independently sufficient to cause it. `Requirements`, `DisplayNames` and `Properties` are fine.

A clean worktree at the pre-review-response commit passes 5 of 5, so the regression came from my second push rather than the original submission.

## How it got past the tests

The unit tests stayed green the whole time because their mocks stubbed those two getters as returning `null`, which the real manager never produces. The doubles encoded the assumption that caused the bug and then confirmed it. Those stubs now return the store defaults, so the unit suite can no longer be green while the integration test is red. That is the part I should have caught: I re-ran unit after the review changes and did not re-run integration.

## The change

Those two are compared only when the descriptor actually specifies a value.

Clearing is not expressible for them. A descriptor that leaves them unset is indistinguishable from one that cleared them, because the store answers with a default either way. The other three keep the clearing behaviour your review asked for, and the tests now assert the direction that is real: a descriptor asking for something different from what is stored.

30 unit and 5 integration tests pass.

Fixes #23544