### PR TITLE
Published Cache: Stop writing unread member rows to the database cache (closes #23070)

### DIFF
--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -182,6 +182,12 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
 
 
     /// <inheritdoc />
+    /// <remarks>
+    /// SQLite has no <c>TRUNCATE TABLE</c> statement.
+    /// </remarks>
+    public override string TruncateTable => "DELETE FROM {0}";
+
+    /// <inheritdoc />
     public override string ConvertIntegerToOrderableString => "substr('0000000000'||'{0}', -10, 10)";
 
     /// <inheritdoc />

--- a/src/Umbraco.PublishedCache.HybridCache/CLAUDE.md
+++ b/src/Umbraco.PublishedCache.HybridCache/CLAUDE.md
@@ -60,7 +60,7 @@ Umbraco.PublishedCache.HybridCache/
 ├── Services/
 │   ├── DocumentCacheService.cs            # Content caching service (372 lines)
 │   ├── MediaCacheService.cs               # Media caching service
-│   ├── MemberCacheService.cs              # Member caching service
+│   ├── MemberCacheService.cs              # Maps members (not cached, see below)
 │   └── DomainCacheService.cs              # Domain caching service
 ├── CacheManager.cs                        # ICacheManager facade (27 lines)
 ├── ContentCacheNode.cs                    # Cache entry model (24 lines)
@@ -261,6 +261,18 @@ Uses `SqlContext.Templates` for cached SQL generation with optimized joins acros
 ### Experimental API Warning
 
 HybridCache API is experimental (suppressed with `#pragma warning disable EXTEXP0018`).
+
+### Members Are Mapped, Not Cached
+
+`IPublishedMemberCache` is the odd one out: it does not use HybridCache or `cmsContentNu` at all.
+`MemberCache.Get(IMember)` goes to `MemberCacheService.Get`, which calls
+`IPublishedContentFactory.ToPublishedMember` to map the supplied `IMember` entity on the fly. `IPublishedMember`
+exposes the underlying `IMember`, which cannot be reconstructed from a cache row, so the entity is required
+regardless — there is nothing a cached row could save. Nothing reads member rows, and the rebuild does not write
+them.
+
+Consequence for anything touching the rebuild: it has two arms (documents and media), not three. A site upgraded
+from a version that did write member rows keeps them until its next *full* rebuild, which truncates the table.
 
 ### Draft vs Published Caching
 

--- a/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
@@ -116,7 +116,7 @@ internal sealed class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
     private Task PerformRebuild()
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
-        _databaseCacheRepository.Rebuild([], [], [], executeStep: null);
+        _databaseCacheRepository.Rebuild([], [], executeStep: null);
 
         // If the serializer type has changed, we also need to update it in the key value store.
         var currentSerializerValue = _keyValueService.GetValue(NuCacheSerializerKey);

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -92,20 +92,23 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
             ContentCacheDataSerializerEntityType.Document
             | ContentCacheDataSerializerEntityType.Media);
 
-        // Both collections non-null but empty means every row this method writes is about to be replaced, so
-        // truncating beats deleting per object type.
+        // Both collections non-null but empty means every row this method writes is about to be replaced,
+        // so clear the whole table in one statement rather than once per object type.
         if (contentTypeIds is not null && contentTypeIds.Count == 0 &&
             mediaTypeIds is not null && mediaTypeIds.Count == 0)
         {
-            TruncateContent();
+            ClearContent();
         }
 
         RebuildContentDbCache(serializer, _nucacheSettings.Value.SqlPageSize, contentTypeIds, executeStep);
         RebuildMediaDbCache(serializer, _nucacheSettings.Value.SqlPageSize, mediaTypeIds, executeStep);
     }
 
-    private void TruncateContent()
-        => Database.TruncateTable(SqlSyntax, Constants.DatabaseSchema.Tables.NodeData);
+    // Deletes rather than truncates. Truncating needs ALTER permission on the table where deleting needs
+    // only DELETE, and this runs from a backoffice action on sites whose runtime database user may have
+    // been reduced to read/write.
+    private void ClearContent()
+        => Database.Execute($"DELETE FROM {QuoteTableName(Constants.DatabaseSchema.Tables.NodeData)}");
 
     /// <inheritdoc/>
     public async Task<ContentCacheNode?> GetContentSourceAsync(Guid key, bool preview = false)

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -105,17 +105,7 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     }
 
     private void TruncateContent()
-    {
-        if (Database.DatabaseType == DatabaseType.SqlServer2012)
-        {
-            Database.Execute($"TRUNCATE TABLE cmsContentNu");
-        }
-
-        if (Database.DatabaseType == DatabaseType.SQLite)
-        {
-            Database.Execute($"DELETE FROM cmsContentNu");
-        }
-    }
+        => Database.TruncateTable(SqlSyntax, Constants.DatabaseSchema.Tables.NodeData);
 
     /// <inheritdoc/>
     public async Task<ContentCacheNode?> GetContentSourceAsync(Guid key, bool preview = false)

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -80,18 +80,9 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     }
 
     /// <inheritdoc/>
-    [Obsolete("Use the overload accepting an executeStep delegate. Scheduled for removal in Umbraco 19.")]
-    public void Rebuild(
-        IReadOnlyCollection<int>? contentTypeIds = null,
-        IReadOnlyCollection<int>? mediaTypeIds = null,
-        IReadOnlyCollection<int>? memberTypeIds = null)
-        => Rebuild(contentTypeIds, mediaTypeIds, memberTypeIds, null);
-
-    /// <inheritdoc/>
     public void Rebuild(
         IReadOnlyCollection<int>? contentTypeIds,
         IReadOnlyCollection<int>? mediaTypeIds,
-        IReadOnlyCollection<int>? memberTypeIds,
         Action<Action>? executeStep)
     {
         // When no executeStep delegate is provided, execute directly against the ambient scope.
@@ -99,21 +90,18 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
 
         IContentCacheDataSerializer serializer = _contentCacheDataSerializerFactory.Create(
             ContentCacheDataSerializerEntityType.Document
-            | ContentCacheDataSerializerEntityType.Media
-            | ContentCacheDataSerializerEntityType.Member);
+            | ContentCacheDataSerializerEntityType.Media);
 
-        // If contentTypeIds, mediaTypeIds and memberTypeIds are all non-null but empty,
-        // truncate the table as all records will be deleted (as these 3 are the only types in the table).
+        // Both collections non-null but empty means every row this method writes is about to be replaced, so
+        // truncating beats deleting per object type.
         if (contentTypeIds is not null && contentTypeIds.Count == 0 &&
-            mediaTypeIds is not null && mediaTypeIds.Count == 0 &&
-            memberTypeIds is not null && memberTypeIds.Count == 0)
+            mediaTypeIds is not null && mediaTypeIds.Count == 0)
         {
             TruncateContent();
         }
 
         RebuildContentDbCache(serializer, _nucacheSettings.Value.SqlPageSize, contentTypeIds, executeStep);
         RebuildMediaDbCache(serializer, _nucacheSettings.Value.SqlPageSize, mediaTypeIds, executeStep);
-        RebuildMemberDbCache(serializer, _nucacheSettings.Value.SqlPageSize, memberTypeIds, executeStep);
     }
 
     private void TruncateContent()
@@ -1299,87 +1287,10 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
         return new ContentNuDto
         {
             NodeId = content.NodeId,
-            Published = false, // Media and members don't have published state
+            Published = false, // Media does not have a published state
             Data = serialized.StringData,
             RawData = serialized.ByteData,
         };
-    }
-
-    /// <summary>
-    /// Rebuilds the content database cache for members by clearing and repopulating the cache with the latest member data.
-    /// </summary>
-    /// <remarks>
-    /// Assumes content tree lock.
-    /// Uses an optimized query approach that bypasses IMember entity hydration for better performance.
-    /// </remarks>
-    private void RebuildMemberDbCache(IContentCacheDataSerializer serializer, int groupSize, IReadOnlyCollection<int>? contentTypeIds, Action<Action> executeStep)
-    {
-        if (contentTypeIds is null)
-        {
-            return;
-        }
-
-        Guid memberObjectType = Constants.ObjectTypes.Member;
-
-        Dictionary<int, List<string>>? propertyAliasesByContentType = null;
-
-        // Delete stale rows in batches (each its own step); the returned count of affected nodes is the
-        // number to repopulate, so no separate count query is needed.
-        long total = RemoveByObjectTypeInBatches(memberObjectType, contentTypeIds, executeStep);
-
-        if (total == 0)
-        {
-            return;
-        }
-
-        executeStep(() =>
-        {
-            propertyAliasesByContentType = GetPropertyAliasesByContentType(contentTypeIds);
-        });
-
-        long processed = 0;
-        long pageIndex = 0;
-
-        while (processed < total)
-        {
-            var pageComplete = false;
-
-            executeStep(() =>
-            {
-                List<int> nodeIds = GetPagedContentNodeIds(memberObjectType, contentTypeIds, pageIndex, groupSize);
-                if (nodeIds.Count == 0)
-                {
-                    return;
-                }
-
-                List<CacheRebuildContentDto> memberDtos = GetContentMetadataForNodes(nodeIds);
-                List<CacheRebuildPropertyDto> propertyDtos = GetPropertyDataForNodes(nodeIds);
-
-                var items = memberDtos
-                    .AsParallel()
-                    .WithDegreeOfParallelism(Environment.ProcessorCount)
-                    .Select(member => BuildCacheDtoForContent(member, propertyDtos, propertyAliasesByContentType!, serializer))
-                    .ToList();
-
-                BulkInsertSkipExisting(items);
-
-                processed += nodeIds.Count;
-                pageComplete = true;
-            });
-
-            // The break IS reachable: the executeStep delegate's early return (a page yielding no nodes — e.g.
-            // content removed concurrently, leaving the total row count stale) leaves pageComplete false, which
-            // guards against looping indefinitely. SonarLint cannot see through the delegate, so it incorrectly
-            // reports the condition as always false.
-#pragma warning disable S2583 // Conditionally executed code should be reachable
-            if (!pageComplete)
-            {
-                break;
-            }
-#pragma warning restore S2583
-
-            pageIndex++;
-        }
     }
 
     /// <summary>

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
@@ -128,7 +128,7 @@ internal interface IDatabaseCacheRepository
     Task RemovePublishedContentAsync(int id);
 
     /// <summary>
-    /// Rebuilds the caches for content, media and/or members based on the content type ids specified.
+    /// Rebuilds the caches for content and/or media based on the content type ids specified.
     /// </summary>
     /// <param name="contentTypeIds">
     ///     If not null will process content for the matching content types, if empty will process all
@@ -137,32 +137,6 @@ internal interface IDatabaseCacheRepository
     /// <param name="mediaTypeIds">
     ///     If not null will process content for the matching media types, if empty will process all
     ///     media.
-    /// </param>
-    /// <param name="memberTypeIds">
-    ///     If not null will process content for the matching members types, if empty will process all
-    ///     members.
-    /// </param>
-    [Obsolete("Use the overload accepting an executeStep delegate. Scheduled for removal in Umbraco 19.")]
-    void Rebuild(
-        IReadOnlyCollection<int>? contentTypeIds = null,
-        IReadOnlyCollection<int>? mediaTypeIds = null,
-        IReadOnlyCollection<int>? memberTypeIds = null)
-        => Rebuild(contentTypeIds, mediaTypeIds, memberTypeIds, null);
-
-    /// <summary>
-    /// Rebuilds the caches for content, media and/or members based on the content type ids specified.
-    /// </summary>
-    /// <param name="contentTypeIds">
-    ///     If not null will process content for the matching content types, if empty will process all
-    ///     content.
-    /// </param>
-    /// <param name="mediaTypeIds">
-    ///     If not null will process content for the matching media types, if empty will process all
-    ///     media.
-    /// </param>
-    /// <param name="memberTypeIds">
-    ///     If not null will process content for the matching members types, if empty will process all
-    ///     members.
     /// </param>
     /// <param name="executeStep">
     ///     Optional delegate that wraps each discrete step (delete, page read + insert) in a scope.
@@ -174,6 +148,5 @@ internal interface IDatabaseCacheRepository
     void Rebuild(
         IReadOnlyCollection<int>? contentTypeIds,
         IReadOnlyCollection<int>? mediaTypeIds,
-        IReadOnlyCollection<int>? memberTypeIds,
         Action<Action>? executeStep);
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/MsgPackContentNestedDataSerializerFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/MsgPackContentNestedDataSerializerFactory.cs
@@ -11,19 +11,16 @@ internal sealed class MsgPackContentNestedDataSerializerFactory : IContentCacheD
     private readonly IContentTypeService _contentTypeService;
     private readonly ConcurrentDictionary<(int, string, bool), bool> _isCompressedCache = new();
     private readonly IMediaTypeService _mediaTypeService;
-    private readonly IMemberTypeService _memberTypeService;
     private readonly PropertyEditorCollection _propertyEditors;
 
     public MsgPackContentNestedDataSerializerFactory(
         IContentTypeService contentTypeService,
         IMediaTypeService mediaTypeService,
-        IMemberTypeService memberTypeService,
         PropertyEditorCollection propertyEditors,
         IPropertyCacheCompressionOptions compressionOptions)
     {
         _contentTypeService = contentTypeService;
         _mediaTypeService = mediaTypeService;
-        _memberTypeService = memberTypeService;
         _propertyEditors = propertyEditors;
         _compressionOptions = compressionOptions;
     }
@@ -47,14 +44,6 @@ internal sealed class MsgPackContentNestedDataSerializerFactory : IContentCacheD
         if ((types & ContentCacheDataSerializerEntityType.Media) == ContentCacheDataSerializerEntityType.Media)
         {
             foreach (IMediaType ct in _mediaTypeService.GetAll())
-            {
-                contentTypes[ct.Id] = ct;
-            }
-        }
-
-        if ((types & ContentCacheDataSerializerEntityType.Member) == ContentCacheDataSerializerEntityType.Member)
-        {
-            foreach (IMemberType ct in _memberTypeService.GetAll())
             {
                 contentTypes[ct.Id] = ct;
             }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -485,7 +485,6 @@ internal sealed class DocumentCacheService : IDocumentCacheService, IMemoryCache
         => _databaseCacheRepository.Rebuild(
             contentTypeIds.ToList(),
             null,
-            null,
             action =>
             {
                 using ICoreScope scope = _scopeProvider.CreateCoreScope();

--- a/src/Umbraco.PublishedCache.HybridCache/Services/IMemberCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/IMemberCacheService.cs
@@ -3,10 +3,26 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
+/// <summary>
+/// Defines a service for retrieving published member data from the cache.
+/// </summary>
 public interface IMemberCacheService
 {
+    /// <summary>
+    /// Gets the published member for the given member entity.
+    /// </summary>
+    /// <param name="member">The member entity.</param>
+    /// <returns>The published member, or <c>null</c> if not found.</returns>
     Task<IPublishedMember?> Get(IMember member);
 
-    // TODO (V18): Remove the default implementation on this method.
-    void Rebuild(IReadOnlyCollection<int> contentTypeIds) => throw new NotImplementedException();
+    /// <summary>
+    /// Does nothing. Members are mapped from the member entity when read, rather than served from the
+    /// published cache database table, so there is nothing to rebuild.
+    /// </summary>
+    /// <param name="contentTypeIds">The member type ids. Ignored.</param>
+    // TODO (V19): remove this member.
+    [Obsolete("Members are not stored in the published cache database table, so this does nothing. Scheduled for removal in Umbraco 19.")]
+    void Rebuild(IReadOnlyCollection<int> contentTypeIds)
+    {
+    }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/IMemberCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/IMemberCacheService.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
 /// <summary>
-/// Defines a service for retrieving published member data from the cache.
+/// Defines a service for mapping member entities to published members.
 /// </summary>
 public interface IMemberCacheService
 {
@@ -20,7 +20,7 @@ public interface IMemberCacheService
     /// published cache database table, so there is nothing to rebuild.
     /// </summary>
     /// <param name="contentTypeIds">The member type ids. Ignored.</param>
-    // TODO (V19): remove this member.
+    // TODO (V19): remove this method.
     [Obsolete("Members are not stored in the published cache database table, so this does nothing. Scheduled for removal in Umbraco 19.")]
     void Rebuild(IReadOnlyCollection<int> contentTypeIds)
     {

--- a/src/Umbraco.PublishedCache.HybridCache/Services/IMemberCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/IMemberCacheService.cs
@@ -20,7 +20,6 @@ public interface IMemberCacheService
     /// published cache database table, so there is nothing to rebuild.
     /// </summary>
     /// <param name="contentTypeIds">The member type ids. Ignored.</param>
-    // TODO (V19): remove this method.
     [Obsolete("Members are not stored in the published cache database table, so this does nothing. Scheduled for removal in Umbraco 19.")]
     void Rebuild(IReadOnlyCollection<int> contentTypeIds)
     {

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -380,7 +380,6 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
         => _databaseCacheRepository.Rebuild(
             null,
             contentTypeIds.ToList(),
-            null,
             action =>
             {
                 using ICoreScope scope = _scopeProvider.CreateCoreScope();

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MemberCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MemberCacheService.cs
@@ -1,38 +1,15 @@
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Infrastructure.HybridCache.Factories;
-using Umbraco.Cms.Infrastructure.HybridCache.Persistence;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
 internal sealed class MemberCacheService : IMemberCacheService
 {
     private readonly IPublishedContentFactory _publishedContentFactory;
-    private readonly IDatabaseCacheRepository _databaseCacheRepository;
-    private readonly ICoreScopeProvider _scopeProvider;
 
-    public MemberCacheService(
-        IPublishedContentFactory publishedContentFactory,
-        IDatabaseCacheRepository databaseCacheRepository,
-        ICoreScopeProvider scopeProvider)
-    {
-        _publishedContentFactory = publishedContentFactory;
-        _databaseCacheRepository = databaseCacheRepository;
-        _scopeProvider = scopeProvider;
-    }
+    public MemberCacheService(IPublishedContentFactory publishedContentFactory)
+        => _publishedContentFactory = publishedContentFactory;
 
     public async Task<IPublishedMember?> Get(IMember member) => member is null ? null : _publishedContentFactory.ToPublishedMember(member);
-
-    public void Rebuild(IReadOnlyCollection<int> contentTypeIds)
-        => _databaseCacheRepository.Rebuild(
-            null,
-            null,
-            contentTypeIds.ToList(),
-            action =>
-            {
-                using ICoreScope scope = _scopeProvider.CreateCoreScope();
-                action();
-                scope.Complete();
-            });
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MemberCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MemberCacheService.cs
@@ -4,12 +4,20 @@ using Umbraco.Cms.Infrastructure.HybridCache.Factories;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
+/// <summary>
+/// Implements a service for mapping member entities to published members.
+/// </summary>
 internal sealed class MemberCacheService : IMemberCacheService
 {
     private readonly IPublishedContentFactory _publishedContentFactory;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemberCacheService"/> class.
+    /// </summary>
+    /// <param name="publishedContentFactory">The published content factory.</param>
     public MemberCacheService(IPublishedContentFactory publishedContentFactory)
         => _publishedContentFactory = publishedContentFactory;
 
+    /// <inheritdoc/>
     public async Task<IPublishedMember?> Get(IMember member) => member is null ? null : _publishedContentFactory.ToPublishedMember(member);
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/TruncateTableTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/TruncateTableTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class TruncateTableTests : UmbracoIntegrationTest
+{
+    private const string TableName = "testTruncateTable";
+
+    private ISqlContext SqlContext => GetRequiredService<ISqlContext>();
+
+    [Test]
+    public void Can_Truncate_A_Table()
+    {
+        // Arrange - a table of our own, so this asserts that emptying a table works rather than
+        // anything about a particular table's contents.
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            IUmbracoDatabase database = ScopeAccessor.AmbientScope!.Database;
+            database.Execute($"CREATE TABLE {TableName} (id int NOT NULL)");
+            database.Execute($"INSERT INTO {TableName} (id) VALUES (1)");
+            database.Execute($"INSERT INTO {TableName} (id) VALUES (2)");
+        }
+
+        Assume.That(CountRows(), Is.EqualTo(2));
+
+        // Act
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            ScopeAccessor.AmbientScope!.Database.TruncateTable(SqlContext.SqlSyntax, TableName);
+        }
+
+        // Assert
+        Assert.That(CountRows(), Is.Zero);
+    }
+
+    private int CountRows()
+    {
+        using var scope = ScopeProvider.CreateScope(autoComplete: true);
+        return ScopeAccessor.AmbientScope!.Database.ExecuteScalar<int>($"SELECT COUNT(*) FROM {TableName}");
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentCacheServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentCacheServiceTests.cs
@@ -366,7 +366,7 @@ internal sealed partial class DocumentCacheServiceTests : UmbracoIntegrationTest
         ContentService.Publish(Textpage, ["*"]);
 
         // Act - Full rebuild (the "Rebuild Database Cache" dashboard button path)
-        // This calls Rebuild([], [], []) internally — empty arrays meaning "rebuild all"
+        // This calls Rebuild([], []) internally — empty arrays meaning "rebuild all"
         await DatabaseCacheRebuilder.RebuildAsync(false);
 
         // Assert - Verify cmsContentNu table has records for the content items

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MemberCacheServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MemberCacheServiceTests.cs
@@ -36,6 +36,8 @@ internal sealed class MemberCacheServiceTests : UmbracoIntegrationTestWithConten
 
     private IMemberCacheService MemberCacheService => GetRequiredService<IMemberCacheService>();
 
+    private IDatabaseCacheRebuilder DatabaseCacheRebuilder => GetRequiredService<IDatabaseCacheRebuilder>();
+
     private IMemberTypeService MemberTypeService => GetRequiredService<IMemberTypeService>();
 
     private IMemberService MemberService => GetRequiredService<IMemberService>();
@@ -60,77 +62,65 @@ internal sealed class MemberCacheServiceTests : UmbracoIntegrationTestWithConten
     }
 
     [Test]
-    public void Rebuild_Creates_Member_Database_Cache_Records_For_Member_Type()
+    public async Task FullRebuild_Does_Not_Create_Member_Database_Cache_Records()
     {
-        // Arrange - member is created in Setup()
+        // Arrange - a member and content are created in Setup()
 
-        // Act - Call Rebuild for the member type
-        MemberCacheService.Rebuild([MemberType.Id]);
+        // Act - full rebuild (the "Rebuild Database Cache" dashboard button path)
+        await DatabaseCacheRebuilder.RebuildAsync(false);
 
-        // Assert - Verify cmsContentNu table has records for the member item
-        using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+        // Assert - members are mapped from the entity on read, so they get no database cache records,
+        // while documents in the same rebuild do.
+        Assert.Multiple(() =>
         {
-            var selectSql = SqlContext.Sql()
-                .Select<ContentNuDto>()
-                .From<ContentNuDto>()
-                .Where<ContentNuDto>(x => x.NodeId == Member.Id);
-
-            var dtos = ScopeAccessor.AmbientScope!.Database.Fetch<ContentNuDto>(selectSql);
-
-            // Verify member has cache entry
-            Assert.That(dtos, Has.Count.EqualTo(1), "MemberItem should have exactly one cache entry");
-
-            // Verify cache data is not empty
-            var memberItemDto = dtos.First();
-            Assert.That(memberItemDto.Data, Is.Not.Null.And.Not.Empty, "Cache data should not be empty");
-
-            // Verify the cached data contains expected structure
-            Assert.That(memberItemDto.Data, Does.Contain("\"pd\":"), "Cache data should contain property data");
-            Assert.That(memberItemDto.Data, Does.Contain("\"us\":\"test-member\""), "Cache data should contain the url segment");
-        }
+            Assert.That(GetCacheRecords(Member.Id), Is.Empty, "Member should have no cache entry");
+            Assert.That(GetCacheRecords(Textpage.Id), Is.Not.Empty, "Document should have a cache entry");
+        });
     }
 
     [Test]
-    public void Rebuild_Replaces_Existing_Member_Database_Cache_Records()
+    public async Task FullRebuild_Removes_Existing_Member_Database_Cache_Records()
     {
-        // Arrange - First rebuild to create initial records
-        MemberCacheService.Rebuild([MemberType.Id]);
-
-        // Get initial data
-        string initialData;
-        using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+        // Arrange - a record left behind by a version that cached members
+        using (ScopeProvider.CreateScope(autoComplete: true))
         {
-            var selectSql = SqlContext.Sql()
-                .Select<ContentNuDto>()
-                .From<ContentNuDto>()
-                .Where<ContentNuDto>(x => x.NodeId == Member.Id);
-            var dto = ScopeAccessor.AmbientScope!.Database.Fetch<ContentNuDto>(selectSql).FirstOrDefault();
-            Assert.That(dto, Is.Not.Null);
-            initialData = dto!.Data!;
+            ScopeAccessor.AmbientScope!.Database.Insert(new ContentNuDto
+            {
+                NodeId = Member.Id,
+                Published = false,
+                Data = "{}",
+                Rv = 1,
+            });
         }
 
-        // Modify member
-        Member.Name = "Modified Member Name";
-        MemberService.Save(Member);
+        Assume.That(GetCacheRecords(Member.Id), Is.Not.Empty);
 
-        // Act - Rebuild again
+        // Act
+        await DatabaseCacheRebuilder.RebuildAsync(false);
+
+        // Assert
+        Assert.That(GetCacheRecords(Member.Id), Is.Empty, "Existing member cache entries should be removed");
+    }
+
+    [Test]
+    public void Rebuild_Does_Not_Create_Member_Database_Cache_Records()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
         MemberCacheService.Rebuild([MemberType.Id]);
+#pragma warning restore CS0618 // Type or member is obsolete
 
-        // Assert - Verify record was updated (not duplicated)
-        using (var scope = ScopeProvider.CreateScope(autoComplete: true))
-        {
-            var selectSql = SqlContext.Sql()
-                .Select<ContentNuDto>()
-                .From<ContentNuDto>()
-                .Where<ContentNuDto>(x => x.NodeId == Member.Id);
-            var dtos = ScopeAccessor.AmbientScope!.Database.Fetch<ContentNuDto>(selectSql);
+        Assert.That(GetCacheRecords(Member.Id), Is.Empty);
+    }
 
-            // Should have exactly one record (no duplicates)
-            Assert.That(dtos, Has.Count.EqualTo(1), "Should have exactly one cache record");
+    private List<ContentNuDto> GetCacheRecords(int nodeId)
+    {
+        using var scope = ScopeProvider.CreateScope(autoComplete: true);
 
-            // Data should be different (updated)
-            var updatedData = dtos[0].Data;
-            Assert.That(updatedData, Does.Contain("modified-member-name"), "Cache data should contain the modified name");
-        }
+        var selectSql = SqlContext.Sql()
+            .Select<ContentNuDto>()
+            .From<ContentNuDto>()
+            .Where<ContentNuDto>(x => x.NodeId == nodeId);
+
+        return ScopeAccessor.AmbientScope!.Database.Fetch<ContentNuDto>(selectSql);
     }
 }


### PR DESCRIPTION
## Description

Members are written into `cmsContentNu` by a full published-cache rebuild, but nothing ever reads those rows. This PR removes the write, and fixes a pre-existing bug that the removal exposed.

Fixes #23070.

### Why this is justified

**Nothing reads member rows.** `MemberCache.Get(IMember)` goes to `MemberCacheService.Get`, which calls `IPublishedContentFactory.ToPublishedMember` and maps the supplied `IMember` entity on the fly. `DatabaseCacheRepository` is the only class in the codebase that queries `cmsContentNu`, and its only member-scoped code was the write. There is no second reader anywhere, including the Examine `MembersIndex` which populates from `IMemberService`.

Digging through the history suggests this is an unfinished or abandoned feature. The comment in `PublishedContentFactory.ToPublishedMember` has said so since the first HybridCache commit:

> Members are only "mapped" never cached, so these default values are a bit weird, but they are not used.

`IPublishedMember` exposes the underlying `IMember`, which cannot be reconstructed from a cache row, so the read path needs the entity regardless. That removes the benefit a cached row could provide, which is presumably why the read side was never wired up — even the original 2016 NuCache `MemberCache` took `IMemberService` rather than the data source.

**The rows are also stale, not merely unused.** Up to v14 the write side was self-consistent: `PublishedSnapshotServiceEventHandler` handled `MemberRefreshNotification` to refresh a member's row on save, and member-type changes triggered a rebuild. Removing NuCache in v15 took both with it, and HybridCache never replaced them. Since then the only thing writing member rows has been the bulk rebuild, so a row reflects whatever the last full rebuild happened to see and nothing else.

**Effect.** A full rebuild — the Settings → Published status button, the post-migration rebuild, and the boot-time serializer-changed rebuild — no longer serialises and inserts a row per member. On a site with a lot of members, that is a considerable amount of pointless work removed from every rebuild, inside the single transaction the rebuild holds.

No longer requesting the `Member` serializer flag also drops a `_memberTypeService.GetAll()` from every rebuild, and makes the corresponding branch in `MsgPackContentNestedDataSerializerFactory` unreachable — that branch and its injected `IMemberTypeService` go too. The public `ContentCacheDataSerializerEntityType.Member` enum value stays, since it is in the package baseline.

### Why not the change requested in the issue

The issue asks for a setting to disable member caching, or for `IDatabaseCacheRepository`/`DatabaseCacheRepository` to become public and unsealed so the rebuild can be overridden as it could in v13. Neither is needed if the work simply isn't done, and a setting would only be a flag over dead code. Making the repository public would also commit us to a large surface for a major, to work around a defect.

### Existing rows

Not migrated. I considered adding a 17.7/18.2 migration step for this, but it doesn't seem necessary. Other than taking space, the stale records don't really do any harm — they're unread, and `cmsContentNu.nodeId` has an `ON DELETE CASCADE` foreign key to `umbracoContent`, so a deleted member takes its row with it.

A full rebuild clears the table before repopulating, so that removes them — though only thanks to the fix below, without which it would never have happened on SQL Server. Worth being precise in the release note: an upgrade won't necessarily perform a full rebuild, because the post-migration rebuild only runs when an executed migration sets `RebuildCache`, and targeted per-content-type rebuilds never truncate. So the rows can outlive several upgrades until someone rebuilds.

## Fix to a pre-existing bug in the rebuild's table clear

In local testing, a full rebuild left member rows behind on SQL Server. The method that clears the table was a silent no-op there:

```csharp
private void TruncateContent()
{
    if (Database.DatabaseType == DatabaseType.SqlServer2012)
    {
        Database.Execute($"TRUNCATE TABLE cmsContentNu");
    }

    if (Database.DatabaseType == DatabaseType.SQLite)
    {
        Database.Execute($"DELETE FROM cmsContentNu");
    }
}
```

Both are reference comparisons against NPoco's singleton instances. On SQL Server, `SqlServerSyntaxProvider.GetUpdatedDatabaseType` returns `UmbracoSqlServerDatabaseType` — a *subclass* of `SqlServer2012DatabaseType`, added so that bulk inserts keep foreign key constraints trusted. Being a subclass, it is not the singleton, so neither branch matched and nothing was executed.

That went unnoticed because each rebuild arm already deletes its own rows via `RemoveByObjectTypeInBatches` before repopulating, leaving this as a pure optimisation whose failure had no visible effect. Removing the member arm is what made it load-bearing: with nothing else deleting member rows, they would have survived every rebuild on SQL Server.

It is now one provider-agnostic statement, renamed to say what it does:

```csharp
// Deletes rather than truncates. Truncating needs ALTER permission on the table where deleting needs
// only DELETE, and this runs from a backoffice action on sites whose runtime database user may have
// been reduced to read/write.
private void ClearContent()
    => Database.Execute($"DELETE FROM {QuoteTableName(Constants.DatabaseSchema.Tables.NodeData)}");
```

`DELETE` rather than `TRUNCATE` is deliberate. `TRUNCATE` has never actually executed on SQL Server previously, so deleting is what SQL Server already does today and introduces no new permission requirement on a backoffice action.

### Also included

`SqliteSyntaxProvider` now overrides `TruncateTable` as `DELETE FROM {0}`. Nothing in production calls `Database.TruncateTable`, but the base provider's format is `TRUNCATE TABLE {0}` and SQLite has no such statement, so the extension would have handed invalid SQL to the first caller that tried it. Happy to drop this if it feels like scope creep, but it seemed worth closing while it was in view.

## Testing

### Automated

Three integration tests in `MemberCacheServiceTests` replace the two that asserted the removed behaviour.

Although now removed from the call site, `TruncateTableTests` covers `Database.TruncateTable` the fix to truncating tables.

### Manual

Clear the member data from the cache with a rebuild from the backoffice via _Settings > Published Status > Rebuild database cache_. Verify no member records exist via:

```sql
SELECT COUNT(*) FROM cmsContentNu n
INNER JOIN umbracoNode un ON un.id = n.nodeId
WHERE un.nodeObjectType = '39EB0F98-B348-42A1-8662-E7EB18487560';
```

Then render a member in a template and confirm the values still resolve — including a custom property, which is the part that used to be serialised into the row. Built-in fields such as `Email` and `UserName` come off the member entity's own columns and would work either way.

<details>
<summary>Template code</summary>

```cshtml
@using Umbraco.Cms.Core.Models
@using Umbraco.Cms.Core.Models.PublishedContent
@using Umbraco.Cms.Core.PublishedCache
@using Umbraco.Cms.Core.Services
@using Umbraco.Extensions
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@inject IMemberService MemberService
@inject IPublishedMemberCache MemberCache
@{
    Layout = null;

    // Set these to match your site.
    const string usernameToLookUp = "testmember";
    const string customPropertyAlias = "memberBio";
}

<h2>Member lookup via IPublishedMemberCache</h2>
@{
    IMember? member = MemberService.GetByUsername(usernameToLookUp);
}
@if (member is null)
{
    <p>No member with username '@usernameToLookUp'.</p>
}
else
{
    IPublishedMember? published = await MemberCache.GetAsync(member);

    if (published is null)
    {
        <p>Mapping returned null — that would be a real failure.</p>
    }
    else
    {
        <ul>
            <li>Name: @published.Name</li>
            <li>Email: @published.Email</li>
            <li>UserName: @published.UserName</li>
            <li>IsApproved: @published.IsApproved</li>
            <li>LastLoginDate: @published.LastLoginDate</li>
            <li>Content type: @published.ContentType.Alias</li>
        </ul>

        <h3>Custom property</h3>
        @if (published.HasProperty(customPropertyAlias))
        {
            <p><code>@customPropertyAlias</code> = <strong>@(published.Value<string>(customPropertyAlias))</strong></p>
        }
        else
        {
            <p>No property '@customPropertyAlias' on this member type — add one and set a value,
               otherwise this page only proves the built-in fields work.</p>
        }

        <h3>All properties</h3>
        <ul>
            @foreach (IPublishedProperty property in published.Properties)
            {
                <li>@property.Alias = @(property.GetValue()?.ToString() ?? "(null)")</li>
            }
        </ul>
    }
}
```

</details>

## Merge notes

Umbraco 18 has a four-arm rebuild — content, media, member, element — and element rows *are* read, so the merge must drop only the member arm. Two specifics:

- The guard around the table clear on `main` covers four collections, so it needs the same reduction there rather than taking this branch's two-collection version wholesale.
- The CLAUDE.md line ("two arms (documents and media), not three") becomes three-of-four.
