### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,8 +46,8 @@
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageVersion Include="BitFaster.Caching" Version="2.6.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageVersion Include="Examine" Version="3.9.0" />
-    <PackageVersion Include="Examine.Core" Version="3.9.0" />
+    <PackageVersion Include="Examine" Version="3.10.0" />
+    <PackageVersion Include="Examine.Core" Version="3.10.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />


### PR DESCRIPTION
## Description

Routine dependency maintenance for the **17.7** release. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Examine | 3.9.0 | 3.10.0 |
| Examine.Core | 3.9.0 | 3.10.0 |

### Test packages (`tests/Directory.Packages.props`)

No changes.

### Inline / template versions

No changes — neither `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj` inline versions nor `templates/UmbracoExtension` reference the updated packages.

### Deliberately left unchanged

- `Microsoft.OpenApi` is held at `2.9.0` per an existing `HOLD` comment in `Directory.Packages.props` (2.10.0+ has a confirmed regression in OpenAPI 3.0 nullability serialization that corrupts the Delivery API contract). A newer minor (2.12.2) is available upstream but is intentionally out of scope.

## Testing

Solution builds in Release and the full unit test suite (6258 tests) passes. No known-vulnerable transitive packages introduced (`dotnet list package --vulnerable --include-transitive` is clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCnc7eQLNM28qCXB514uqf)_