### PR TITLE
EFCore: MemberTypeRepository migration

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/BatchMemberTypesController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/BatchMemberTypesController.cs
@@ -45,7 +45,7 @@ public class BatchMemberTypesController : MemberTypeControllerBase
             return Ok(new BatchResponseModel<MemberTypeResponseModel>());
         }
 
-        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(requestedIds);
+        IEnumerable<IMemberType> memberTypes = await _memberTypeService.GetManyAsync(requestedIds);
 
         List<IMemberType> ordered = OrderByRequestedIds(memberTypes, requestedIds);
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/CompositionReferenceMemberTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/CompositionReferenceMemberTypeController.cs
@@ -54,7 +54,7 @@ public class CompositionReferenceMemberTypeController : MemberTypeControllerBase
             return OperationStatusResult(ContentTypeOperationStatus.NotFound);
         }
 
-        IEnumerable<IMemberType> composedOf = _memberTypeService.GetComposedOf(memberType.Id);
+        IEnumerable<IMemberType> composedOf = await _memberTypeService.GetComposedOfAsync(memberType.Id);
         List<MemberTypeCompositionResponseModel> responseModels = _umbracoMapper.MapEnumerable<IMemberType, MemberTypeCompositionResponseModel>(composedOf);
 
         return Ok(responseModels);

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/ExportMemberTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/ExportMemberTypeController.cs
@@ -39,11 +39,11 @@ public class ExportMemberTypeController : MemberTypeControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [EndpointSummary("Exports a member type.")]
     [EndpointDescription("Exports the member type identified by the provided Id to a downloadable format.")]
-    public IActionResult Export(
+    public async Task<IActionResult> Export(
         CancellationToken cancellationToken,
         Guid id)
     {
-        IMemberType? memberType = _memberTypeService.Get(id);
+        IMemberType? memberType = await _memberTypeService.GetAsync(id);
         if (memberType is null)
         {
             return OperationStatusResult(ContentTypeOperationStatus.NotFound);

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/ItemMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/ItemMemberTypeItemController.cs
@@ -39,17 +39,17 @@ public class ItemMemberTypeItemController : MemberTypeItemControllerBase
     [ProducesResponseType(typeof(IEnumerable<MemberTypeItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Gets a collection of member type items.")]
     [EndpointDescription("Gets a collection of member type items identified by the provided Ids.")]
-    public Task<IActionResult> Item(
+    public async Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         if (ids.Count is 0)
         {
-            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<MemberTypeItemResponseModel>()));
+            return Ok(Enumerable.Empty<MemberTypeItemResponseModel>());
         }
 
-        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(ids);
+        IEnumerable<IMemberType> memberTypes = await _memberTypeService.GetManyAsync(ids);
         List<MemberTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(memberTypes);
-        return Task.FromResult<IActionResult>(Ok(responseModels));
+        return Ok(responseModels);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
@@ -45,16 +45,16 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
     [ProducesResponseType(typeof(PagedModel<MemberTypeItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches member type items.")]
     [EndpointDescription("Searches member type items by the provided query with pagination support.")]
-    public Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
+    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
     {
         PagedModel<IEntitySlim> searchResult = _entitySearchService.Search(UmbracoObjectTypes.MemberType, query, skip, take);
         if (searchResult.Items.Any() is false)
         {
-            return Task.FromResult<IActionResult>(Ok(new PagedModel<MemberTypeItemResponseModel> { Total = searchResult.Total }));
+            return Ok(new PagedModel<MemberTypeItemResponseModel> { Total = searchResult.Total });
         }
 
         Guid[] keys = searchResult.Items.Select(item => item.Key).ToArray();
-        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(keys);
+        IEnumerable<IMemberType> memberTypes = await _memberTypeService.GetManyAsync(keys);
         IEnumerable<IMemberType> orderedMemberTypes = OrderByRequestedIds(memberTypes, keys);
 
         var result = new PagedModel<MemberTypeItemResponseModel>
@@ -63,6 +63,6 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
             Total = searchResult.Total,
         };
 
-        return Task.FromResult<IActionResult>(Ok(result));
+        return Ok(result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/MemberTypeTreeControllerBase.cs
@@ -58,8 +58,8 @@ public class MemberTypeTreeControllerBase : FolderTreeControllerBase<MemberTypeT
 
     protected override async Task<MemberTypeTreeItemResponseModel[]> MapTreeItemViewModelsAsync(Guid? parentKey, IEntitySlim[] entities)
     {
-        var memberTypes = _memberTypeService
-            .GetMany(entities.Select(entity => entity.Id).ToArray())
+        var memberTypes = (await _memberTypeService
+            .GetManyAsync(entities.Select(entity => entity.Id).ToArray()))
             .ToDictionary(contentType => contentType.Id);
 
         IEnumerable<Task<MemberTypeTreeItemResponseModel>> tasks = entities.Select(async entity =>

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferencePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypeReferencePresentationFactory.cs
@@ -42,7 +42,7 @@ public class DataTypeReferencePresentationFactory : IDataTypeReferencePresentati
         {
             { UmbracoObjectTypes.DocumentType.GetUdiType(), keys => _contentTypeService.GetManyAsync(keys).GetAwaiter().GetResult() },
             { UmbracoObjectTypes.MediaType.GetUdiType(), keys => _mediaTypeService.GetMany(keys) },
-            { UmbracoObjectTypes.MemberType.GetUdiType(), keys => _memberTypeService.GetMany(keys) }
+            { UmbracoObjectTypes.MemberType.GetUdiType(), keys => _memberTypeService.GetManyAsync(keys).GetAwaiter().GetResult() }
         };
 
         foreach (IGrouping<string, KeyValuePair<Udi, IEnumerable<string>>> usagesByEntityType in dataTypeUsages.GroupBy(u => u.Key.EntityType))

--- a/src/Umbraco.Cms.Api.Management/Factories/MemberTypeEditingPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MemberTypeEditingPresentationFactory.cs
@@ -14,7 +14,7 @@ internal sealed class MemberTypeEditingPresentationFactory : ContentTypeEditingP
     /// <param name="memberTypeService">The service used to manage and retrieve member types.</param>
     /// <param name="containerService">The service used to retrieve member type containers (folders).</param>
     public MemberTypeEditingPresentationFactory(IMemberTypeService memberTypeService, IMemberTypeContainerService containerService)
-        : base(containerService, () => memberTypeService.GetAll())
+        : base(containerService, () => memberTypeService.GetAllAsync().GetAwaiter().GetResult())
     {
     }
 

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentTypeIndexingService.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentTypeIndexingService.cs
@@ -75,7 +75,7 @@ internal sealed class ContentTypeIndexingService : IContentTypeIndexingService
         {
             UmbracoObjectTypes.Document => await GetDocumentKeysByContentTypesAsync(contentTypeKeys),
             UmbracoObjectTypes.Media => GetMediaKeysByMediaTypes(contentTypeKeys),
-            UmbracoObjectTypes.Member => GetMemberKeysByMemberTypes(contentTypeKeys),
+            UmbracoObjectTypes.Member => await GetMemberKeysByMemberTypesAsync(contentTypeKeys),
             _ => [],
         };
 
@@ -145,12 +145,10 @@ internal sealed class ContentTypeIndexingService : IContentTypeIndexingService
         return keys.ToArray();
     }
 
-    private Guid[] GetMemberKeysByMemberTypes(Guid[] memberTypeKeys)
+    private async Task<Guid[]> GetMemberKeysByMemberTypesAsync(Guid[] memberTypeKeys)
     {
-        int[] directMemberTypeIds = memberTypeKeys
-            .Select(key => _memberTypeService.Get(key))
-            .Where(mt => mt is not null)
-            .Select(mt => mt!.Id)
+        int[] directMemberTypeIds = (await _memberTypeService.GetManyAsync(memberTypeKeys))
+            .Select(mt => mt.Id)
             .ToArray();
 
         if (directMemberTypeIds.Length == 0)
@@ -158,7 +156,7 @@ internal sealed class ContentTypeIndexingService : IContentTypeIndexingService
             return [];
         }
 
-        int[] allMemberTypeIds = ExpandWithDependentContentTypes(_memberTypeService, directMemberTypeIds);
+        int[] allMemberTypeIds = await ExpandWithDependentMemberTypesAsync(directMemberTypeIds);
 
         var keys = new List<Guid>();
         foreach (int memberTypeId in allMemberTypeIds)
@@ -180,6 +178,12 @@ internal sealed class ContentTypeIndexingService : IContentTypeIndexingService
     private async Task<int[]> ExpandWithDependentContentTypesAsync(int[] contentTypeIds)
     {
         IContentType[] allTypes = (await _contentTypeService.GetAllAsync()).ToArray();
+        return ExpandWithDependentContentTypes(allTypes, contentTypeIds);
+    }
+
+    private async Task<int[]> ExpandWithDependentMemberTypesAsync(int[] contentTypeIds)
+    {
+        IMemberType[] allTypes = (await _memberTypeService.GetAllAsync()).ToArray();
         return ExpandWithDependentContentTypes(allTypes, contentTypeIds);
     }
 

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -1846,7 +1846,7 @@ public static class PublishedContentExtensions
     {
         IContentTypeBase? type = contentTypeService.GetAsync(alias).GetAwaiter().GetResult()
                                  ?? mediaTypeService.Get(alias)
-                                 ?? (IContentTypeBase?)memberTypeService.Get(alias);
+                                 ?? (IContentTypeBase?)memberTypeService.GetAsync(alias).GetAwaiter().GetResult();
         Dictionary<string, string> fields = GetAliasesAndNames(type);
 
         // ensure the standard fields are there

--- a/src/Umbraco.Core/Persistence/Repositories/IMediaTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMediaTypeRepository.cs
@@ -5,6 +5,9 @@ namespace Umbraco.Cms.Core.Persistence.Repositories;
 /// <summary>
 ///     Represents a repository for <see cref="IMediaType" /> entities.
 /// </summary>
+// TODO (EFCore): Once this repository migrates to EF Core, add IAsyncContentTypeRepositoryBase<IMediaType> here
+// (see IMemberTypeRepository) — and then IMemberTypeRepository can drop IContentTypeRepositoryBase<IMemberType>
+// entirely, going async-only like IContentTypeRepository.
 public interface IMediaTypeRepository : IContentTypeRepositoryBase<IMediaType>
 {
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IMemberTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberTypeRepository.cs
@@ -5,6 +5,14 @@ namespace Umbraco.Cms.Core.Persistence.Repositories;
 /// <summary>
 ///     Represents a repository for <see cref="IMemberType" /> entities.
 /// </summary>
-public interface IMemberTypeRepository : IContentTypeRepositoryBase<IMemberType>
+/// <remarks>
+///     Implements both the synchronous <see cref="IContentTypeRepositoryBase{TItem}"/> (still used by the
+///     synchronous member repository/service call sites) and the asynchronous
+///     <see cref="IAsyncContentTypeRepositoryBase{TItem}"/> (required by <see cref="AsyncContentTypeServiceBase{TRepository,TItem}"/>,
+///     used by <see cref="Umbraco.Cms.Core.Services.MemberTypeService"/>).
+/// </remarks>
+// TODO (EFCore): Drop IContentTypeRepositoryBase<IMemberType> here once IMediaTypeRepository has also migrated to
+// EF Core, so this can go async-only like IContentTypeRepository.
+public interface IMemberTypeRepository : IContentTypeRepositoryBase<IMemberType>, IAsyncContentTypeRepositoryBase<IMemberType>
 {
 }

--- a/src/Umbraco.Core/Services/ContentTypeBaseServiceProvider.cs
+++ b/src/Umbraco.Core/Services/ContentTypeBaseServiceProvider.cs
@@ -59,7 +59,7 @@ public class ContentTypeBaseServiceProvider : IContentTypeBaseServiceProvider
             case IMedia _:
                 return _mediaTypeService.Get(contentBase.Key);
             case IMember _:
-                return _memberTypeService.Get(contentBase.Key);
+                return _memberTypeService.GetAsync(contentBase.Key).GetAwaiter().GetResult();
             default:
                 throw new ArgumentException(
                     $"Invalid contentBase type: {contentBase.GetType().FullName}",

--- a/src/Umbraco.Core/Services/ContentTypeEditing/MemberTypeEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/MemberTypeEditingService.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.Services.ContentTypeEditing;
 ///     This service handles creating and updating member types including their properties,
 ///     compositions, and member-specific settings such as property sensitivity and visibility.
 /// </remarks>
-internal sealed class MemberTypeEditingService : ContentTypeEditingServiceBase<IMemberType, IMemberTypeService, MemberTypePropertyTypeModel, MemberTypePropertyContainerModel>, IMemberTypeEditingService
+internal sealed class MemberTypeEditingService : AsyncContentTypeEditingServiceBase<IMemberType, IMemberTypeService, MemberTypePropertyTypeModel, MemberTypePropertyContainerModel>, IMemberTypeEditingService
 {
     private readonly IMemberTypeService _memberTypeService;
     private readonly IUserService _userService;

--- a/src/Umbraco.Core/Services/IMemberTypeService.cs
+++ b/src/Umbraco.Core/Services/IMemberTypeService.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Core.Services;
 /// <summary>
 ///     Manages <see cref="IMemberType" /> objects.
 /// </summary>
-public interface IMemberTypeService : IContentTypeBaseService<IMemberType>
+public interface IMemberTypeService : IAsyncContentTypeBaseService<IMemberType>
 {
     /// <summary>
     ///     Gets the alias of the default <see cref="IMemberType" />.

--- a/src/Umbraco.Core/Services/MemberContentEditingService.cs
+++ b/src/Umbraco.Core/Services/MemberContentEditingService.cs
@@ -21,9 +21,9 @@ namespace Umbraco.Cms.Core.Services;
 ///     functionality such as handling sensitive property access control.
 /// </remarks>
 internal sealed class MemberContentEditingService
-    : ContentEditingServiceBase<IMember, IMemberType, IMemberService, IMemberTypeService>, IMemberContentEditingService
+    : AsyncContentEditingServiceBase<IMember, IMemberType, IMemberService, IMemberTypeService>, IMemberContentEditingService
 {
-    private readonly ILogger<ContentEditingServiceBase<IMember, IMemberType, IMemberService, IMemberTypeService>> _logger;
+    private readonly ILogger<AsyncContentEditingServiceBase<IMember, IMemberType, IMemberService, IMemberTypeService>> _logger;
     private readonly IUserService _userService;
 
     /// <summary>
@@ -46,7 +46,7 @@ internal sealed class MemberContentEditingService
         IMemberTypeService contentTypeService,
         PropertyEditorCollection propertyEditorCollection,
         IDataTypeService dataTypeService,
-        ILogger<ContentEditingServiceBase<IMember, IMemberType, IMemberService, IMemberTypeService>> logger,
+        ILogger<AsyncContentEditingServiceBase<IMember, IMemberType, IMemberService, IMemberTypeService>> logger,
         ICoreScopeProvider scopeProvider,
         IUserIdKeyResolver userIdKeyResolver,
         IMemberValidationService memberValidationService,

--- a/src/Umbraco.Core/Services/MemberTypeService.cs
+++ b/src/Umbraco.Core/Services/MemberTypeService.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Core.Services;
 ///     available for members in the system. It extends the base content type service functionality
 ///     with member-specific behavior.
 /// </remarks>
-public class MemberTypeService : ContentTypeServiceBase<IMemberTypeRepository, IMemberType>, IMemberTypeService
+public class MemberTypeService : AsyncContentTypeServiceBase<IMemberTypeRepository, IMemberType>, IMemberTypeService
 {
     private readonly IMemberTypeRepository _memberTypeRepository;
 
@@ -203,20 +203,22 @@ public class MemberTypeService : ContentTypeServiceBase<IMemberTypeRepository, I
     ///     Deletes all members that use the specified member type IDs.
     /// </summary>
     /// <param name="typeIds">The IDs of the member types whose members should be deleted.</param>
-    protected override void DeleteItemsOfTypes(IEnumerable<int> typeIds)
+    protected override Task DeleteItemsOfTypesAsync(IEnumerable<int> typeIds)
     {
         foreach (var typeId in typeIds)
         {
             MemberService.DeleteMembersOfType(typeId);
         }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     /// <remarks>
     /// Unlike document and media types, members are a flat list, so all member types are allowed at root.
     /// </remarks>
-    protected override IEnumerable<IMemberType> GetAllowedAtRootCandidates()
-        => _memberTypeRepository.GetMany(Array.Empty<int>()).ToArray();
+    protected override Task<IEnumerable<IMemberType>> GetAllowedAtRootCandidatesAsync()
+        => _memberTypeRepository.GetManyAsync(Array.Empty<int>(), CancellationToken.None);
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
@@ -113,7 +113,7 @@ public class MigrateSingleBlockList : AsyncMigrationBase
         IEnumerable<IPropertyType> mediaPropertyTypes = allMediaTypes
             .SelectMany(ct => ct.PropertyTypes);
 
-        IMemberType[] allMemberTypes = _memberTypeService.GetAll().ToArray();
+        IMemberType[] allMemberTypes = (await _memberTypeService.GetAllAsync()).ToArray();
         IEnumerable<IPropertyType> memberPropertyTypes = allMemberTypes
             .SelectMany(mt => mt.PropertyTypes);
 

--- a/src/Umbraco.Infrastructure/ModelsBuilder/UmbracoServices.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/UmbracoServices.cs
@@ -78,7 +78,7 @@ public sealed class UmbracoServices
             _mediaTypeService.GetAll().Cast<IContentTypeComposition>().ToArray()));
         types.AddRange(GetTypes(
             PublishedItemType.Member,
-            _memberTypeService.GetAll().Cast<IContentTypeComposition>().ToArray()));
+            _memberTypeService.GetAllAsync().GetAwaiter().GetResult().Cast<IContentTypeComposition>().ToArray()));
 
         return EnsureDistinctAliases(types);
     }
@@ -111,7 +111,7 @@ public sealed class UmbracoServices
     /// <returns>A list of <see cref="TypeModel"/> objects representing the member types.</returns>
     public IList<TypeModel> GetMemberTypes()
     {
-        IContentTypeComposition[] memberTypes = _memberTypeService.GetAll().Cast<IContentTypeComposition>().ToArray();
+        IContentTypeComposition[] memberTypes = _memberTypeService.GetAllAsync().GetAwaiter().GetResult().Cast<IContentTypeComposition>().ToArray();
         return GetTypes(PublishedItemType.Member, memberTypes); // aliases have to be unique here
     }
 

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -347,7 +347,7 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 docTypeElements.ToList(),
                 true,
                 userId,
-                _memberTypeService,
+                new MemberTypeImportService(_memberTypeService),
                 out entityContainersInstalled);
 
         #endregion
@@ -2521,6 +2521,22 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 => _inner.CreateAsync(item, performingUserKey);
 
             public Task<Attempt<ContentTypeOperationStatus>> UpdateAsync(IContentType item, Guid performingUserKey)
+                => _inner.UpdateAsync(item, performingUserKey);
+        }
+
+        // Adapter over the asynchronous member-type service.
+        private sealed class MemberTypeImportService : IContentTypeImportService<IMemberType>
+        {
+            private readonly IMemberTypeService _inner;
+
+            public MemberTypeImportService(IMemberTypeService inner) => _inner = inner;
+
+            public IMemberType? Get(string alias) => _inner.GetAsync(alias).GetAwaiter().GetResult();
+
+            public Task<Attempt<ContentTypeOperationStatus>> CreateAsync(IMemberType item, Guid performingUserKey)
+                => _inner.CreateAsync(item, performingUserKey);
+
+            public Task<Attempt<ContentTypeOperationStatus>> UpdateAsync(IMemberType item, Guid performingUserKey)
                 => _inner.UpdateAsync(item, performingUserKey);
         }
     }

--- a/src/Umbraco.Infrastructure/Persistence/EFCore/UmbracoDbContext.cs
+++ b/src/Umbraco.Infrastructure/Persistence/EFCore/UmbracoDbContext.cs
@@ -96,6 +96,8 @@ public class UmbracoDbContext : DbContext
 
     public required DbSet<PropertyTypeDto> PropertyTypes { get; set; }
 
+    public required DbSet<MemberPropertyTypeDto> MemberPropertyTypes { get; set; }
+
     public required DbSet<DataTypeDto> DataTypes { get; set; }
 
     public required DbSet<RedirectUrlDto> RedirectUrls { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Factories/EFCore/ContentTypeFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/EFCore/ContentTypeFactory.cs
@@ -148,6 +148,9 @@ internal static class ContentTypeFactory
     /// <returns>An enumerable of <see cref="MemberPropertyTypeDto"/> for each property type on the member type, or an empty collection if none exist.</returns>
     public static IEnumerable<MemberPropertyTypeDto> BuildMemberPropertyTypeDtos(IMemberType entity)
     {
+        // MemberCanEditProperty/MemberCanViewProperty/IsSensitiveProperty are only exposed on the
+        // concrete MemberType class, not on IMemberType, so a non-MemberType implementation has no
+        // member-specific metadata to persist.
         if (entity is not MemberType memberType || memberType.PropertyTypes.Any() == false)
         {
             return Enumerable.Empty<MemberPropertyTypeDto>();

--- a/src/Umbraco.Infrastructure/Persistence/Factories/EFCore/ContentTypeFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/EFCore/ContentTypeFactory.cs
@@ -140,6 +140,29 @@ internal static class ContentTypeFactory
         };
     }
 
+    /// <summary>
+    /// Creates a collection of <see cref="MemberPropertyTypeDto"/> objects representing the property types defined
+    /// on the specified <see cref="IMemberType"/>.
+    /// </summary>
+    /// <param name="entity">The member type entity whose property types will be converted to DTOs.</param>
+    /// <returns>An enumerable of <see cref="MemberPropertyTypeDto"/> for each property type on the member type, or an empty collection if none exist.</returns>
+    public static IEnumerable<MemberPropertyTypeDto> BuildMemberPropertyTypeDtos(IMemberType entity)
+    {
+        if (entity is not MemberType memberType || memberType.PropertyTypes.Any() == false)
+        {
+            return Enumerable.Empty<MemberPropertyTypeDto>();
+        }
+
+        return memberType.PropertyTypes.Select(x => new MemberPropertyTypeDto
+        {
+            NodeId = entity.Id,
+            PropertyTypeId = x.Id,
+            CanEdit = memberType.MemberCanEditProperty(x.Alias),
+            ViewOnProfile = memberType.MemberCanViewProperty(x.Alias),
+            IsSensitive = memberType.IsSensitiveProperty(x.Alias),
+        }).ToList();
+    }
+
     private static NodeDto BuildNodeDto(IUmbracoEntity entity, Guid nodeObjectType) => new()
     {
         CreateDate = entity.CreateDate,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -1,45 +1,36 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
-using Umbraco.Cms.Infrastructure.Persistence.Dtos;
-using Umbraco.Cms.Infrastructure.Persistence.Factories;
-using Umbraco.Cms.Infrastructure.Persistence.Querying;
-using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore.Scoping;
+using Umbraco.Cms.Infrastructure.Persistence.Factories.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.EFCore;
 using Umbraco.Extensions;
-using static Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 /// <summary>
 ///     Represents a repository for doing CRUD operations for <see cref="IMemberType" />
 /// </summary>
-internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberType>, IMemberTypeRepository
+/// <remarks>
+///     The shared content-type-composition logic lives in <see cref="AsyncContentTypeRepositoryBase{TEntity}"/>;
+///     this class only supplies the member-type specifics: the node object type, the built-in standard properties,
+///     and the member-only property metadata (<see cref="MemberPropertyTypeDto"/>) persistence.
+/// </remarks>
+internal sealed class MemberTypeRepository : AsyncContentTypeRepositoryBase<IMemberType>, IMemberTypeRepository
 {
     private readonly IShortStringHelper _shortStringHelper;
-    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
-    private readonly ICacheSyncService _cacheSyncService;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.MemberTypeRepository"/> class,
-    /// which is responsible for managing member type persistence in the Umbraco CMS.
+    /// Initializes a new instance of the <see cref="MemberTypeRepository"/> class.
     /// </summary>
-    /// <param name="scopeAccessor">Provides access to the current database scope for transactional operations.</param>
-    /// <param name="cache">The application-level caches used for optimizing repository operations.</param>
-    /// <param name="logger">The logger used for logging repository activity and errors.</param>
-    /// <param name="commonRepository">A repository for common content type operations shared across repositories.</param>
-    /// <param name="languageRepository">Repository for accessing language information.</param>
-    /// <param name="shortStringHelper">Helper for generating and manipulating short strings, such as aliases.</param>
-    /// <param name="repositoryCacheVersionService">Service for managing cache versioning within the repository.</param>
-    /// <param name="idKeyMap">Maps between integer IDs and GUID keys for entities.</param>
-    /// <param name="cacheSyncService">Service for synchronizing cache across distributed environments.</param>
     public MemberTypeRepository(
-        IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<MemberTypeRepository> logger,
         IContentTypeCommonRepository commonRepository,
@@ -47,107 +38,29 @@ internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberTy
         IShortStringHelper shortStringHelper,
         IRepositoryCacheVersionService repositoryCacheVersionService,
         IIdKeyMap idKeyMap,
-        ICacheSyncService cacheSyncService)
+        ICacheSyncService cacheSyncService,
+        IEFCoreScopeAccessor<UmbracoDbContext> efCoreScopeAccessor)
         : base(
-            scopeAccessor,
             cache,
             logger,
             commonRepository,
             languageRepository,
-            shortStringHelper,
             repositoryCacheVersionService,
             idKeyMap,
-            cacheSyncService)
+            cacheSyncService,
+            efCoreScopeAccessor)
     {
         _shortStringHelper = shortStringHelper;
-        _repositoryCacheVersionService = repositoryCacheVersionService;
-        _cacheSyncService = cacheSyncService;
     }
 
-    protected override bool SupportsPublishing => MemberType.SupportsPublishingConst;
-
+    /// <inheritdoc />
     protected override Guid NodeObjectTypeId => Constants.ObjectTypes.MemberType;
 
-    protected override IRepositoryCachePolicy<IMemberType, int> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<IMemberType, int>(GlobalIsolatedCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ true);
+    /// <inheritdoc />
+    protected override bool SupportsPublishing => MemberType.SupportsPublishingConst;
 
-    // Note: PerformGet(int) is passed as a callback to the cache policy's Get(TId) method,
-    // but FullDataSetRepositoryCachePolicy.Get() never invokes it — it uses GetAllCached()
-    // internally and clones only the matched entity. This override exists only as a required
-    // implementation of the abstract base and as a fallback for non-FullDataSet policies.
-    protected override IMemberType? PerformGet(int id)
-        => GetMany().FirstOrDefault(x => x.Id == id);
-
-    protected override IEnumerable<IMemberType>? GetAllWithFullCachePolicy() =>
-        CommonRepository.GetAllTypesAsync().GetAwaiter().GetResult()?.OfType<IMemberType>();
-
-    protected override IEnumerable<IMemberType> PerformGetByQuery(IQuery<IMemberType> query)
-    {
-        Sql<ISqlContext> subQuery = GetSubquery();
-        var translator = new SqlTranslator<IMemberType>(subQuery, query);
-        Sql<ISqlContext> subSql = translator.Translate();
-        Sql<ISqlContext> sql = GetBaseQuery(false)
-            .WhereIn<NodeDto>(x => x.NodeId, subSql)
-            .OrderBy<NodeDto>(x => x.SortOrder);
-        var ids = Database.Fetch<int>(sql).Distinct().ToArray();
-
-        return ids.Length > 0 ? GetMany(ids).OrderBy(x => x.Name) : Enumerable.Empty<IMemberType>();
-    }
-
-    protected override Sql<ISqlContext> GetBaseQuery(bool isCount)
-    {
-        if (isCount)
-        {
-            return Sql()
-                .SelectCount()
-                .From<NodeDto>()
-                .InnerJoin<ContentTypeDto>().On<ContentTypeDto, NodeDto>(left => left.NodeId, right => right.NodeId)
-                .Where<NodeDto>(x => x.NodeObjectType == NodeObjectTypeId);
-        }
-
-        Sql<ISqlContext> sql = Sql()
-            .Select<NodeDto>(x => x.NodeId)
-            .From<NodeDto>()
-            .InnerJoin<ContentTypeDto>().On<ContentTypeDto, NodeDto>(left => left.NodeId, right => right.NodeId)
-            .LeftJoin<PropertyTypeDto>().On<PropertyTypeDto, NodeDto>(left => left.ContentTypeId, right => right.NodeId)
-            .LeftJoin<MemberPropertyTypeDto>()
-            .On<MemberPropertyTypeDto, PropertyTypeDto>(left => left.PropertyTypeId, right => right.Id)
-            .LeftJoin<DataTypeDto>().On<DataTypeDto, PropertyTypeDto>(left => left.NodeId, right => right.DataTypeId)
-            .LeftJoin<PropertyTypeGroupDto>()
-            .On<PropertyTypeGroupDto, NodeDto>(left => left.ContentTypeNodeId, right => right.NodeId)
-            .Where<NodeDto>(x => x.NodeObjectType == NodeObjectTypeId);
-
-        return sql;
-    }
-
-    private Sql<ISqlContext> GetSubquery()
-    {
-        Sql<ISqlContext> sql = Sql()
-            .Select($"DISTINCT({QuoteTableName("umbracoNode")}.id)")
-            .From<NodeDto>()
-            .InnerJoin<ContentTypeDto>().On<ContentTypeDto, NodeDto>(left => left.NodeId, right => right.NodeId)
-            .LeftJoin<PropertyTypeDto>().On<PropertyTypeDto, NodeDto>(left => left.ContentTypeId, right => right.NodeId)
-            .LeftJoin<MemberPropertyTypeDto>()
-            .On<MemberPropertyTypeDto, PropertyTypeDto>(left => left.PropertyTypeId, right => right.Id)
-            .LeftJoin<DataTypeDto>().On<DataTypeDto, PropertyTypeDto>(left => left.NodeId, right => right.DataTypeId)
-            .LeftJoin<PropertyTypeGroupDto>()
-            .On<PropertyTypeGroupDto, NodeDto>(left => left.ContentTypeNodeId, right => right.NodeId)
-            .Where<NodeDto>(x => x.NodeObjectType == NodeObjectTypeId);
-        return sql;
-    }
-
-    protected override string GetBaseWhereClause() => $"{QuoteTableName(Constants.DatabaseSchema.Tables.Node)}.id = @id";
-
-    protected override IEnumerable<string> GetDeleteClauses()
-    {
-        var l = (List<string>)base.GetDeleteClauses(); // we know it's a list
-        l.Add($"DELETE FROM {QuoteTableName(MemberPropertyTypeDto.TableName)} WHERE {QuoteColumnName(MemberPropertyTypeDto.NodeIdColumnName)} = @id");
-        l.Add($"DELETE FROM {QuoteTableName(ContentTypeDto.TableName)} WHERE {QuoteColumnName(ContentTypeDto.NodeIdColumnName)} = @id");
-        l.Add($"DELETE FROM {QuoteTableName(NodeDto.TableName)} WHERE id = @id");
-        return l;
-    }
-
-    protected override void PersistNewItem(IMemberType entity)
+    /// <inheritdoc />
+    protected override async Task PersistNewItemAsync(IMemberType entity)
     {
         ValidateAlias(entity);
 
@@ -171,77 +84,67 @@ internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberTy
         }
 
         EnsureExplicitDataTypeForBuiltInProperties(entity);
-        PersistNewBaseContentType(entity);
+        await PersistNewBaseContentTypeAsync(entity);
 
-        // Handles the MemberTypeDto (cmsMemberType table)
-        IEnumerable<MemberPropertyTypeDto> memberTypeDtos = ContentTypeFactory.BuildMemberPropertyTypeDtos(entity);
-        foreach (MemberPropertyTypeDto memberTypeDto in memberTypeDtos)
-        {
-            Database.Insert(memberTypeDto);
-        }
+        await PersistMemberPropertyTypesAsync(entity);
 
         entity.ResetDirtyProperties();
     }
 
-    protected override void PersistUpdatedItem(IMemberType entity)
+    /// <inheritdoc />
+    protected override async Task PersistUpdatedItemAsync(IMemberType entity)
     {
         ValidateAlias(entity);
 
         // Updates Modified date
         entity.UpdatingEntity();
 
-        Sql<ISqlContext> sql;
         // Look up parent to get and set the correct Path if ParentId has changed
         if (entity.IsPropertyDirty("ParentId"))
         {
-            NodeDto? parent = Database.First<NodeDto>("WHERE id = @ParentId", new { entity.ParentId });
+            var parent = await ExecuteEfScopeAsync(db => db.Nodes
+                .Where(x => x.NodeId == entity.ParentId)
+                .Select(x => new { x.Path, x.Level })
+                .FirstAsync());
             entity.Path = string.Concat(parent.Path, ",", entity.Id);
             entity.Level = parent.Level + 1;
-            sql = Sql()
-                .SelectMax<NodeDto>(c => c.SortOrder, 0)
-                .From<NodeDto>()
-                .Where<NodeDto>(x => x.ParentId == entity.ParentId && x.NodeObjectType == NodeObjectTypeId);
-            var maxSortOrder = Database.ExecuteScalar<int>(sql);
+
+            var maxSortOrder = await ExecuteEfScopeAsync(db => db.Nodes
+                .Where(x => x.ParentId == entity.ParentId && x.NodeObjectType == NodeObjectTypeId)
+                .Select(x => (int?)x.SortOrder)
+                .MaxAsync()) ?? 0;
             entity.SortOrder = maxSortOrder + 1;
         }
 
         EnsureExplicitDataTypeForBuiltInProperties(entity);
-        PersistUpdatedBaseContentType(entity);
+        await PersistUpdatedBaseContentTypeAsync(entity);
 
-        // remove and insert - handle cmsMemberType table
-        sql = Sql().Delete<MemberPropertyTypeDto>(c => c.NodeId == entity.Id);
-        _ = Database.Execute(sql);
-        IEnumerable<MemberPropertyTypeDto> memberTypeDtos = ContentTypeFactory.BuildMemberPropertyTypeDtos(entity);
-        foreach (MemberPropertyTypeDto memberTypeDto in memberTypeDtos)
-        {
-            Database.Insert(memberTypeDto);
-        }
+        // remove and re-insert - handle the cmsMemberType table
+        await ExecuteEfScopeAsync(db => db.MemberPropertyTypes.Where(x => x.NodeId == entity.Id).ExecuteDeleteAsync());
+        await PersistMemberPropertyTypesAsync(entity);
 
         entity.ResetDirtyProperties();
     }
 
-    /// <summary>
-    ///     Override so we can specify explicit db type's on any property types that are built-in.
-    /// </summary>
-    /// <param name="propertyEditorAlias"></param>
-    /// <param name="storageType"></param>
-    /// <param name="propertyTypeAlias"></param>
-    /// <returns></returns>
-    protected override PropertyType CreatePropertyType(string propertyEditorAlias, ValueStorageType storageType, string propertyTypeAlias)
-    {
-        // custom property type constructor logic to set explicit dbtype's for built in properties
-        Dictionary<string, PropertyType> builtinProperties =
-            ConventionsHelper.GetStandardPropertyTypeStubs(_shortStringHelper);
-        var readonlyStorageType = builtinProperties.TryGetValue(propertyTypeAlias, out PropertyType? propertyType);
-        storageType = readonlyStorageType ? propertyType!.ValueStorageType : storageType;
-        return new PropertyType(_shortStringHelper, propertyEditorAlias, storageType, readonlyStorageType, propertyTypeAlias);
-    }
+    /// <inheritdoc />
+    protected override Task DeleteContentTypeSpecificDefinitionTablesAsync(UmbracoDbContext db, int id)
+        => db.MemberPropertyTypes.Where(x => x.NodeId == id).ExecuteDeleteAsync();
+
+    private Task PersistMemberPropertyTypesAsync(IMemberType entity)
+        => ExecuteEfScopeAsync(async db =>
+        {
+            foreach (MemberPropertyTypeDto memberPropertyTypeDto in ContentTypeFactory.BuildMemberPropertyTypeDtos(entity))
+            {
+                db.MemberPropertyTypes.Add(memberPropertyTypeDto);
+            }
+
+            await db.SaveChangesAsync();
+        });
 
     /// <summary>
     ///     Ensure that all the built-in membership provider properties have their correct data type
     ///     and property editors assigned. This occurs prior to saving so that the correct values are persisted.
     /// </summary>
-    /// <param name="memberType"></param>
     private void EnsureExplicitDataTypeForBuiltInProperties(IContentTypeBase memberType)
     {
         Dictionary<string, PropertyType> builtinProperties =

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -119,8 +119,6 @@ internal sealed class MemberTypeRepository : AsyncContentTypeRepositoryBase<IMem
         EnsureExplicitDataTypeForBuiltInProperties(entity);
         await PersistUpdatedBaseContentTypeAsync(entity);
 
-        // remove and re-insert - handle the cmsMemberType table
-        await ExecuteEfScopeAsync(db => db.MemberPropertyTypes.Where(x => x.NodeId == entity.Id).ExecuteDeleteAsync());
         await PersistMemberPropertyTypesAsync(entity);
 
         entity.ResetDirtyProperties();
@@ -133,6 +131,9 @@ internal sealed class MemberTypeRepository : AsyncContentTypeRepositoryBase<IMem
     private Task PersistMemberPropertyTypesAsync(IMemberType entity)
         => ExecuteEfScopeAsync(async db =>
         {
+            // remove and re-insert - ExecuteDeleteAsync is set-based and bypasses the change tracker.
+            await db.MemberPropertyTypes.Where(x => x.NodeId == entity.Id).ExecuteDeleteAsync();
+
             foreach (MemberPropertyTypeDto memberPropertyTypeDto in ContentTypeFactory.BuildMemberPropertyTypeDtos(entity))
             {
                 db.MemberPropertyTypes.Add(memberPropertyTypeDto);

--- a/src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs
+++ b/src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs
@@ -376,7 +376,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
             PublishedItemType.Content => _contentTypeService is null ? null : _contentTypeService.GetAsync(key).GetAwaiter().GetResult(),
             PublishedItemType.Element => _contentTypeService is null ? null : _contentTypeService.GetAsync(key).GetAwaiter().GetResult(),
             PublishedItemType.Media => _mediaTypeService?.Get(key),
-            PublishedItemType.Member => _memberTypeService?.Get(key),
+            PublishedItemType.Member => _memberTypeService?.GetAsync(key).GetAwaiter().GetResult(),
             _ => throw new ArgumentOutOfRangeException(nameof(itemType)),
         };
         if (contentType == null)
@@ -395,7 +395,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
             PublishedItemType.Content => _contentTypeService is null ? null : _contentTypeService.GetAsync(alias).GetAwaiter().GetResult(),
             PublishedItemType.Element => _contentTypeService is null ? null : _contentTypeService.GetAsync(alias).GetAwaiter().GetResult(),
             PublishedItemType.Media => _mediaTypeService?.Get(alias),
-            PublishedItemType.Member => _memberTypeService?.Get(alias),
+            PublishedItemType.Member => _memberTypeService?.GetAsync(alias).GetAwaiter().GetResult(),
             _ => throw new ArgumentOutOfRangeException(nameof(itemType)),
         };
         if (contentType == null)
@@ -414,7 +414,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
             PublishedItemType.Content => _contentTypeService is null ? null : _contentTypeService.GetAsync(id).GetAwaiter().GetResult(),
             PublishedItemType.Element => _contentTypeService is null ? null : _contentTypeService.GetAsync(id).GetAwaiter().GetResult(),
             PublishedItemType.Media => _mediaTypeService?.Get(id),
-            PublishedItemType.Member => _memberTypeService?.Get(id),
+            PublishedItemType.Member => _memberTypeService?.GetAsync(id).GetAwaiter().GetResult(),
             _ => throw new ArgumentOutOfRangeException(nameof(itemType)),
         };
         if (contentType == null)

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/MsgPackContentNestedDataSerializerFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/MsgPackContentNestedDataSerializerFactory.cs
@@ -54,7 +54,7 @@ internal sealed class MsgPackContentNestedDataSerializerFactory : IContentCacheD
 
         if ((types & ContentCacheDataSerializerEntityType.Member) == ContentCacheDataSerializerEntityType.Member)
         {
-            foreach (IMemberType ct in _memberTypeService.GetAll())
+            foreach (IMemberType ct in _memberTypeService.GetAllAsync().GetAwaiter().GetResult())
             {
                 contentTypes[ct.Id] = ct;
             }

--- a/src/Umbraco.Web.Website/Controllers/UmbProfileController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbProfileController.cs
@@ -137,7 +137,7 @@ public class UmbProfileController : SurfaceController
             throw new InvalidOperationException($"Could not find a member with key: {member?.Key}.");
         }
 
-        IMemberType? memberType = _memberTypeService.Get(member.ContentTypeId);
+        IMemberType? memberType = await _memberTypeService.GetAsync(member.ContentTypeId);
 
         foreach (MemberPropertyModel property in model.MemberProperties
 

--- a/src/Umbraco.Web.Website/Models/ProfileModelBuilder.cs
+++ b/src/Umbraco.Web.Website/Models/ProfileModelBuilder.cs
@@ -79,7 +79,7 @@ public class ProfileModelBuilder : MemberModelBuilderBase
             return model;
         }
 
-        IMemberType? memberType = member.MemberTypeAlias is null ? null : MemberTypeService.Get(member.MemberTypeAlias);
+        IMemberType? memberType = member.MemberTypeAlias is null ? null : await MemberTypeService.GetAsync(member.MemberTypeAlias);
         if (memberType == null)
         {
             throw new InvalidOperationException($"Could not find a member type with alias: {member.MemberTypeAlias}.");

--- a/src/Umbraco.Web.Website/Models/RegisterModelBuilder.cs
+++ b/src/Umbraco.Web.Website/Models/RegisterModelBuilder.cs
@@ -54,7 +54,7 @@ public class RegisterModelBuilder : MemberModelBuilderBase
     public RegisterModel Build()
     {
         var providedOrDefaultMemberTypeAlias = _memberTypeAlias ?? Constants.Conventions.MemberTypes.DefaultAlias;
-        IMemberType? memberType = MemberTypeService.Get(providedOrDefaultMemberTypeAlias);
+        IMemberType? memberType = MemberTypeService.GetAsync(providedOrDefaultMemberTypeAlias).GetAwaiter().GetResult();
         if (memberType == null)
         {
             throw new InvalidOperationException(

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
@@ -11,6 +11,8 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore.Scoping;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -27,7 +29,8 @@ internal sealed class MemberTypeRepositoryTest : UmbracoIntegrationTest
     {
         var commonRepository = GetRequiredService<IContentTypeCommonRepository>();
         var languageRepository = GetRequiredService<ILanguageRepository>();
-        return new MemberTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger<MemberTypeRepository>>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>());
+        var efCoreScopeAccessor = GetRequiredService<IEFCoreScopeAccessor<UmbracoDbContext>>();
+        return new MemberTypeRepository(AppCaches.Disabled, Mock.Of<ILogger<MemberTypeRepository>>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>(), efCoreScopeAccessor);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
@@ -278,6 +278,30 @@ internal sealed class MemberTypeRepositoryTest : UmbracoIntegrationTest
     }
 
     [Test]
+    public void Can_Persist_Member_Type_Property_Metadata()
+    {
+        var provider = ScopeProvider;
+        using (var scope = provider.CreateScope())
+        {
+            var repository = CreateRepository(provider);
+
+            var memberType = (MemberType)MemberTypeBuilder.CreateSimpleMemberType();
+            memberType.SetMemberCanEditProperty("title", true);
+            memberType.SetMemberCanViewProperty("title", false);
+            memberType.SetIsSensitiveProperty("title", true);
+
+            repository.Save(memberType);
+            scope.Complete();
+
+            var sut = (MemberType)repository.Get(memberType.Id);
+
+            Assert.That(sut.MemberCanEditProperty("title"), Is.True);
+            Assert.That(sut.MemberCanViewProperty("title"), Is.False);
+            Assert.That(sut.IsSensitiveProperty("title"), Is.True);
+        }
+    }
+
+    [Test]
     public void Can_Delete_MemberType()
     {
         // Arrange

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
@@ -56,9 +56,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Can_Get_By_Username()
+    public async Task Can_Get_By_Username()
     {
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true);
         MemberService.Save(member);
 
@@ -69,10 +69,10 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Can_Set_Last_Login_Date()
+    public async Task Can_Set_Last_Login_Date()
     {
         var now = DateTime.UtcNow;
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true)
         {
             LastLoginDate = now,
@@ -94,9 +94,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
 
     // These might seem like some somewhat pointless tests, but there's some funky things going on in MemberRepository when saving.
     [Test]
-    public void Can_Set_Failed_Password_Attempts()
+    public async Task Can_Set_Failed_Password_Attempts()
     {
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true)
         {
             FailedPasswordAttempts = 1
@@ -112,9 +112,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Can_Set_Is_Approved()
+    public async Task Can_Set_Is_Approved()
     {
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true);
         MemberService.Save(member);
 
@@ -127,9 +127,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Can_Set_Is_Locked_Out()
+    public async Task Can_Set_Is_Locked_Out()
     {
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member =
             new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true) { IsLockedOut = false };
         MemberService.Save(member);
@@ -143,10 +143,10 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Can_Set_Last_Lockout_Date()
+    public async Task Can_Set_Last_Lockout_Date()
     {
         var now = DateTime.UtcNow;
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member =
             new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true) { LastLockoutDate = now };
         MemberService.Save(member);
@@ -162,10 +162,10 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Can_set_Last_Login_Date()
+    public async Task Can_set_Last_Login_Date()
     {
         var now = DateTime.UtcNow;
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member =
             new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true) { LastLoginDate = now };
         MemberService.Save(member);
@@ -181,10 +181,10 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Can_Set_Last_Password_Change_Date()
+    public async Task Can_Set_Last_Password_Change_Date()
     {
         var now = DateTime.UtcNow;
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true)
         {
             LastPasswordChangeDate = now
@@ -202,9 +202,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Can_Create_Member_With_Properties()
+    public async Task Can_Create_Member_With_Properties()
     {
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember member = new Member("xname", "xemail", "xusername", "xrawpassword", memberType, true);
         MemberService.Save(member);
 
@@ -1101,7 +1101,7 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     [Test]
     public async Task Can_Get_Multiple_By_Key()
     {
-        var memberType = MemberTypeService.Get("member");
+        var memberType = await MemberTypeService.GetAsync("member");
         IMember memberA = new Member("aname", "a@email", "ausername", "arawpassword", memberType, true);
         MemberService.Save(memberA);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberTypeServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberTypeServiceTests.cs
@@ -31,7 +31,7 @@ internal sealed class MemberTypeServiceTests : UmbracoIntegrationTest
         await MemberTypeService.CreateAsync(memberType, Constants.Security.SuperUserKey);
 
         // re-get
-        memberType = MemberTypeService.Get(memberType.Id);
+        memberType = await MemberTypeService.GetAsync(memberType.Id);
         foreach (var p in memberType.PropertyTypes)
         {
             Assert.IsFalse(memberType.MemberCanEditProperty(p.Alias));
@@ -48,7 +48,7 @@ internal sealed class MemberTypeServiceTests : UmbracoIntegrationTest
         await MemberTypeService.UpdateAsync(memberType, Constants.Security.SuperUserKey);
 
         // re-get
-        memberType = MemberTypeService.Get(memberType.Id);
+        memberType = await MemberTypeService.GetAsync(memberType.Id);
         foreach (var p in memberType.PropertyTypes.Where(x => x.Alias != prop))
         {
             Assert.IsFalse(memberType.MemberCanEditProperty(p.Alias));
@@ -64,7 +64,7 @@ internal sealed class MemberTypeServiceTests : UmbracoIntegrationTest
         await MemberTypeService.CreateAsync(memberType, Constants.Security.SuperUserKey);
 
         // re-get
-        memberType = MemberTypeService.Get(memberType.Id);
+        memberType = await MemberTypeService.GetAsync(memberType.Id);
         foreach (var p in memberType.PropertyTypes)
         {
             Assert.IsFalse(memberType.MemberCanViewProperty(p.Alias));
@@ -81,7 +81,7 @@ internal sealed class MemberTypeServiceTests : UmbracoIntegrationTest
         await MemberTypeService.UpdateAsync(memberType, Constants.Security.SuperUserKey);
 
         // re-get
-        memberType = MemberTypeService.Get(memberType.Id);
+        memberType = await MemberTypeService.GetAsync(memberType.Id);
         foreach (var p in memberType.PropertyTypes.Where(x => x.Alias != prop))
         {
             Assert.IsFalse(memberType.MemberCanViewProperty(p.Alias));

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MemberCacheServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MemberCacheServiceTests.cs
@@ -49,7 +49,7 @@ internal sealed class MemberCacheServiceTests : UmbracoIntegrationTestWithConten
         await base.CreateTestDataAsync();
 
         // Create and Save Member "MemberItem" based on "Member" member type
-        MemberType = MemberTypeService.Get("Member")!;
+        MemberType = (await MemberTypeService.GetAsync("Member"))!;
         Member = new MemberBuilder()
             .WithMemberType(MemberType)
             .WithLogin("testmember", "password123")

--- a/tests/Umbraco.Tests.Integration/Umbraco.Search.Core/MemberTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Search.Core/MemberTests.cs
@@ -83,7 +83,7 @@ public class MemberTests : ContentBaseTestBase
     public async Task AllMembers_DoesNotIndexSensitiveProperties()
     {
         IMemberTypeService memberTypeService = GetRequiredService<IMemberTypeService>();
-        IMemberType? memberType = memberTypeService.Get("myMemberType");
+        IMemberType? memberType = await memberTypeService.GetAsync("myMemberType");
         Assert.That(memberType, Is.Not.Null);
 
         memberType.SetIsSensitiveProperty("organization", true);
@@ -148,9 +148,9 @@ public class MemberTests : ContentBaseTestBase
     }
 
     [Test]
-    public void Can_Index_More_Than_Content_Enumeration_Page_Size()
+    public async Task Can_Index_More_Than_Content_Enumeration_Page_Size()
     {
-        IMemberType memberType = MemberTypeService.GetAll().First();
+        IMemberType memberType = (await MemberTypeService.GetAllAsync()).First();
         foreach (var count in Enumerable.Range(1, ContentChangeStrategyBase.ContentEnumerationPageSize))
         {
             MemberService.Save(

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemControllerTests.cs
@@ -55,8 +55,8 @@ public class SearchMemberTypeItemControllerTests
         IMemberType memberTypeA = Mock.Of<IMemberType>(x => x.Key == keyA);
         IMemberType memberTypeB = Mock.Of<IMemberType>(x => x.Key == keyB);
         _memberTypeService
-            .Setup(x => x.GetMany(It.IsAny<IEnumerable<Guid>>()))
-            .Returns(new[] { memberTypeC, memberTypeA, memberTypeB });
+            .Setup(x => x.GetManyAsync(It.IsAny<IEnumerable<Guid>>()))
+            .ReturnsAsync(new[] { memberTypeC, memberTypeA, memberTypeB });
 
         _mapper
             .Setup(x => x.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(It.IsAny<IEnumerable<IMemberType>>()))

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbProfileControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbProfileControllerTests.cs
@@ -183,7 +183,7 @@ public class UmbProfileControllerTests
         _memberServiceMock.Setup(x => x.GetById(It.IsAny<Guid>())).Returns(member.Object);
 
         var memberType = new Mock<IMemberType>();
-        _memberTypeServiceMock.Setup(x => x.Get(It.IsAny<int>())).Returns(memberType.Object);
+        _memberTypeServiceMock.Setup(x => x.GetAsync(It.IsAny<int>())).ReturnsAsync(memberType.Object);
     }
 
     private UmbProfileController CreateController()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Models/ProfileModelBuilderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Models/ProfileModelBuilderTests.cs
@@ -82,7 +82,7 @@ public class ProfileModelBuilderTests
 
         var mockMemberType = new Mock<IMemberType>();
         mockMemberType.Setup(x => x.PropertyTypes).Returns(Enumerable.Empty<IPropertyType>());
-        _mockMemberTypeService.Setup(x => x.Get("Member")).Returns(mockMemberType.Object);
+        _mockMemberTypeService.Setup(x => x.GetAsync("Member")).ReturnsAsync(mockMemberType.Object);
 
         var mockMember = new Mock<IMember>();
         mockMember.Setup(x => x.Key).Returns(memberKey);
@@ -156,7 +156,7 @@ public class ProfileModelBuilderTests
 
         // Assert — neither IMemberService nor IMemberTypeService should be called.
         _mockMemberService.Verify(x => x.GetById(It.IsAny<Guid>()), Times.Never);
-        _mockMemberTypeService.Verify(x => x.Get(It.IsAny<string>()), Times.Never);
+        _mockMemberTypeService.Verify(x => x.GetAsync(It.IsAny<string>()), Times.Never);
     }
 
     [Test]


### PR DESCRIPTION
# Notes
- ⚠️ The migration of member type service will come in a follow up PR
- Miration of MemberTypeRepository, most of the work has been done in https://github.com/umbraco/Umbraco-CMS/pull/23160, so this is mostly just adding the DTO to the db context and then deriving from the new interface.

# How to test
- The tests should run ✅ 
