### PR TITLE
Multinode Treepicker: Correct the entity types advertised by the value schema

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -58,8 +58,11 @@ public class MultiNodeTreePickerPropertyEditor : DataEditor, IValueSchemaProvide
                     ["type"] = new JsonObject
                     {
                         ["type"] = "string",
-                        ["enum"] = new JsonArray("content", "media", "member"),
-                        ["description"] = "Entity type (content, media, or member)",
+                        ["enum"] = new JsonArray(
+                            Constants.UdiEntityType.Document,
+                            Constants.UdiEntityType.Media,
+                            Constants.UdiEntityType.Member),
+                        ["description"] = "UDI entity type of the selected entity",
                     },
                     ["unique"] = new JsonObject
                     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ValueSchemaProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ValueSchemaProviderTests.cs
@@ -114,6 +114,30 @@ public class ValueSchemaProviderTests
         Assert.That(valueType, Is.EqualTo(typeof(string)));
     }
 
+    [Test]
+    public void MultiNodeTreePickerPropertyEditor_Returns_Udi_Entity_Types_For_Reference_Type()
+    {
+        // Arrange
+        var editor = CreateMultiNodeTreePickerPropertyEditor();
+
+        // Act
+        var schema = editor.GetValueSchema(null);
+
+        // Assert
+        Assert.That(schema, Is.Not.Null);
+
+        var entityTypes = schema!["items"]?["properties"]?["type"]?["enum"] as JsonArray;
+        Assert.That(entityTypes, Is.Not.Null);
+        Assert.That(
+            entityTypes!.Select(entityType => entityType?.GetValue<string>()),
+            Is.EquivalentTo(new[]
+            {
+                Constants.UdiEntityType.Document,
+                Constants.UdiEntityType.Media,
+                Constants.UdiEntityType.Member,
+            }));
+    }
+
     private static IntegerPropertyEditor CreateIntegerPropertyEditor()
     {
         var dataValueEditorFactory = Mock.Of<IDataValueEditorFactory>(f =>
@@ -138,6 +162,21 @@ public class ValueSchemaProviderTests
                     new DataEditorAttribute(Constants.PropertyEditors.Aliases.ContentPicker)));
 
         return new ContentPickerPropertyEditor(
+            dataValueEditorFactory,
+            Mock.Of<IIOHelper>());
+    }
+
+    private static MultiNodeTreePickerPropertyEditor CreateMultiNodeTreePickerPropertyEditor()
+    {
+        var dataValueEditorFactory = Mock.Of<IDataValueEditorFactory>(f =>
+            f.Create<DataValueEditor>(It.IsAny<DataEditorAttribute>()) ==
+                new DataValueEditor(
+                    Mock.Of<IShortStringHelper>(),
+                    Mock.Of<IJsonSerializer>(),
+                    Mock.Of<IIOHelper>(),
+                    new DataEditorAttribute(Constants.PropertyEditors.Aliases.MultiNodeTreePicker)));
+
+        return new MultiNodeTreePickerPropertyEditor(
             dataValueEditorFactory,
             Mock.Of<IIOHelper>());
     }


### PR DESCRIPTION
## Description

As part of testing another PR using the MCP for test data set up, I ran into this issue: `MultiNodeTreePickerPropertyEditor.GetValueSchema` advertised the reference `type` as `enum: ["content", "media", "member"]`, described as "Entity type (content, media, or member)". The value editor does not accept `"content"` and will through a 500 error if passed. The correct value is `"document"`.

### Why `document` is correct

The word `content` does appear in this editor, but on a different axis. There are two distinct `type` fields, and the schema was describing one using the other's vocabulary:

**Configuration** — `MultiNodePickerConfiguration.TreeSource.ObjectType`, stored in `umbracoDataType.config` as `{"startNode":{"type":"content"}, ...}`. Here `"content"` is correct: it's `DocumentObjectType = "content"` in this same file, mapped to `Constants.ObjectTypes.Document` by `ObjectTypeValidator.GetObjectType` and consumed by `ContentTypeValidator`.

**Property value** — what `GetValueSchema` actually describes. `IValueSchemaProvider` states that implementations return the schema for *"the incoming value (what `FromEditor` receives via `ContentPropertyData.Value`), not the stored/database model"*, and that `configuration` is only an argument that may shape it. `FromEditor` converts that value with
`EntityReferencesToUdis` → `Udi.Create(reference.Type, reference.Unique)`, and `ToEditor` reads it back with
`UdisToEntityReferences` → `Type = guidUdi.EntityType`. So `type` is a UDI entity type, and is literally the segment between `umb://` and `/` in the stored value:

```
stored:  umb://document/37acb4c2beb9494dade4133a0a27f147
               ^^^^^^^^
editor:  [{ "type": "document", "unique": "37acb4c2-beb9-494d-ade4-133a0a27f147" }]
```

### The fix

The value is corrected, now using `Constants.UdiEntityType.Document` / `.Media` / `.Member` rather than string literals, so it is tied to the same source `Udi.Create` validates against and cannot silently drift again. The `description` no longer re-lists the values in prose.

## Testing

Request the value schema for any `Umbraco.MultiNodeTreePicker` data type (`GET /umbraco/management/api/v1/data-type/{id}/schema`) and confirm the reference `type` enum reads `["document", "media", "member"]`.

E.g (from my local setup):

```
curl -X 'GET' \
  'https://localhost:44339/umbraco/management/api/v1/data-type/E4A4A3E7-FC19-45A5-8D4C-A9F72E405CC2/schema' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer ***'
```

```json
{
  "valueTypeName": "Umbraco.Cms.Core.PropertyEditors.MultiNodeTreePickerPropertyEditor+MultiNodeTreePickerPropertyValueEditor+EditorEntityReference[]",
  "jsonSchema": {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type": [
      "array",
      "null"
    ],
    "items": {
      "type": "object",
      "properties": {
        "type": {
          "type": "string",
          "enum": [
            "document",
            "media",
            "member"
          ],
          "description": "UDI entity type of the selected entity"
        },
        "unique": {
          "type": "string",
          "format": "uuid",
          "pattern": "^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$",
          "description": "GUID of the selected entity"
        }
      },
      "required": [
        "type",
        "unique"
      ]
    },
    "description": "Array of selected entity references",
    "maxItems": 1
  }
}
```
