### PR TITLE
Document Link Picker: Scope search results to the selected/inherited culture

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/document-link-picker-modal/document-link-picker.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/document-link-picker-modal/document-link-picker.context.test.ts
@@ -1,0 +1,132 @@
+import { UmbDocumentLinkPickerContext } from './document-link-picker.context.js';
+import { aTimeout, expect } from '@open-wc/testing';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS } from '@umbraco-cms/backoffice/document';
+import { UmbVariantContext } from '@umbraco-cms/backoffice/variant';
+
+@customElement('test-document-link-picker-context-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+interface UmbTestSearchCall {
+	query?: string;
+	culture?: string | null;
+}
+
+const getConfigCulture = (context: UmbDocumentLinkPickerContext) =>
+	(context.search.getConfig()?.queryParams as { culture?: string | null } | undefined)?.culture;
+
+// The picker context configures search on construction, which resolves this provider from the
+// registry. Registering a stub keeps the run free of "Failed to get manifest by alias" noise, and
+// lets the tests observe which args each search call was made with.
+describe('UmbDocumentLinkPickerContext', () => {
+	// The inherited variant context (e.g. from the workspace that opened this picker) lives on an
+	// ancestor host, distinct from the picker's own host - mirroring how the modal element is a
+	// descendant of whatever opened it, not the same node.
+	let inheritedContextHost: UmbTestControllerHostElement;
+	let pickerHost: UmbTestControllerHostElement;
+	let searchCalls: Array<UmbTestSearchCall>;
+
+	const searchProviderManifest = {
+		type: 'searchProvider' as const,
+		alias: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
+		name: 'Test Document Search Provider',
+		api: class {
+			destroy() {}
+			async search(args: UmbTestSearchCall) {
+				searchCalls.push(args);
+				return { data: { items: [], total: 0 } };
+			}
+		},
+		meta: { label: 'Documents' },
+	};
+
+	before(() => {
+		umbExtensionsRegistry.register(searchProviderManifest as never);
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregister(searchProviderManifest.alias);
+	});
+
+	beforeEach(() => {
+		searchCalls = [];
+		inheritedContextHost = new UmbTestControllerHostElement();
+		pickerHost = new UmbTestControllerHostElement();
+		inheritedContextHost.appendChild(pickerHost);
+		document.body.appendChild(inheritedContextHost);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	describe('search culture scoping', () => {
+		it('scopes search to the inherited variant culture before any language is explicitly picked', async () => {
+			const variantContext = new UmbVariantContext(inheritedContextHost);
+			await variantContext.setCulture('da-DK');
+
+			const context = new UmbDocumentLinkPickerContext(pickerHost);
+			await aTimeout(0);
+
+			expect(getConfigCulture(context)).to.equal('da-DK');
+		});
+
+		it('re-scopes search to the explicitly picked language', async () => {
+			const variantContext = new UmbVariantContext(inheritedContextHost);
+			await variantContext.setCulture('da-DK');
+
+			const context = new UmbDocumentLinkPickerContext(pickerHost);
+			await aTimeout(0);
+
+			await context.setCulture('en-US');
+
+			expect(getConfigCulture(context)).to.equal('en-US');
+		});
+
+		it('falls back to the inherited culture once the explicit pick is cleared', async () => {
+			const variantContext = new UmbVariantContext(inheritedContextHost);
+			await variantContext.setCulture('da-DK');
+
+			const context = new UmbDocumentLinkPickerContext(pickerHost);
+			await aTimeout(0);
+
+			await context.setCulture('en-US');
+			await context.setCulture(null);
+
+			expect(getConfigCulture(context)).to.equal('da-DK');
+		});
+
+		it('re-runs an already active search when the culture changes', async () => {
+			const variantContext = new UmbVariantContext(inheritedContextHost);
+			await variantContext.setCulture('da-DK');
+
+			const context = new UmbDocumentLinkPickerContext(pickerHost);
+			await aTimeout(0);
+
+			context.search.updateQuery({ query: 'home' });
+			context.search.search();
+			await aTimeout(400);
+
+			expect(searchCalls).to.have.lengthOf(1);
+			expect(searchCalls[0].culture).to.equal('da-DK');
+
+			await context.setCulture('en-US');
+			await aTimeout(400);
+
+			expect(searchCalls).to.have.lengthOf(2);
+			expect(searchCalls[1].culture).to.equal('en-US');
+		});
+
+		it('does not trigger a search when the culture changes with no active query', async () => {
+			const context = new UmbDocumentLinkPickerContext(pickerHost);
+			await aTimeout(0);
+
+			await context.setCulture('en-US');
+			await aTimeout(400);
+
+			expect(searchCalls).to.have.lengthOf(0);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/document-link-picker-modal/document-link-picker.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/document-link-picker-modal/document-link-picker.context.ts
@@ -20,7 +20,6 @@ export class UmbDocumentLinkPickerContext extends UmbPickerContext {
 	#variantContext = new UmbVariantContext(this).inherit();
 	public culture = this.#variantContext.culture;
 
-	#lastSearchCulture?: string | null;
 	#languageCollectionRepository = new UmbLanguageCollectionRepository(this);
 
 	constructor(host: UmbControllerHost) {
@@ -44,11 +43,6 @@ export class UmbDocumentLinkPickerContext extends UmbPickerContext {
 	}
 
 	#updateSearchCulture(culture: string | null) {
-		// Losing/regaining the inherited context (e.g. while tearing down) can re-emit an unchanged
-		// effective culture - skip the no-op to avoid redundantly re-running an already active search.
-		if (culture === this.#lastSearchCulture) return;
-		this.#lastSearchCulture = culture;
-
 		this.search.updateConfig({ queryParams: { culture } });
 
 		// Re-run an already active search so visible results reflect the new culture scope right away.

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/document-link-picker-modal/document-link-picker.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/document-link-picker-modal/document-link-picker.context.ts
@@ -30,11 +30,7 @@ export class UmbDocumentLinkPickerContext extends UmbPickerContext {
 			providerAlias: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
 		});
 
-		this.observe(
-			this.#variantContext.displayCulture,
-			(culture) => this.#updateSearchCulture(culture ?? null),
-			'umbDocumentLinkPickerSearchCultureObserver',
-		);
+		this.observe(this.#variantContext.displayCulture, (culture) => this.#updateSearchCulture(culture ?? null), null);
 
 		this.#loadLanguages();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/document-link-picker-modal/document-link-picker.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/document-link-picker-modal/document-link-picker.context.ts
@@ -1,7 +1,7 @@
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS } from '@umbraco-cms/backoffice/document';
 import { UmbLanguageCollectionRepository, type UmbLanguageDetailModel } from '@umbraco-cms/backoffice/language';
-import { UmbArrayState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
 import { UmbTreeItemPickerExpansionManager } from '@umbraco-cms/backoffice/tree';
 import { UmbVariantContext } from '@umbraco-cms/backoffice/variant';
@@ -14,10 +14,13 @@ export class UmbDocumentLinkPickerContext extends UmbPickerContext {
 	#languages = new UmbArrayState<UmbLanguageDetailModel>([], (x) => x.unique);
 	public languages = this.#languages.asObservable();
 
-	#culture = new UmbStringState<string | null>(null);
-	public culture = this.#culture.asObservable();
+	// Provided downward (so the tree renders document names in the picked culture) and read from directly
+	// here to scope search - both need the same "explicit pick, else inherited" culture, so one context
+	// computes it once rather than each maintaining its own copy.
+	#variantContext = new UmbVariantContext(this).inherit();
+	public culture = this.#variantContext.culture;
 
-	#variantContext?: UmbVariantContext;
+	#lastSearchCulture?: string | null;
 	#languageCollectionRepository = new UmbLanguageCollectionRepository(this);
 
 	constructor(host: UmbControllerHost) {
@@ -27,32 +30,40 @@ export class UmbDocumentLinkPickerContext extends UmbPickerContext {
 			providerAlias: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
 		});
 
+		this.observe(
+			this.#variantContext.displayCulture,
+			(culture) => this.#updateSearchCulture(culture ?? null),
+			'umbDocumentLinkPickerSearchCultureObserver',
+		);
+
 		this.#loadLanguages();
 	}
 
 	async setCulture(culture: string | null) {
-		this.#culture.setValue(culture);
-		await this.#variantContext?.setCulture(culture);
+		await this.#variantContext.setCulture(culture);
 	}
 
 	async getCulture(): Promise<string | null> {
-		return this.#culture.getValue();
+		return (await this.#variantContext.getCulture()) ?? null;
+	}
+
+	#updateSearchCulture(culture: string | null) {
+		// Losing/regaining the inherited context (e.g. while tearing down) can re-emit an unchanged
+		// effective culture - skip the no-op to avoid redundantly re-running an already active search.
+		if (culture === this.#lastSearchCulture) return;
+		this.#lastSearchCulture = culture;
+
+		this.search.updateConfig({ queryParams: { culture } });
+
+		// Re-run an already active search so visible results reflect the new culture scope right away.
+		if (this.search.getSearchable() && this.search.getQuery()?.query) {
+			this.search.search();
+		}
 	}
 
 	async #loadLanguages() {
 		const { data } = await this.#languageCollectionRepository.requestAllItems();
-		const languages = data?.items || [];
-
-		this.#languages.setValue(languages);
-
-		if (languages.length > 0) {
-			// Create variant context only when we have languages available
-			this.#variantContext = new UmbVariantContext(this).inherit();
-		} else {
-			// No languages available - ensure variant context is not set
-			this.#variantContext?.destroy();
-			this.#variantContext = undefined;
-		}
+		this.#languages.setValue(data?.items || []);
 	}
 }
 


### PR DESCRIPTION
Partly fixed #13807 

Fixes the document link picker's search to be variant-aware.

This PR ensures that the Document Link Picker's local variant context is also passed to the search field configuration, and therefore to the server.

How to test:
* On a multi-language site, open the Multi URL Picker and select Content.
* Ensure that the tree is displayed with names for the current Document Workspace culture.
* Ensure that when searching, the current Document Workspace culture is sent as a culture query parameter to the server.
* Ensure that when changing to a different culture in the select box, the tree displays the correct names, and the new culture is passed to the server when searching.



