### PR TITLE
Maintenance page: Fix custom view override and make view paths configurable (closes #23749)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeDefaultController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeDefaultController.cs
@@ -57,7 +57,7 @@ public class BackOfficeDefaultController : Controller
     /// <summary>
     ///     Returns the default view for the BackOffice
     /// </summary>
-    /// <returns>The default view currently /umbraco/UmbracoBackOffice/Default.cshtml</returns>
+    /// <returns>The default view currently /umbraco/UmbracoBackOffice/Index.cshtml</returns>
     public ViewResult DefaultView()
     {
         var viewPath = Path.Combine(Constants.SystemDirectories.Umbraco, Constants.Web.Mvc.BackOfficeArea, nameof(Index) + ".cshtml")

--- a/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
+++ b/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
@@ -3,6 +3,12 @@
     <Title>Umbraco CMS - Static assets</Title>
     <Description>Contains the static assets needed to run Umbraco CMS.</Description>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+    <!--
+      Emit source checksum attributes for the views compiled into this assembly. Without them
+      ChecksumValidator.IsRecompilationSupported returns false, so the runtime view compiler pins the
+      precompiled view and a consuming site can never replace one by adding a file at the same path.
+    -->
+    <GenerateRazorMetadataSourceChecksumAttributes>true</GenerateRazorMetadataSourceChecksumAttributes>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
     <!-- Disable compression for static files, because MapStaticAssets() is not used anyway (yet) -->
     <CompressionEnabled>false</CompressionEnabled>

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/Maintenance.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoWebsite/Maintenance.cshtml
@@ -11,7 +11,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-    <title>Website is Under Maintainance</title>
+    <title>Website is Under Maintenance</title>
 
     <link rel="stylesheet" href="@WebPath.Combine(backOfficePath , "website", "/nonodes.css")" />
     <style type="text/css">
@@ -50,7 +50,7 @@
 
                         <div class="col">
                             <h2>Finish the maintenance</h2>
-                            <p>If you are an administrator, you finish the maintanance by going to backoffice.</p>
+                            <p>If you are an administrator, you can finish the maintenance by going to the backoffice.</p>
 
                             <a href="@backOfficePath">Handle the upgrade &rarr;</a>
                         </div>

--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -80,6 +80,11 @@ public class GlobalSettings
     internal const string StaticNoNodesViewPath = "~/umbraco/UmbracoWebsite/NoNodes.cshtml";
 
     /// <summary>
+    ///     The default value for the <see cref="NotFoundViewPath" /> setting.
+    /// </summary>
+    internal const string StaticNotFoundViewPath = "~/umbraco/UmbracoWebsite/NotFound.cshtml";
+
+    /// <summary>
     ///     The default value for the <see cref="DistributedLockingReadLockDefaultTimeout" /> setting.
     /// </summary>
     internal const string StaticDistributedLockingReadLockDefaultTimeout = "00:01:00";
@@ -106,6 +111,11 @@ public class GlobalSettings
     ///     The default value for the <see cref="UpgradingViewPath" /> setting.
     /// </summary>
     internal const string StaticUpgradingViewPath = "~/umbraco/UmbracoWebsite/Upgrading.cshtml";
+
+    /// <summary>
+    ///     The default value for the <see cref="MaintenanceViewPath" /> setting.
+    /// </summary>
+    internal const string StaticMaintenanceViewPath = "~/umbraco/UmbracoWebsite/Maintenance.cshtml";
 
     /// <summary>
     ///     Gets or sets a value for the reserved URLs (must end with a comma).
@@ -245,6 +255,13 @@ public class GlobalSettings
     public string NoNodesViewPath { get; set; } = StaticNoNodesViewPath;
 
     /// <summary>
+    ///     Gets or sets a value for the path to the view shown when a request cannot be rendered, because no document
+    ///     matches the URL or the matched document has no template.
+    /// </summary>
+    [DefaultValue(StaticNotFoundViewPath)]
+    public string NotFoundViewPath { get; set; } = StaticNotFoundViewPath;
+
+    /// <summary>
     ///     Gets or sets a value for the database server registrar settings.
     /// </summary>
     public DatabaseServerRegistrarSettings DatabaseServerRegistrar { get; set; } = new();
@@ -328,4 +345,11 @@ public class GlobalSettings
     /// </summary>
     [DefaultValue(StaticUpgradingViewPath)]
     public string UpgradingViewPath { get; set; } = StaticUpgradingViewPath;
+
+    /// <summary>
+    ///     Gets or sets the view path shown while an upgrade is pending and awaiting an administrator
+    ///     (<see cref="RuntimeLevel.Upgrade"/>).
+    /// </summary>
+    [DefaultValue(StaticMaintenanceViewPath)]
+    public string MaintenanceViewPath { get; set; } = StaticMaintenanceViewPath;
 }

--- a/src/Umbraco.Web.Common/ActionsResults/MaintenanceResult.cs
+++ b/src/Umbraco.Web.Common/ActionsResults/MaintenanceResult.cs
@@ -11,6 +11,10 @@ public class MaintenanceResult : IActionResult
     /// <summary>
     /// Initializes a new instance of the <see cref="MaintenanceResult"/> class using the default maintenance view.
     /// </summary>
+    /// <remarks>
+    /// This is the built-in view, not the one configured for the site. To honour the site's configuration, pass
+    /// <c>GlobalSettings.MaintenanceViewPath</c> to the overload taking a view path.
+    /// </remarks>
     public MaintenanceResult()
         : this("~/umbraco/UmbracoWebsite/Maintenance.cshtml")
     {

--- a/src/Umbraco.Web.Common/ActionsResults/MaintenanceResult.cs
+++ b/src/Umbraco.Web.Common/ActionsResults/MaintenanceResult.cs
@@ -21,7 +21,7 @@ public class MaintenanceResult : IActionResult
     /// <summary>
     /// Initializes a new instance of the <see cref="MaintenanceResult"/> class using a custom view path.
     /// </summary>
-    /// <param name="viewName">The view path to render, e.g. <c>~/umbraco/UmbracoWebsite/Upgrading.cshtml</c>.</param>
+    /// <param name="viewName">The view path to render, e.g. <c>~/umbraco/UmbracoWebsite/Maintenance.cshtml</c>.</param>
     public MaintenanceResult(string viewName)
         => _viewName = viewName;
 

--- a/src/Umbraco.Web.Common/ActionsResults/MaintenanceResult.cs
+++ b/src/Umbraco.Web.Common/ActionsResults/MaintenanceResult.cs
@@ -8,8 +8,6 @@ namespace Umbraco.Cms.Web.Common.ActionsResults;
 /// </summary>
 public class MaintenanceResult : IActionResult
 {
-    private readonly string _viewName;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="MaintenanceResult"/> class using the default maintenance view.
     /// </summary>
@@ -23,7 +21,12 @@ public class MaintenanceResult : IActionResult
     /// </summary>
     /// <param name="viewName">The view path to render, e.g. <c>~/umbraco/UmbracoWebsite/Maintenance.cshtml</c>.</param>
     public MaintenanceResult(string viewName)
-        => _viewName = viewName;
+        => ViewName = viewName;
+
+    /// <summary>
+    /// Gets the path of the view that will be rendered.
+    /// </summary>
+    public string ViewName { get; }
 
     /// <inheritdoc />
     public async Task ExecuteResultAsync(ActionContext context)
@@ -34,7 +37,7 @@ public class MaintenanceResult : IActionResult
 
         response.StatusCode = StatusCodes.Status503ServiceUnavailable;
 
-        var viewResult = new ViewResult { ViewName = _viewName };
+        var viewResult = new ViewResult { ViewName = ViewName };
 
         await viewResult.ExecuteResultAsync(context);
     }

--- a/src/Umbraco.Web.Common/ActionsResults/MaintenanceResult.cs
+++ b/src/Umbraco.Web.Common/ActionsResults/MaintenanceResult.cs
@@ -30,6 +30,10 @@ public class MaintenanceResult : IActionResult
     /// <summary>
     /// Gets the path of the view that will be rendered.
     /// </summary>
+    /// <remarks>
+    /// Exposed so the chosen view can be inspected without executing the result. Tests rely on this to assert
+    /// which view the maintenance mode filter selects for a given runtime level.
+    /// </remarks>
     public string ViewName { get; }
 
     /// <inheritdoc />

--- a/src/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResult.cs
+++ b/src/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResult.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Web;
 
@@ -43,7 +46,10 @@ public class PublishedContentNotFoundResult : IActionResult
             reason = "No template exists to render the document at URL '{0}'.";
         }
 
-        var viewResult = new ViewResult { ViewName = "~/umbraco/UmbracoWebsite/NotFound.cshtml" };
+        GlobalSettings globalSettings = context.HttpContext.RequestServices
+            .GetRequiredService<IOptions<GlobalSettings>>().Value;
+
+        var viewResult = new ViewResult { ViewName = globalSettings.NotFoundViewPath };
         context.HttpContext.Items.Add(
             "reason",
             string.Format(reason, WebUtility.HtmlEncode(_umbracoContext.OriginalRequestUrl.PathAndQuery)));

--- a/src/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResult.cs
+++ b/src/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResult.cs
@@ -47,7 +47,7 @@ public class PublishedContentNotFoundResult : IActionResult
         }
 
         GlobalSettings globalSettings = context.HttpContext.RequestServices
-            .GetRequiredService<IOptions<GlobalSettings>>().Value;
+            .GetRequiredService<IOptionsMonitor<GlobalSettings>>().CurrentValue;
 
         var viewResult = new ViewResult { ViewName = globalSettings.NotFoundViewPath };
         context.HttpContext.Items.Add(

--- a/src/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResult.cs
+++ b/src/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResult.cs
@@ -17,6 +17,9 @@ public class PublishedContentNotFoundResult : IActionResult
     private readonly string? _message;
     private readonly IUmbracoContext _umbracoContext;
 
+    // TODO (V19): Take the view path as a constructor parameter, as MaintenanceResult does, and drop the
+    // service location in ExecuteResultAsync.
+
     /// <summary>
     ///     Initializes a new instance of the <see cref="PublishedContentNotFoundResult" /> class.
     /// </summary>
@@ -46,6 +49,9 @@ public class PublishedContentNotFoundResult : IActionResult
             reason = "No template exists to render the document at URL '{0}'.";
         }
 
+        // Resolved from the request rather than injected: this type is public and constructed with `new` by
+        // callers outside this assembly, so taking the settings as a constructor parameter would be a binary
+        // breaking change.
         GlobalSettings globalSettings = context.HttpContext.RequestServices
             .GetRequiredService<IOptionsMonitor<GlobalSettings>>().CurrentValue;
 

--- a/src/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttribute.cs
@@ -88,7 +88,7 @@ public sealed class MaintenanceModeActionFilterAttribute : TypeFilterAttribute
 
             context.Result = _runtimeState.Level is RuntimeLevel.Upgrading || inInitializationWindow
                 ? new MaintenanceResult(_globalSettings.CurrentValue.UpgradingViewPath)
-                : new MaintenanceResult();
+                : new MaintenanceResult(_globalSettings.CurrentValue.MaintenanceViewPath);
         }
 
         public void OnActionExecuted(ActionExecutedContext context)

--- a/src/Umbraco.Web.Website/Controllers/BasicAuthLoginController.cs
+++ b/src/Umbraco.Web.Website/Controllers/BasicAuthLoginController.cs
@@ -144,7 +144,7 @@ public class BasicAuthLoginController : Controller
             ReturnPath = returnPath,
             ProviderNames = providerNames,
         };
-        return View("/umbraco/BasicAuthLogin/TwoFactor.cshtml", model);
+        return View(_basicAuthSettings.Value.TwoFactorViewPath, model);
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResultTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResultTests.cs
@@ -39,6 +39,9 @@ public class PublishedContentNotFoundResultTests
 
         await ExecuteAsync(new GlobalSettings(), executor);
 
+        // Spelled out rather than read from GlobalSettings.StaticNotFoundViewPath: this pins the default to the
+        // view that actually ships in Umbraco.Cms.StaticAssets. Asserting against the constant would make the
+        // test follow a change to it, and a default pointing at a non-existent view would still pass.
         Assert.That(executor.CapturedViewName, Is.EqualTo("~/umbraco/UmbracoWebsite/NotFound.cshtml"));
     }
 
@@ -55,7 +58,7 @@ public class PublishedContentNotFoundResultTests
     private static async Task<ActionContext> ExecuteAsync(GlobalSettings settings, IActionResultExecutor<ViewResult> executor)
     {
         IServiceProvider services = new ServiceCollection()
-            .AddSingleton<IOptions<GlobalSettings>>(Options.Create(settings))
+            .AddSingleton<IOptionsMonitor<GlobalSettings>>(Mock.Of<IOptionsMonitor<GlobalSettings>>(m => m.CurrentValue == settings))
             .AddSingleton(executor)
             .BuildServiceProvider();
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResultTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ActionsResults/PublishedContentNotFoundResultTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Common.ActionsResults;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.ActionsResults;
+
+[TestFixture]
+public class PublishedContentNotFoundResultTests
+{
+    private const string CustomNotFoundViewPath = "~/Views/CustomNotFound.cshtml";
+
+    [Test]
+    public async Task ExecuteResultAsync_RendersTheConfiguredNotFoundView()
+    {
+        var settings = new GlobalSettings { NotFoundViewPath = CustomNotFoundViewPath };
+        var executor = new CapturingViewResultExecutor();
+
+        await ExecuteAsync(settings, executor);
+
+        Assert.That(executor.CapturedViewName, Is.EqualTo(CustomNotFoundViewPath));
+    }
+
+    [Test]
+    public async Task ExecuteResultAsync_WithoutConfiguration_RendersTheBuiltInNotFoundView()
+    {
+        var executor = new CapturingViewResultExecutor();
+
+        await ExecuteAsync(new GlobalSettings(), executor);
+
+        Assert.That(executor.CapturedViewName, Is.EqualTo("~/umbraco/UmbracoWebsite/NotFound.cshtml"));
+    }
+
+    [Test]
+    public async Task ExecuteResultAsync_RespondsWithNotFoundStatusCode()
+    {
+        var executor = new CapturingViewResultExecutor();
+
+        ActionContext context = await ExecuteAsync(new GlobalSettings(), executor);
+
+        Assert.That(context.HttpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    private static async Task<ActionContext> ExecuteAsync(GlobalSettings settings, IActionResultExecutor<ViewResult> executor)
+    {
+        IServiceProvider services = new ServiceCollection()
+            .AddSingleton<IOptions<GlobalSettings>>(Options.Create(settings))
+            .AddSingleton(executor)
+            .BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        var context = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+        IUmbracoContext umbracoContext = Mock.Of<IUmbracoContext>(c
+            => c.OriginalRequestUrl == new Uri("https://example.com/no-such-page"));
+
+        await new PublishedContentNotFoundResult(umbracoContext).ExecuteResultAsync(context);
+
+        return context;
+    }
+
+    private sealed class CapturingViewResultExecutor : IActionResultExecutor<ViewResult>
+    {
+        public string? CapturedViewName { get; private set; }
+
+        public Task ExecuteAsync(ActionContext context, ViewResult result)
+        {
+            CapturedViewName = result.ViewName;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttributeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttributeTests.cs
@@ -23,6 +23,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Controllers;
 public class MaintenanceModeActionFilterAttributeTests
 {
     private const string CustomUpgradingViewPath = "~/Views/CustomUpgrading.cshtml";
+    private const string CustomMaintenanceViewPath = "~/Views/CustomMaintenance.cshtml";
 
     [Test]
     public void OnActionExecuting_MvcController_WhenUpgradingAndMaintenanceEnabled_SetsMaintenanceResultWithUpgradingViewPath()
@@ -31,12 +32,14 @@ public class MaintenanceModeActionFilterAttributeTests
         {
             ShowMaintenancePageWhenInUpgradeState = true,
             UpgradingViewPath = CustomUpgradingViewPath,
+            MaintenanceViewPath = CustomMaintenanceViewPath,
         };
         var context = CreateMvcControllerContext();
 
         InvokeFilter(RuntimeLevel.Upgrading, settings, context);
 
         Assert.That(context.Result, Is.InstanceOf<MaintenanceResult>());
+        Assert.That(((MaintenanceResult)context.Result!).ViewName, Is.EqualTo(CustomUpgradingViewPath));
     }
 
     [Test]
@@ -51,14 +54,20 @@ public class MaintenanceModeActionFilterAttributeTests
     }
 
     [Test]
-    public void OnActionExecuting_MvcController_WhenUpgradeAndMaintenanceEnabled_SetsMaintenanceResult()
+    public void OnActionExecuting_MvcController_WhenUpgradeAndMaintenanceEnabled_SetsMaintenanceResultWithMaintenanceViewPath()
     {
-        var settings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = true };
+        var settings = new GlobalSettings
+        {
+            ShowMaintenancePageWhenInUpgradeState = true,
+            UpgradingViewPath = CustomUpgradingViewPath,
+            MaintenanceViewPath = CustomMaintenanceViewPath,
+        };
         var context = CreateMvcControllerContext();
 
         InvokeFilter(RuntimeLevel.Upgrade, settings, context);
 
         Assert.That(context.Result, Is.InstanceOf<MaintenanceResult>());
+        Assert.That(((MaintenanceResult)context.Result!).ViewName, Is.EqualTo(CustomMaintenanceViewPath));
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/BasicAuthLoginControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/BasicAuthLoginControllerTests.cs
@@ -23,6 +23,7 @@ public class BasicAuthLoginControllerTests
     private Mock<IBackOfficeSignInManager> _signInManagerMock = null!;
     private Mock<ITwoFactorLoginService> _twoFactorServiceMock = null!;
     private Mock<IBasicAuthService> _basicAuthServiceMock = null!;
+    private ServiceProvider _serviceProvider = null!;
     private BasicAuthLoginController _controller = null!;
 
     [SetUp]
@@ -40,11 +41,16 @@ public class BasicAuthLoginControllerTests
         services.AddAntiforgery();
         services.AddLogging();
         services.AddControllersWithViews();
-        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        _serviceProvider = services.BuildServiceProvider();
 
-        var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
+        _controller = CreateController(new BasicAuthSettings());
+    }
 
-        _controller = new BasicAuthLoginController(Options.Create(new BasicAuthSettings()))
+    private BasicAuthLoginController CreateController(BasicAuthSettings settings)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = _serviceProvider };
+
+        return new BasicAuthLoginController(Options.Create(settings))
         {
             ControllerContext = new ControllerContext
             {
@@ -283,6 +289,39 @@ public class BasicAuthLoginControllerTests
         Assert.That(model!.ReturnPath, Is.EqualTo("/page"));
         Assert.IsNull(model.ErrorMessage);
         Assert.That(model.ProviderNames, Is.EquivalentTo(new[] { "UmbracoUserAppAuthenticator" }));
+    }
+
+    /// <summary>
+    /// Verifies that both entry points to the 2FA form honour the configured view path: the initial GET
+    /// render and the re-render after an invalid code.
+    /// </summary>
+    [TestCase(true, TestName = "TwoFactor_Get_UsesConfiguredTwoFactorViewPath")]
+    [TestCase(false, TestName = "TwoFactor_Post_InvalidCode_UsesConfiguredTwoFactorViewPath")]
+    public async Task TwoFactor_UsesConfiguredTwoFactorViewPath(bool initialRender)
+    {
+        const string CustomTwoFactorViewPath = "/Views/CustomTwoFactor.cshtml";
+
+        BasicAuthLoginController controller =
+            CreateController(new BasicAuthSettings { TwoFactorViewPath = CustomTwoFactorViewPath });
+
+        var user = CreateBackOfficeUser();
+        _signInManagerMock
+            .Setup(x => x.GetTwoFactorAuthenticationUserAsync())
+            .ReturnsAsync(user);
+        _twoFactorServiceMock
+            .Setup(x => x.GetEnabledTwoFactorProviderNamesAsync(user.Key))
+            .ReturnsAsync(["UmbracoUserAppAuthenticator"]);
+        _signInManagerMock
+            .Setup(x => x.TwoFactorSignInAsync("UmbracoUserAppAuthenticator", "000000", false, false))
+            .ReturnsAsync(SignInResult.Failed);
+
+        IActionResult result = initialRender
+            ? await controller.TwoFactor("/page")
+            : await controller.TwoFactor("UmbracoUserAppAuthenticator", "000000", "/page");
+
+        var viewResult = result as ViewResult;
+        Assert.IsNotNull(viewResult);
+        Assert.That(viewResult!.ViewName, Is.EqualTo(CustomTwoFactorViewPath));
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

As reported in #23749, the ["Create a Custom Maintenance Page"](https://docs.umbraco.com/umbraco-cms/run-in-production/tutorials/create-a-custom-maintenance-page) tutorial doesn't work. Investigating turned up four separate problems.

Fixes #23749.

### 1. Typos in the shipped maintenance page

`Maintenance.cshtml` had `<title>Website is Under Maintainance</title>` while the `<h1>` immediately below said "Maintenance", and the body had "you finish the maintanance by going to backoffice".

### 2. The override could never work (the actual bug)

Even with the file at the path the code really looks for — `umbraco/UmbracoWebsite/Maintenance.cshtml`, not the project-root path the tutorial names — the built-in page still rendered.

`Umbraco.Cms.StaticAssets` is a Razor Class Library, and its views were compiled **without source-checksum attributes**. `ChecksumValidator.IsRecompilationSupported` therefore returns `false`, so `RuntimeViewCompiler.CreatePrecompiledWorkItem` marks the view `SupportsCompilation = false` and caches the precompiled RCL view with no expiration token. A same-path file in the consuming site is never looked at.

Those attributes are only emitted when `GenerateRazorMetadataSourceChecksumAttributes` is set; the SDK doesn't default it on, and the `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` package's targets (which do set it) aren't referenced by StaticAssets.

This only bites sites that rely on runtime compilation — but that includes the default `dotnet new umbraco` project setup.

Fixed by setting the property on `Umbraco.Cms.StaticAssets`. It applies to all eight views the package ships, so `NoNodes`, `NotFound`, `Upgrading`, `UmbracoLogin`, `UmbracoBackOffice` and the two `BasicAuthLogin` views become overridable the same way.

### 3. Inconsistent override story across the shipped views

Four of the eight already had a configurable path (`NoNodesViewPath`, `UpgradingViewPath`, `BasicAuth:LoginViewPath`, `BasicAuth:TwoFactorViewPath`); four were hardcoded. The sharpest case was inside `MaintenanceModeActionFilter` itself, where the unattended-upgrade branch reads `UpgradingViewPath` from config and the attended-upgrade branch one line below used a hardcoded path.

Added `Global:MaintenanceViewPath` and `Global:NotFoundViewPath`, both defaulting to their existing built-in paths.

### 4. `BasicAuth:TwoFactorViewPath` was honoured in only one of two code paths

`BasicAuthLoginController.TwoFactor` (the GET that renders the 2FA form) hardcoded `/umbraco/BasicAuthLogin/TwoFactor.cshtml`, while its sibling `TwoFactorView` (the re-render after a bad code) used the configured path. Configuring a custom 2FA view gave you the built-in form on first load and your own only after a failed attempt.

### Also in here

- `MaintenanceResult.ViewName` is now a public get-only property (was a private field) so the filter's branch choice is assertable.
- Two stale doc comments: `BackOfficeDefaultController.DefaultView()` was documented as returning `Default.cshtml` but builds `Index.cshtml`, and `MaintenanceResult`'s `viewName` example pointed at `Upgrading.cshtml`.

## Recommended documentation updates

**[Create a Custom Maintenance Page](https://docs.umbraco.com/umbraco-cms/run-in-production/tutorials/create-a-custom-maintenance-page)** needs correcting regardless of this PR — the path it gives has never been the one the code looks for:

1. The file goes at `umbraco/UmbracoWebsite/Maintenance.cshtml` — inside the `umbraco` folder, capital `M`. The tutorial currently says `UmbracoWebsite/maintenance.cshtml` at the project root.
2. Lead with the config setting rather than the file drop. `Umbraco:CMS:Global:MaintenanceViewPath` lets the view live alongside the site's other views, and a wrong path fails loudly with a view-not-found error. Dropping a file at Umbraco's own path silently does nothing if the path or casing is off — which is exactly how this issue arose, with no signal to the reporter that anything was wrong.
3. Note that the maintenance page and the upgrading page are two different views. `Maintenance.cshtml` shows during an attended upgrade (`RuntimeLevel.Upgrade`); `Upgrading.cshtml` shows during an unattended background upgrade and the post-upgrade initialization window. Customising one does not affect the other. `Upgrading.cshtml` is configurable via `Umbraco:CMS:Global:UpgradingViewPath`.
4. Keep the existing `ShowMaintenancePageWhenInUpgradeState` section as-is.
5. State the minimum version, since the file-override route does not work on earlier releases.

**Any other page describing a view override.** If the NoNodes / NotFound / login pages are documented the same way, those instructions were broken for the same reason and are fixed by the same change. `NotFoundViewPath` is new here and worth documenting alongside `NoNodesViewPath`.

## Testing

Verified end-to-end on a site in `RuntimeLevel.Upgrade`, with counterfactual runs confirming the built-in page returns when the fix is reverted; unit tests added for both new settings and checked to fail without the production changes.
