### PR TITLE
Rich Text: Fix local link tag matching for encoded braces and neighbouring tags

### DIFF
--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -11,13 +11,13 @@ namespace Umbraco.Cms.Core.Templates;
 /// <remarks>
 /// Needs to support media and document links, order of attributes should not matter nor should other attributes mess with things:
 /// <![CDATA[
-/// <a type = "media" href="/{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}" title="media">media</a>
+/// <a type="media" href="/{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}" title="media">media</a>
 /// <a type="document" href="/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}" title="other page">other page</a>
 /// ]]>
 /// </remarks>
 public sealed partial class HtmlLocalLinkParser
 {
-    [GeneratedRegex(@"<a.+?href=['""](?<locallink>\/?{localLink:(?<guid>[a-fA-F0-9-]+)})[^>]*?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace, "en-GB")]
+    [GeneratedRegex(@"<a\b[^>]*?href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-fA-F0-9-]+)(?:\}|\%7D))[^>]*?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
     private static partial Regex GetLocalLinkTagPattern();
 
     [GeneratedRegex("""type=['"](?<type>(?:media|document))['"]""", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
@@ -38,8 +38,8 @@ public sealed partial class HtmlLocalLinkParser
     ///     &lt;a type="document" href="/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}" title="other page"&gt;other page&lt;/a&gt;
     /// </remarks>
     internal static readonly Regex LocalLinkTagPattern = new(
-        @"<a.+?href=['""](?<locallink>\/?{localLink:(?<guid>[a-fA-F0-9-]+)})[^>]*?>",
-        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline | RegexOptions.Compiled);
+        @"<a\b[^>]*?href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-fA-F0-9-]+)(?:\}|\%7D))[^>]*?>",
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 
     /// <summary>
     ///     Regex pattern to match the type attribute (media or document) in local link tags.

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -20,7 +20,7 @@ public sealed partial class HtmlLocalLinkParser
     [GeneratedRegex(@"<a\b[^>]*?href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-fA-F0-9-]+)(?:\}|\%7D))[^>]*?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
     private static partial Regex GetLocalLinkTagPattern();
 
-    [GeneratedRegex("""type=['"](?<type>(?:media|document))['"]""", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
+    [GeneratedRegex("""(?<![\w-])type=['"](?<type>(?:media|document))['"]""", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
     private static partial Regex GetTypePattern();
 
     [GeneratedRegex("""data-culture=['"](?<culture>[a-zA-Z0-9-_]+)['"]""", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-GB")]
@@ -45,7 +45,7 @@ public sealed partial class HtmlLocalLinkParser
     ///     Regex pattern to match the type attribute (media or document) in local link tags.
     /// </summary>
     internal static readonly Regex TypePattern = new(
-        """type=['"](?<type>(?:media|document))['"]""",
+        """(?<![\w-])type=['"](?<type>(?:media|document))['"]""",
         RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 
     /// <summary>

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -20,7 +20,7 @@ public sealed partial class HtmlLocalLinkParser
     [GeneratedRegex(@"<a\b[^>]*?href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-fA-F0-9-]+)(?:\}|\%7D))[^>]*?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
     private static partial Regex GetLocalLinkTagPattern();
 
-    [GeneratedRegex("""(?<![\w-])type=['"](?<type>(?:media|document))['"]""", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
+    [GeneratedRegex("""\s*(?<![\w-])type=['"](?<type>(?:media|document))['"]""", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
     private static partial Regex GetTypePattern();
 
     [GeneratedRegex("""data-culture=['"](?<culture>[a-zA-Z0-9-_]+)['"]""", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-GB")]
@@ -45,7 +45,7 @@ public sealed partial class HtmlLocalLinkParser
     ///     Regex pattern to match the type attribute (media or document) in local link tags.
     /// </summary>
     internal static readonly Regex TypePattern = new(
-        """(?<![\w-])type=['"](?<type>(?:media|document))['"]""",
+        """\s*(?<![\w-])type=['"](?<type>(?:media|document))['"]""",
         RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 
     /// <summary>
@@ -58,9 +58,6 @@ public sealed partial class HtmlLocalLinkParser
     [GeneratedRegex(@"href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-zA-Z0-9-://]+)(?:\}|\%7D))", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
     private static partial Regex GetLocalLinkPattern();
 
-    [GeneratedRegex(@"(<a\b(?=[^>]*data-culture=['""](?<culture>[a-zA-Z0-9-_]+)['""])(?=[^>]*href=['""])[^>]*href=['""])(?<href>[^""']*)(?<closequote>[""'])", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-GB")]
-    private static partial Regex GetLinkPattern();
-
     private static readonly Regex _localLinkTagPattern = GetLocalLinkTagPattern();
 
     private static readonly Regex _typePattern = GetTypePattern();
@@ -68,8 +65,6 @@ public sealed partial class HtmlLocalLinkParser
     private static readonly Regex _localLinkPattern = GetLocalLinkPattern();
 
     private static readonly Regex _culturePattern = GetCulturePattern();
-
-    private static readonly Regex _linkPattern = GetLinkPattern();
 
     private readonly IPublishedUrlProvider _publishedUrlProvider;
 
@@ -114,85 +109,115 @@ public sealed partial class HtmlLocalLinkParser
     /// </summary>
     public string EnsureInternalLinks(string text, UrlMode urlMode)
     {
-        foreach (LocalLinkTag tagData in FindLocalLinkIds(text))
+        text = _localLinkTagPattern.Replace(text, match => ReplaceLocalLinkTag(match, urlMode));
+
+        return ReplaceLegacyLocalLinks(text, urlMode);
+    }
+
+    // Rewrites a single matched tag, replacing the local link with the resolved URL and removing the type
+    // attribute that identified the entity. Every edit is confined to the matched tag, so a tag that
+    // resolves to nothing keeps its original markup even when a neighbouring tag holds the same local link.
+    private string ReplaceLocalLinkTag(Match tagMatch, UrlMode urlMode)
+    {
+        LocalLinkTagData? tagData = ReadLocalLinkTagData(tagMatch);
+        if (tagData is null)
+        {
+            return tagMatch.Value;
+        }
+
+        var newLink = tagData.EntityType switch
+        {
+            Constants.UdiEntityType.Document => _publishedUrlProvider.GetUrl(tagData.Key, urlMode, tagData.Culture),
+            Constants.UdiEntityType.Media => _publishedUrlProvider.GetMediaUrl(tagData.Key, urlMode),
+            _ => string.Empty,
+        };
+
+        Group localLink = tagMatch.Groups["locallink"];
+        var localLinkIndex = localLink.Index - tagMatch.Index;
+        Match typeMatch = tagData.TypeMatch;
+
+        // Both offsets are relative to the tag, so the later edit is applied first to keep the other valid.
+        if (typeMatch.Index > localLinkIndex)
+        {
+            return tagMatch.Value
+                .Remove(typeMatch.Index, typeMatch.Length)
+                .Remove(localLinkIndex, localLink.Length)
+                .Insert(localLinkIndex, newLink);
+        }
+
+        return tagMatch.Value
+            .Remove(localLinkIndex, localLink.Length)
+            .Insert(localLinkIndex, newLink)
+            .Remove(typeMatch.Index, typeMatch.Length);
+    }
+
+    private string ReplaceLegacyLocalLinks(string text, UrlMode urlMode)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        foreach (LocalLinkTag tagData in FindLegacyLocalLinkIds(text))
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             if (tagData.Udi is not null)
             {
-                var newLink = tagData.Udi?.EntityType switch
+                var newLink = tagData.Udi.EntityType switch
                 {
                     Constants.UdiEntityType.Document => _publishedUrlProvider.GetUrl(tagData.Udi.Guid, urlMode, tagData.Culture),
                     Constants.UdiEntityType.Media => _publishedUrlProvider.GetMediaUrl(tagData.Udi.Guid, urlMode),
                     _ => string.Empty,
                 };
 
-                text = StripTypeAttributeFromTag(text, tagData.Udi!.EntityType);
-                text = ReplaceLink(text, tagData.TagHref, newLink, tagData.Culture);
+                text = text.Replace(tagData.TagHref, newLink);
             }
             else if (tagData.IntId.HasValue)
             {
-                var newLink = _publishedUrlProvider.GetUrl(tagData.IntId.Value, urlMode);
-                text = text.Replace(tagData.TagHref, newLink);
+                text = text.Replace(tagData.TagHref, _publishedUrlProvider.GetUrl(tagData.IntId.Value, urlMode));
             }
         }
 
         return text;
     }
 
-    private string ReplaceLink(string text, string tagHref, string newLink, string? culture = null)
+    private static LocalLinkTagData? ReadLocalLinkTagData(Match tagMatch)
     {
-        if (string.IsNullOrEmpty(culture))
+        if (Guid.TryParse(tagMatch.Groups["guid"].ValueSpan, out Guid key) is false)
         {
-            return text.Replace(tagHref, newLink);
+            return null;
         }
-        else
-        {
-            return _linkPattern.Replace(text, match =>
-            {
-                if (match.Groups["culture"].ValueSpan.Equals(culture, StringComparison.OrdinalIgnoreCase)
-                    && match.Groups["href"].Value == tagHref)
-                {
-                    return $"{match.Groups[1].ValueSpan}{newLink}{match.Groups["closequote"].ValueSpan}";
-                }
-                return match.Value;
-            });
-        }
-    }
 
-    // Under normal circumstances, the type attribute is preceded by a space
-    // to cover the rare occasion where it isn't, we first replace with a space and then without.
-    // Case-insensitive to tolerate historic mis-cased values written by the (now fixed) ConvertLocalLinks
-    // migration for Umbraco 15 (see #22597).
-    private static string StripTypeAttributeFromTag(string tag, string type) =>
-        tag.Replace($" type=\"{type}\"", string.Empty, StringComparison.OrdinalIgnoreCase)
-            .Replace($"type=\"{type}\"", string.Empty, StringComparison.OrdinalIgnoreCase);
+        // A tag that carries no type of its own cannot be resolved, as the entity type is what tells the
+        // document and media URL providers apart.
+        Match typeMatch = _typePattern.Match(tagMatch.Value);
+        if (typeMatch.Success is false)
+        {
+            return null;
+        }
+
+        Match cultureMatch = _culturePattern.Match(tagMatch.Value);
+
+        // Normalize the type to lower case to tolerate historic mis-cased values written by the (now fixed)
+        // ConvertLocalLinks migration (see #22597). Constants.UdiEntityType.* values are lower case.
+        return new LocalLinkTagData(
+            key,
+            typeMatch.Groups["type"].Value.ToLowerInvariant(),
+            cultureMatch.Success ? cultureMatch.Groups["culture"].Value : null,
+            typeMatch);
+    }
 
     private IEnumerable<LocalLinkTag> FindLocalLinkIds(string text)
     {
-        MatchCollection localLinkTagMatches = _localLinkTagPattern.Matches(text);
-        foreach (Match linkTag in localLinkTagMatches)
+        foreach (Match linkTag in _localLinkTagPattern.Matches(text))
         {
-            if (Guid.TryParse(linkTag.Groups["guid"].ValueSpan, out Guid guid) is false)
+            LocalLinkTagData? tagData = ReadLocalLinkTagData(linkTag);
+            if (tagData is null)
             {
                 continue;
             }
 
-            // Find the type attribute
-            Match typeMatch = _typePattern.Match(linkTag.Value);
-            if (typeMatch.Success is false)
-            {
-                continue;
-            }
-
-            // Find the culture attribute if it exists
-            Match cultureMatch = _culturePattern.Match(linkTag.Value);
-
-            // Normalize the type to lower case to tolerate historic mis-cased values written by the (now fixed)
-            // ConvertLocalLinks migration (see #22597). Constants.UdiEntityType.* values are lower case.
             yield return new LocalLinkTag(
                 null,
-                new GuidUdi(typeMatch.Groups["type"].Value.ToLowerInvariant(), guid),
+                new GuidUdi(tagData.EntityType, tagData.Key),
                 linkTag.Groups["locallink"].Value,
-                cultureMatch.Success ? cultureMatch.Groups["culture"].Value : null);
+                tagData.Culture);
         }
 
         // also return legacy results for values that have not been migrated
@@ -201,6 +226,8 @@ public sealed partial class HtmlLocalLinkParser
             yield return legacyResult;
         }
     }
+
+    private sealed record LocalLinkTagData(Guid Key, string EntityType, string? Culture, Match TypeMatch);
 
     /// <summary>
     ///     Finds legacy local link identifiers in the specified text.

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -17,6 +17,14 @@ namespace Umbraco.Cms.Core.Templates;
 /// </remarks>
 public sealed partial class HtmlLocalLinkParser
 {
+    /// <summary>
+    ///     The name of the capture group holding the local link.
+    /// </summary>
+    /// <remarks>
+    ///     Must match the group name used by every local link pattern below.
+    /// </remarks>
+    private const string LocalLinkGroupName = "locallink";
+
     [GeneratedRegex(@"<a\b[^>]*?href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-fA-F0-9-]+)(?:\}|\%7D))[^>]*?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
     private static partial Regex GetLocalLinkTagPattern();
 
@@ -132,7 +140,7 @@ public sealed partial class HtmlLocalLinkParser
             _ => string.Empty,
         };
 
-        Group localLink = tagMatch.Groups["locallink"];
+        Group localLink = tagMatch.Groups[LocalLinkGroupName];
         var localLinkIndex = localLink.Index - tagMatch.Index;
         Match typeMatch = tagData.TypeMatch;
 
@@ -216,7 +224,7 @@ public sealed partial class HtmlLocalLinkParser
             yield return new LocalLinkTag(
                 null,
                 new GuidUdi(tagData.EntityType, tagData.Key),
-                linkTag.Groups["locallink"].Value,
+                linkTag.Groups[LocalLinkGroupName].Value,
                 tagData.Culture);
         }
 
@@ -253,13 +261,13 @@ public sealed partial class HtmlLocalLinkParser
             {
                 if (udi is GuidUdi guidUdi)
                 {
-                    yield return new LocalLinkTag(null, guidUdi, tag.Groups["locallink"].Value);
+                    yield return new LocalLinkTag(null, guidUdi, tag.Groups[LocalLinkGroupName].Value);
                 }
             }
 
             if (int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intId))
             {
-                yield return new LocalLinkTag (intId, null, tag.Groups["locallink"].Value);
+                yield return new LocalLinkTag (intId, null, tag.Groups[LocalLinkGroupName].Value);
             }
         }
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -140,10 +140,31 @@ public class HtmlLocalLinkParserTests
         "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}?v=1\" title=\"world\">world</a>",
         "<a href=\"/my-test-url?v=1\" title=\"world\">world</a>")]
 
+    // URL encoded braces, as accepted by the legacy pattern and preserved by the ConvertLocalLinks migration
+    [TestCase(
+        "<a type=\"document\" href=\"/%7BlocalLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E%7D\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url\" title=\"world\">world</a>")]
+    [TestCase(
+        "<a type=\"media\" href=\"/%7BlocalLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E%7D\" title=\"world\">world</a>",
+        "<a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a>")]
+    [TestCase(
+        "<a type=\"document\" href=\"/%7BlocalLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E%7D#anchor\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url#anchor\" title=\"world\">world</a>")]
+
     // custom type ignored
     [TestCase(
         "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
         "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
+
+    // the type attribute has to belong to the anchor holding the local link, not to a preceding tag
+    [TestCase(
+        "<a href=\"/other\" type=\"document\">other</a> <a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a href=\"/other\" type=\"document\">other</a> <a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
+
+    // only anchors hold local links, an element whose name merely starts with "a" does not
+    [TestCase(
+        "<abbr type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</abbr>",
+        "<abbr type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</abbr>")]
 
     // PascalCase type — historic mis-cased values written by the (now fixed) ConvertLocalLinks migration for Umbraco 15 (see #22597).
     [TestCase(

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -111,6 +111,13 @@ public class HtmlLocalLinkParserTests
     [TestCase(
         "<a type=\"media\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
         "<a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a>")]
+
+    // a single quoted type attribute is honoured when reading the entity type, so it has to be
+    // removed from the rendered output too.
+    [TestCase(
+        "<a type='document' href='/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}'>world</a>",
+        "<a href='/my-test-url'>world</a>")]
+
     [TestCase(
         "<a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\"type=\"document\" title=\"world\">world</a>",
         "<a href=\"/my-test-url\" title=\"world\">world</a>")]
@@ -140,6 +147,14 @@ public class HtmlLocalLinkParserTests
         "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}?v=1\" title=\"world\">world</a>",
         "<a href=\"/my-test-url?v=1\" title=\"world\">world</a>")]
 
+    // the attributes of a single tag may be spread over several lines
+    [TestCase(
+        "<a\n  type=\"document\"\n  href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\"\n  title=\"world\">world</a>",
+        "<a\n  href=\"/my-test-url\"\n  title=\"world\">world</a>")]
+    [TestCase(
+        "<a\n  href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\"\n  type=\"media\">world</a>",
+        "<a\n  href=\"/media/1001/my-image.jpg\">world</a>")]
+
     // URL encoded braces, as accepted by the legacy pattern and preserved by the ConvertLocalLinks migration
     [TestCase(
         "<a type=\"document\" href=\"/%7BlocalLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E%7D\" title=\"world\">world</a>",
@@ -164,10 +179,21 @@ public class HtmlLocalLinkParserTests
         "<a itemtype=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
         "<a itemtype=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
 
+    // such an attribute also survives untouched when an unrelated local link elsewhere in the value resolves.
+    [TestCase(
+        "<a data-type=\"document\" href=\"/other\">other</a><a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">world</a>",
+        "<a data-type=\"document\" href=\"/other\">other</a><a href=\"/my-test-url\">world</a>")]
+
     // the type attribute has to belong to the anchor holding the local link, not to a preceding tag
     [TestCase(
         "<a href=\"/other\" type=\"document\">other</a> <a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
         "<a href=\"/other\" type=\"document\">other</a> <a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
+
+    // a local link with no type of its own stays unresolved even when another anchor in the same value
+    // points at the same entity.
+    [TestCase(
+        "<a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">no type</a> <a type=\"media\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">no type</a> <a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a>")]
 
     // only anchors hold local links, an element whose name merely starts with "a" does not
     [TestCase(
@@ -506,6 +532,14 @@ public class HtmlLocalLinkParserTests
     [TestCase(
         "<a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" type=\"media\" data-culture=\"no-NO\" title=\"world\">world</a>",
         "<a href=\"/media/1001/my-image.jpg\" data-culture=\"no-NO\" title=\"world\">world</a>")]
+
+    // trailing content in the href is preserved for a cultured link, just as it is without a culture
+    [TestCase(
+        "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}#anchor\" data-culture=\"en-US\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url#anchor\" data-culture=\"en-US\" title=\"world\">world</a>")]
+    [TestCase(
+        "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}?v=1\" data-culture=\"en-US\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url?v=1\" data-culture=\"en-US\" title=\"world\">world</a>")]
     public void EnsureInternalLinks_WithCultureAttribute_ReplacesLinkPreservingCulture(string input, string expected)
     {
         // Arrange

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -103,6 +103,44 @@ public class HtmlLocalLinkParserTests
         });
     }
 
+    // Discovering the UDIs applies the same rules as resolving the URLs, as the entity type is what
+    // identifies the target. A tag it cannot be read from yields nothing rather than a guessed type.
+    [TestCase("<a href=\"/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}\">no type of its own</a>")]
+    [TestCase("<a data-type=\"document\" href=\"/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}\">data-type only</a>")]
+    [TestCase("<a itemtype=\"document\" href=\"/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}\">itemtype only</a>")]
+    [TestCase("<abbr type=\"document\" href=\"/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}\">not an anchor</abbr>")]
+    [TestCase("<a href=\"/other\" type=\"document\">other</a> <a href=\"/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}\">type on a preceding tag</a>")]
+    public void Returns_No_Udis_From_Unresolvable_LocalLinks(string input)
+    {
+        var parser = new HtmlLocalLinkParser(Mock.Of<IPublishedUrlProvider>());
+
+        var result = parser.FindUdisFromLocalLinks(input).ToList();
+
+        Assert.IsEmpty(result);
+    }
+
+    [TestCase(
+        "<a type=\"document\" href=\"/%7BlocalLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f%7D\">encoded braces</a>",
+        "umb://document/eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f")]
+    [TestCase(
+        "<a data-type=\"media\" type=\"document\" href=\"/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}\">both attributes</a>",
+        "umb://document/eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f")]
+    [TestCase(
+        "<a type=\"media\" href=\"/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}\">media</a>",
+        "umb://media/eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f")]
+    public void Returns_Udi_From_Resolvable_LocalLink(string input, string expectedUdi)
+    {
+        var parser = new HtmlLocalLinkParser(Mock.Of<IPublishedUrlProvider>());
+
+        var result = parser.FindUdisFromLocalLinks(input).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(UdiParser.Parse(expectedUdi), result[0]);
+        });
+    }
+
     [TestCase("", "")]
     // current
     [TestCase(
@@ -127,6 +165,16 @@ public class HtmlLocalLinkParserTests
     [TestCase(
         "<p><a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a></p><p><a href=\"/{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}\" title=\"world\" type=\"media\">world</a></p>",
         "<p><a href=\"/my-test-url\" title=\"world\">world</a></p><p><a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a></p>")]
+
+    // every tag is resolved on its own, so two tags holding the same local link and type both get the URL
+    [TestCase(
+        "<p><a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">one</a><a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">two</a></p>",
+        "<p><a href=\"/my-test-url\">one</a><a href=\"/my-test-url\">two</a></p>")]
+
+    // the tag and attribute names are matched without regard to case
+    [TestCase(
+        "<A TYPE=\"document\" HREF=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">world</A>",
+        "<A HREF=\"/my-test-url\">world</A>")]
 
     // attributes order should not matter
     [TestCase(
@@ -179,6 +227,14 @@ public class HtmlLocalLinkParserTests
         "<a itemtype=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
         "<a itemtype=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
 
+    // the type attribute is still found when an attribute whose name merely ends with "type" precedes it
+    [TestCase(
+        "<a data-type=\"document\" type=\"media\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a data-type=\"document\" href=\"/media/1001/my-image.jpg\" title=\"world\">world</a>")]
+    [TestCase(
+        "<a itemtype=\"media\" type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a itemtype=\"media\" href=\"/my-test-url\" title=\"world\">world</a>")]
+
     // such an attribute also survives untouched when an unrelated local link elsewhere in the value resolves.
     [TestCase(
         "<a data-type=\"document\" href=\"/other\">other</a><a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">world</a>",
@@ -227,6 +283,17 @@ public class HtmlLocalLinkParserTests
     [TestCase(
         "hello href='{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}' world ",
         "hello href='/media/1001/my-image.jpg' world ")]
+
+    // a legacy local link inside an anchor is left to the legacy pattern, as the tag pattern cannot read its type
+    [TestCase(
+        "<a href=\"{localLink:1234}\">world</a>",
+        "<a href=\"/my-test-url\">world</a>")]
+    [TestCase(
+        "<a href=\"{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}\">world</a>",
+        "<a href=\"/media/1001/my-image.jpg\">world</a>")]
+    [TestCase(
+        "<a href=\"{localLink:umb://document/9931BDE0AAC34BABB838909A7B47570E}\">legacy</a><a type=\"media\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">current</a>",
+        "<a href=\"/my-test-url\">legacy</a><a href=\"/media/1001/my-image.jpg\">current</a>")]
 
     // This one has an invalid char so won't match.
     [TestCase(
@@ -380,6 +447,20 @@ public class HtmlLocalLinkParserTests
     [TestCase(UrlMode.Relative, "hello href=\"{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}\" world ", "hello href=\"/media/relative/image.jpg\" world ")]
     [TestCase(UrlMode.Absolute, "hello href=\"{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}\" world ", "hello href=\"https://example.com/media/absolute/image.jpg\" world ")]
     [TestCase(UrlMode.Auto, "hello href=\"{localLink:umb://media/9931BDE0AAC34BABB838909A7B47570E}\" world ", "hello href=\"/media/relative/image.jpg\" world ")]
+
+    // the URL mode reaches the providers for the current format, not only the legacy one
+    [TestCase(
+        UrlMode.Relative,
+        "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">world</a>",
+        "<a href=\"/relative-url\">world</a>")]
+    [TestCase(
+        UrlMode.Absolute,
+        "<a type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">world</a>",
+        "<a href=\"https://example.com/absolute-url\">world</a>")]
+    [TestCase(
+        UrlMode.Absolute,
+        "<a type=\"media\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\">world</a>",
+        "<a href=\"https://example.com/media/absolute/image.jpg\">world</a>")]
     public void ParseLocalLinks_WithVariousUrlModes_ReturnsCorrectUrls(UrlMode urlMode, string input, string expectedResult)
     {
         // Setup content URL provider that returns different URLs based on UrlMode

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -156,6 +156,14 @@ public class HtmlLocalLinkParserTests
         "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
         "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
 
+    // an attribute whose name merely ends with "type" is not the type attribute
+    [TestCase(
+        "<a data-type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a data-type=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
+    [TestCase(
+        "<a itemtype=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a itemtype=\"document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
+
     // the type attribute has to belong to the anchor holding the local link, not to a preceding tag
     [TestCase(
         "<a href=\"/other\" type=\"document\">other</a> <a href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Four fixes to `HtmlLocalLinkParser`, found while adding support for the current local link format to Umbraco Deploy's dependency tracking. They are independent, but all sit in the same two regex patterns, so they are combined here. Targeting v17 so the LTS gets them.

#### 1. The current format no longer accepts URL encoded braces

`LocalLinkTagPattern` requires literal `{` and `}`. The pattern it replaced accepted both forms. In v13 there was a single pattern, and it read:

```
href=""[/]?(?:\{|\%7B)localLink:([a-zA-Z0-9-://]+)(?:\}|\%7D)
```

The encoded alternatives were kept in `LocalLinkPattern` when the current format was introduced, but not carried over into the new tag pattern, so the support was dropped for anything migrated to the current format.

That matters because `V_15_0_0.LocalLinks.LocalLinkProcessor.ProcessStringValue` builds its replacement from the legacy match with `tag.TagHref.Replace(tag.Udi.ToString(), tag.Udi.Guid.ToString())`, which preserves whatever brace form was there, and then appends the `type` attribute. So an encoded legacy link migrates into a shape that neither pattern can resolve:

```
before   : <a href="/%7BlocalLink:umb://document/9931BDE0-AAC3-4BAB-B838-909A7B47570E%7D" title="x">x</a>
migrated : <a href="/%7BlocalLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E%7D" type="document" title="x">x</a>
```

`LocalLinkTagPattern` does not match it because the braces are encoded. `LocalLinkPattern` does match it, but the `guid` group is then a bare GUID, which `FindLegacyLocalLinkIds` discards because it parses as neither a UDI nor an int. The link is dead in both paths and renders literally as `/%7BlocalLink:...%7D`.

I have not been able to confirm how much content in the wild still stores the encoded form, and there was no test coverage for it, so I cannot put a number on the impact. The point stands regardless: the old pattern accepted it, the new one silently does not, and restoring that is one alternation in each brace position.

#### 2. The `type` attribute can be read from a preceding tag

`LocalLinkTagPattern` starts with `<a.+?href=` and sets `RegexOptions.Singleline`, so `.` matches both newlines and `>` and a single match can begin at an earlier anchor and run through the intervening markup. `FindLocalLinkIds` then does `_typePattern.Match(linkTag.Value)` over that whole span, so the type is taken from the wrong tag:

```
input : <a href="/other" type="document">other</a> <a href="/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}">world</a>
match : <a href="/other" type="document">other</a> <a href="/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}">
type  : document          <-- inherited from the first anchor
```

The second anchor carries no `type` and should be skipped, but it resolves as a document instead. Anchors in the current format without a `type` are not hypothetical: two fallback paths in `LocalLinkProcessor.ProcessStringValue` write a converted link without one when it cannot locate the closing quote of the `href`.

Fixed by scoping the match to a single tag with `<a\b[^>]*?href=` and dropping `Singleline`. `[^>]` still matches newlines, so anchors spread over several lines keep working, and the existing test case for that still passes. `GetLinkPattern` a few lines below already uses this `<a\b[^>]*href=` idiom.

The word boundary also stops the pattern matching elements whose name merely starts with `a`, such as `<abbr href="...">`, which it previously did.

This deliberately does not try to resolve a link that has no usable `type`. Guessing the entity type would be making an assumption about content the parser cannot see, and the shape is better fixed where it is produced.

#### 3. Any attribute ending in `type` is treated as the type attribute

`TypePattern` matches the substring `type='...'` anywhere in the tag, with nothing requiring it to be the start of an attribute name. So an unrelated attribute supplies the entity type:

```
<a data-type="document" href="/{localLink:...}">     -> type: document
<a data-mce-type="media" href="/{localLink:...}">    -> type: media
<a itemtype="document" href="/{localLink:...}">      -> type: document
```

Each of those anchors has no `type` attribute and should be skipped. Fixed with a `(?<![\w-])` lookbehind, which still allows the attribute to follow a quote directly rather than a space, so the existing `... title="world"type="media">` case keeps working.

Credit where due: this one was spotted by the Copilot reviewer on the corresponding Umbraco Deploy PR, and applies equally here.

#### 4. The documented example does not actually work

The `<remarks>` on the class shows `<a type = "media" href=...>` with spaces around the `=`, but `TypePattern` has no whitespace allowance, so that exact markup parses the tag and then finds no type. No property editor writes spaces there, so the doc is what is wrong rather than the pattern. Corrected the example to `type="media"`, matching the second copy of the same example in the `<remarks>` on `LocalLinkTagPattern`, which was already written without spaces.

#### Note on the duplicated patterns

`LocalLinkTagPattern`, `TypePattern` and `LocalLinkPattern` exist twice, once as `internal static readonly` fields and once as `[GeneratedRegex]` partials, and only the generated ones are used. I have kept the unused copies of the two patterns I changed identical to the generated ones rather than letting them drift, but have not otherwise touched them.

### How to test

Automated: `HtmlLocalLinkParserTests.ParseLocalLinks` gains seven cases. Three cover the encoded braces (document, media, and with a trailing `#anchor`), two assert that a local link is left alone when the only `type` attribute belongs to a preceding tag or when the element is not an anchor, and two assert the same for `data-type` and `itemtype`. Reverting `HtmlLocalLinkParser.cs` alone fails exactly those seven and nothing else. The full `Umbraco.Tests.UnitTests` project passes: 6304 passed, 6 skipped, 0 failed.

Manually:

1. On a v17 site, add a rich text property and set its value to `<a type="document" href="/%7BlocalLink:<guid of a published page>%7D">encoded</a>` via the source view or directly in `umbracoPropertyData`.
2. Render the property on the front end. Before this change the href renders literally as `/%7BlocalLink:...%7D`; after it resolves to the page URL.
3. For the second fix, set the value to `<a href="/somewhere" type="document">first</a> <a href="/{localLink:<guid of a media item>}">second</a>`. Before this change the second link resolves as a document, which for a media GUID gives a wrong or empty URL; after it is left untouched, because it has no `type` of its own.
4. For the third fix, set the value to `<a data-type="document" href="/{localLink:<guid of a published page>}">no type</a>`. Before this change it resolves as a document; after it is left untouched.
