### PR TITLE
fix(Scoping-`CoreScope`): Correct WriteLock/ReadLock return behaviour when TimeSpan is passed in

### DIFF
--- a/src/Umbraco.Core/Scoping/CoreScope.cs
+++ b/src/Umbraco.Core/Scoping/CoreScope.cs
@@ -247,10 +247,10 @@ public class CoreScope : ICoreScope
     public void WriteLock(params int[] lockIds) => Locks.WriteLock(InstanceId, null, lockIds);
 
     /// <inheritdoc />
-    public void WriteLock(TimeSpan timeout, int lockId) => Locks.ReadLock(InstanceId, timeout, lockId);
+    public void WriteLock(TimeSpan timeout, int lockId) => Locks.WriteLock(InstanceId, timeout, lockId);
 
     /// <inheritdoc />
-    public void ReadLock(TimeSpan timeout, int lockId) => Locks.WriteLock(InstanceId, timeout, lockId);
+    public void ReadLock(TimeSpan timeout, int lockId) => Locks.ReadLock(InstanceId, timeout, lockId);
 
     /// <inheritdoc />
     public void EagerWriteLock(params int[] lockIds) => Locks.EagerWriteLock(InstanceId, null, lockIds);


### PR DESCRIPTION
Update `CoreScope` so that `ReadLock` requests always returns a `ReadLock` and `WriteLock` always returns a `WriteLock`

see description at: https://github.com/umbraco/Umbraco-CMS/discussions/23772 & associated write-lock issue https://github.com/umbraco/Umbraco-CMS/issues/14195

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

### Description

`ReadLock` sometimes incorrectly returned a `WriteLock`, and `WriteLock` sometimes incorrectly returned a `ReadLock` in `CoreScope.cs`. This PR inverts that behaviour.

Shouldn't be a breaking change, because the only path into this code is already marked as `Obsolete` under a warning.


<!-- Thanks for contributing to Umbraco CMS! -->
