### PR TITLE
Migrations: Process single block list property data in pages to bound memory use (closes #23766)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
@@ -313,8 +313,7 @@ WHERE nodeId IN (@0)";
                                        ?? throw new InvalidOperationException(
                                            "The data type value editor could not be obtained.");
 
-        var total = await Database.ExecuteScalarAsync<long>(
-            BuildPropertyDataSql(propertyType, lastId: 0, isCount: true));
+        var total = await Database.ExecuteScalarAsync<long>(BuildPropertyDataCountSql(propertyType));
         if (total == 0)
         {
             return (false, true);
@@ -340,9 +339,8 @@ WHERE nodeId IN (@0)";
 
         while (true)
         {
-            // SelectTop has to be applied last: SQL Server inserts "TOP n" after SELECT, SQLite appends "LIMIT n".
             List<PropertyDataDto> page = await Database.FetchAsync<PropertyDataDto>(
-                BuildPropertyDataSql(propertyType, lastId).SelectTop(pageSize));
+                BuildPropertyDataPageSql(propertyType, lastId, pageSize));
 
             if (page.Count == 0)
             {
@@ -378,10 +376,26 @@ WHERE nodeId IN (@0)";
         return (true, success);
     }
 
-    private Sql<ISqlContext> BuildPropertyDataSql(IPropertyType propertyType, int lastId, bool isCount = false)
-    {
-        Sql<ISqlContext> sql = (isCount ? Sql().SelectCount() : Sql().Select<PropertyDataDto>())
-            .From<PropertyDataDto>()
+    /// <summary>
+    /// Counts the property data of a property type that is a candidate for conversion, for progress reporting. No
+    /// ordering, as an ordered count would only add an avoidable sort.
+    /// </summary>
+    private Sql<ISqlContext> BuildPropertyDataCountSql(IPropertyType propertyType)
+        => AddPropertyDataFilter(Sql().SelectCount(), propertyType);
+
+    /// <summary>
+    /// Selects the next page of a property type's candidate property data, by keyset rather than by offset.
+    /// </summary>
+    private Sql<ISqlContext> BuildPropertyDataPageSql(IPropertyType propertyType, int lastId, int pageSize)
+        => AddPropertyDataFilter(Sql().Select<PropertyDataDto>(), propertyType)
+            .Where<PropertyDataDto>(propertyData => propertyData.Id > lastId)
+            .OrderBy<PropertyDataDto>(propertyData => propertyData.Id)
+
+            // Applied last: SQL Server inserts "TOP n" after SELECT, but SQLite appends "LIMIT n" to the statement.
+            .SelectTop(pageSize);
+
+    private static Sql<ISqlContext> AddPropertyDataFilter(Sql<ISqlContext> sql, IPropertyType propertyType)
+        => sql.From<PropertyDataDto>()
             .InnerJoin<ContentVersionDto>()
             .On<PropertyDataDto, ContentVersionDto>((propertyData, contentVersion) =>
                 propertyData.VersionId == contentVersion.Id)
@@ -391,16 +405,10 @@ WHERE nodeId IN (@0)";
             .Where<PropertyDataDto, ContentVersionDto, DocumentVersionDto>((propertyData, contentVersion, documentVersion) =>
                 (contentVersion.Current == true || documentVersion.Published == true)
                 && propertyData.PropertyTypeId == propertyType.Id
-                && propertyData.Id > lastId
 
                 // Block and rich text values are held as text, but PropertyDataDto.Value falls back to the varchar
                 // column before the text one, so a row only has nothing to convert when both are empty.
                 && (propertyData.TextValue != null || propertyData.VarcharValue != null));
-
-        return isCount
-            ? sql
-            : sql.OrderBy<PropertyDataDto>(propertyData => propertyData.Id);
-    }
 
     /// <summary>
     /// Converts a page of property data and persists whatever converted, leaving the rest of the rows untouched.
@@ -428,7 +436,7 @@ WHERE nodeId IN (@0)";
         {
             using UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext();
 
-            var completed = Interlocked.Increment(ref progress.Processed);
+            var completed = progress.Increment();
             if (completed % 100 == 0)
             {
                 _logger.LogInformation("  - finished {Progress} of {Total} properties", completed, progress.Total);
@@ -679,15 +687,17 @@ WHERE nodeId IN (@0)";
     /// </summary>
     private sealed class MigrationProgress
     {
+        private long _processed;
+
         public MigrationProgress(long total) => Total = total;
 
         public long Total { get; }
 
         /// <summary>
-        /// The number of property data values processed so far. A field rather than a property as it is
-        /// incremented with <see cref="Interlocked" />.
+        /// Counts one more processed property data value and returns the running total. Safe to call from the
+        /// parallelized conversion workers.
         /// </summary>
-        public int Processed;
+        public long Increment() => Interlocked.Increment(ref _processed);
     }
 
     private class UpdateItem

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
@@ -40,6 +40,8 @@ public class MigrateSingleBlockList : AsyncMigrationBase
     private readonly IBlockEditorElementTypeCache _elementTypeCache;
     private readonly AppCaches _appCaches;
     private readonly IDataTypeConfigurationCache _dataTypeConfigurationCache;
+    private const int DefaultPageSize = 1000;
+
     private readonly ILogger<MigrateSingleBlockList> _logger;
     private readonly IDataValueEditor _dummySingleBlockValueEditor;
 
@@ -158,8 +160,21 @@ public class MigrateSingleBlockList : AsyncMigrationBase
         _dummySingleBlockValueEditor = new SingleBlockPropertyEditor(dataValueEditorFactory, jsonSerializer, ioHelper, blockValuePropertyIndexValueFactory).GetValueEditor();
     }
 
+    /// <summary>
+    /// Gets the number of property data rows fetched, converted and saved at a time.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately lower than the page size other property data migrations use: this migration deserializes a
+    /// whole block object graph per row, which is several times the size of the stored JSON it came from.
+    /// Overridable so tests can exercise the paging loop without creating thousands of rows.
+    /// </remarks>
+    internal virtual int PageSize => DefaultPageSize;
+
     protected override async Task MigrateAsync()
     {
+        // Give scope for the migration to complete within the command timeout, which may be necessary on large datasets.
+        EnsureLongCommandTimeout(Database);
+
         // gets filled by all registered ITypedSingleBlockListProcessor
         IEnumerable<string> propertyEditorAliases = _singleBlockListProcessor.GetSupportedPropertyEditorAliases();
 
@@ -196,33 +211,6 @@ public class MigrateSingleBlockList : AsyncMigrationBase
             "Found {blockListsConfiguredAsSingleCount} number of blockListConfigurations with UseSingleBlockMode set to true",
             blockListsConfiguredAsSingleCount);
 
-        // we want to batch actual update calls to the database, so we are grouping them by propertyEditorAlias
-        // and again by propertyType(dataType).
-        var updateItemsByPropertyEditorAlias = new Dictionary<string, Dictionary<IPropertyType, List<UpdateItem>>>();
-
-        // For each propertyEditor, collect and process all propertyTypes and their propertyData
-        foreach (var propertyEditorAlias in propertyEditorAliases)
-        {
-            if (relevantPropertyEditors.TryGetValue(propertyEditorAlias, out IPropertyType[]? propertyTypes) is false)
-            {
-                continue;
-            }
-
-            _logger.LogInformation(
-                "Migration starting for all properties of type: {propertyEditorAlias}",
-                propertyEditorAlias);
-            Dictionary<IPropertyType, List<UpdateItem>> updateItemsByPropertyType = await ProcessPropertyTypesAsync(propertyTypes, languagesById);
-            if (updateItemsByPropertyType.Count < 1)
-            {
-                _logger.LogInformation(
-                    "No properties have been found to migrate for {propertyEditorAlias}",
-                    propertyEditorAlias);
-                continue;
-            }
-
-            updateItemsByPropertyEditorAlias[propertyEditorAlias] = updateItemsByPropertyType;
-        }
-
         IDataType[] singleBlockListDataTypes = _blockListConfigurationCache.CachedDataTypes.ToArray();
         var singleBlockListDataTypeKeys = singleBlockListDataTypes.Select(dataType => dataType.Key).ToHashSet();
 
@@ -234,9 +222,45 @@ public class MigrateSingleBlockList : AsyncMigrationBase
         // written but not committed. Converting first means those lookups only ever read committed, pre-migration
         // state, and SingleBlockMigrationEditorAliasOverride is what routes the converted values to the single block
         // value editor regardless (https://github.com/umbraco/Umbraco-CMS/issues/23596).
-        foreach (string propertyEditorAlias in updateItemsByPropertyEditorAlias.Keys)
+        //
+        // Each page of property data is converted and saved before the next one is fetched, so that neither the
+        // fetched rows nor the values they deserialize to accumulate across the whole site
+        // (https://github.com/umbraco/Umbraco-CMS/issues/23766). That does not weaken the ordering above, which
+        // constrains when umbracoDataType is written, not umbracoPropertyData.
+        foreach (var propertyEditorAlias in propertyEditorAliases)
         {
-            if (await SavePropertyTypes(updateItemsByPropertyEditorAlias[propertyEditorAlias], singleBlockListDataTypeKeys))
+            if (relevantPropertyEditors.TryGetValue(propertyEditorAlias, out IPropertyType[]? propertyTypes) is false)
+            {
+                continue;
+            }
+
+            _logger.LogInformation(
+                "Migration starting for all properties of type: {propertyEditorAlias}",
+                propertyEditorAlias);
+
+            var success = true;
+            var foundPropertyData = false;
+
+            foreach (IPropertyType propertyType in propertyTypes)
+            {
+                (bool hadPropertyData, bool propertyTypeSucceeded) =
+                    await MigratePropertyTypeAsync(propertyType, languagesById, singleBlockListDataTypeKeys);
+
+                foundPropertyData |= hadPropertyData;
+                success &= propertyTypeSucceeded;
+            }
+
+            // Reported when no property type of this editor alias had any candidate property data at all - not
+            // when none of it needed converting, which is a normal outcome.
+            if (foundPropertyData is false)
+            {
+                _logger.LogInformation(
+                    "No properties have been found to migrate for {propertyEditorAlias}",
+                    propertyEditorAlias);
+                continue;
+            }
+
+            if (success)
             {
                 _logger.LogInformation(
                     "Migration succeeded for all properties of type: {propertyEditorAlias}",
@@ -270,130 +294,168 @@ WHERE nodeId IN (@0)";
         RebuildCache = true;
     }
 
-    private async Task<Dictionary<IPropertyType, List<UpdateItem>>> ProcessPropertyTypesAsync(IPropertyType[] propertyTypes, IDictionary<int, ILanguage> languagesById)
-    {
-        var updateItemsByPropertyType = new Dictionary<IPropertyType, List<UpdateItem>>();
-        foreach (IPropertyType propertyType in propertyTypes)
-        {
-            // make sure the passed in data is valid and can be processed
-            IDataType dataType = await _dataTypeService.GetAsync(propertyType.DataTypeKey)
-                                 ?? throw new InvalidOperationException("The data type could not be fetched.");
-            IDataValueEditor valueEditor = dataType.Editor?.GetValueEditor()
-                                           ?? throw new InvalidOperationException(
-                                               "The data type value editor could not be obtained.");
-
-            // fetch all the propertyData for the current propertyType
-            Sql<ISqlContext> sql = Sql()
-                .Select<PropertyDataDto>()
-                .From<PropertyDataDto>()
-                .InnerJoin<ContentVersionDto>()
-                .On<PropertyDataDto, ContentVersionDto>((propertyData, contentVersion) =>
-                    propertyData.VersionId == contentVersion.Id)
-                .LeftJoin<DocumentVersionDto>()
-                .On<ContentVersionDto, DocumentVersionDto>((contentVersion, documentVersion) =>
-                    contentVersion.Id == documentVersion.Id)
-                .Where<PropertyDataDto, ContentVersionDto, DocumentVersionDto>((propertyData, contentVersion, documentVersion) =>
-                    (contentVersion.Current == true || documentVersion.Published == true)
-                    && propertyData.PropertyTypeId == propertyType.Id);
-
-            List<PropertyDataDto> propertyDataDtos = await Database.FetchAsync<PropertyDataDto>(sql);
-            if (propertyDataDtos.Count < 1)
-            {
-                continue;
-            }
-
-            var updateItems = new List<UpdateItem>();
-
-            // process all the propertyData
-            // if none of the processors modify the value, the propertyData is skipped from being saved.
-            foreach (PropertyDataDto propertyDataDto in propertyDataDtos)
-            {
-                if (ProcessPropertyDataDto(propertyDataDto, propertyType, languagesById, valueEditor, out UpdateItem? updateItem) is false)
-                {
-                    continue;
-                }
-
-                updateItems.Add(updateItem!);
-            }
-
-            updateItemsByPropertyType[propertyType] = updateItems;
-        }
-
-        return updateItemsByPropertyType;
-    }
-
-    private async Task<bool> SavePropertyTypes(
-        IDictionary<IPropertyType, List<UpdateItem>> propertyTypes,
-        IReadOnlySet<Guid> singleBlockListDataTypeKeys)
-    {
-        var success = true;
-
-        foreach (IPropertyType propertyType in propertyTypes.Keys)
-        {
-            success &= await SavePropertyType(propertyType, propertyTypes[propertyType], singleBlockListDataTypeKeys);
-        }
-
-        return success;
-    }
-
-    private async Task<bool> SavePropertyType(
+    /// <summary>
+    /// Converts and saves the property data of a single property type, a page at a time.
+    /// </summary>
+    /// <returns>
+    /// Whether the property type had any candidate property data at all, and whether every value that needed
+    /// converting could be converted.
+    /// </returns>
+    private async Task<(bool HadPropertyData, bool Success)> MigratePropertyTypeAsync(
         IPropertyType propertyType,
-        List<UpdateItem> updateItems,
+        IDictionary<int, ILanguage> languagesById,
         IReadOnlySet<Guid> singleBlockListDataTypeKeys)
     {
-        // Both lookups already succeeded for this property type in ProcessPropertyTypesAsync, so neither can
-        // realistically fail here - the throws are only because the APIs are nullable.
+        // make sure the passed in data is valid and can be processed
         IDataType dataType = await _dataTypeService.GetAsync(propertyType.DataTypeKey)
                              ?? throw new InvalidOperationException("The data type could not be fetched.");
         IDataValueEditor valueEditor = dataType.Editor?.GetValueEditor()
                                        ?? throw new InvalidOperationException(
                                            "The data type value editor could not be obtained.");
 
-        // batch by datatype
-        var propertyDataDtos = updateItems.Select(item => item.PropertyDataDto).ToList();
+        var total = await Database.ExecuteScalarAsync<long>(
+            BuildPropertyDataSql(propertyType, lastId: 0, isCount: true));
+        if (total == 0)
+        {
+            return (false, true);
+        }
 
-        var updateBatch = propertyDataDtos.Select(propertyDataDto =>
-            UpdateBatch.For(propertyDataDto, Database.StartSnapshot(propertyDataDto))).ToList();
+        _logger.LogInformation(
+            "Migrating {PropertyDataCount} property data values for property {PropertyTypeAlias} ({PropertyTypeKey}) with property editor alias {PropertyEditorAlias}",
+            total,
+            propertyType.Alias,
+            propertyType.Key,
+            propertyType.PropertyEditorAlias);
 
-        var updatesToSkip = new ConcurrentBag<UpdateBatch<PropertyDataDto>>();
+        var pageSize = PageSize;
+        var progress = new MigrationProgress(total);
+        var success = true;
+        var converted = 0;
 
-        var total = updateBatch.Count;
-        var progress = 0;
+        // Keyset paging, restarting from zero for each property type: the page is the next rows by id rather than
+        // an offset into the result set, so every page costs the same and no row can be visited twice or skipped.
+        // That holds because nothing this migration writes touches a column the query filters or orders on - the
+        // batched update below only ever writes a non-empty textValue.
+        var lastId = 0;
+
+        while (true)
+        {
+            // SelectTop has to be applied last: SQL Server inserts "TOP n" after SELECT, SQLite appends "LIMIT n".
+            List<PropertyDataDto> page = await Database.FetchAsync<PropertyDataDto>(
+                BuildPropertyDataSql(propertyType, lastId).SelectTop(pageSize));
+
+            if (page.Count == 0)
+            {
+                break;
+            }
+
+            lastId = page[^1].Id;
+
+            (bool pageSucceeded, int pageConverted) = ConvertAndSavePage(
+                page, propertyType, languagesById, valueEditor, singleBlockListDataTypeKeys, progress);
+
+            success &= pageSucceeded;
+            converted += pageConverted;
+
+            if (page.Count < pageSize)
+            {
+                break;
+            }
+        }
+
+        if (converted > 0)
+        {
+            _logger.LogDebug(
+                "Migration completed for property type: {propertyTypeName} (id: {propertyTypeId}, key: {propertyTypeKey}, alias: {propertyTypeAlias}, editor alias: {propertyTypeEditorAlias}) - {updateCount} property DTO entries updated.",
+                propertyType.Name,
+                propertyType.Id,
+                propertyType.Key,
+                propertyType.Alias,
+                propertyType.PropertyEditorAlias,
+                converted);
+        }
+
+        return (true, success);
+    }
+
+    private Sql<ISqlContext> BuildPropertyDataSql(IPropertyType propertyType, int lastId, bool isCount = false)
+    {
+        Sql<ISqlContext> sql = (isCount ? Sql().SelectCount() : Sql().Select<PropertyDataDto>())
+            .From<PropertyDataDto>()
+            .InnerJoin<ContentVersionDto>()
+            .On<PropertyDataDto, ContentVersionDto>((propertyData, contentVersion) =>
+                propertyData.VersionId == contentVersion.Id)
+            .LeftJoin<DocumentVersionDto>()
+            .On<ContentVersionDto, DocumentVersionDto>((contentVersion, documentVersion) =>
+                contentVersion.Id == documentVersion.Id)
+            .Where<PropertyDataDto, ContentVersionDto, DocumentVersionDto>((propertyData, contentVersion, documentVersion) =>
+                (contentVersion.Current == true || documentVersion.Published == true)
+                && propertyData.PropertyTypeId == propertyType.Id
+                && propertyData.Id > lastId
+
+                // Block and rich text values are held as text, but PropertyDataDto.Value falls back to the varchar
+                // column before the text one, so a row only has nothing to convert when both are empty.
+                && (propertyData.TextValue != null || propertyData.VarcharValue != null));
+
+        return isCount
+            ? sql
+            : sql.OrderBy<PropertyDataDto>(propertyData => propertyData.Id);
+    }
+
+    /// <summary>
+    /// Converts a page of property data and persists whatever converted, leaving the rest of the rows untouched.
+    /// </summary>
+    private (bool Success, int Converted) ConvertAndSavePage(
+        List<PropertyDataDto> page,
+        IPropertyType propertyType,
+        IDictionary<int, ILanguage> languagesById,
+        IDataValueEditor valueEditor,
+        IReadOnlySet<Guid> singleBlockListDataTypeKeys,
+        MigrationProgress progress)
+    {
+        // The snapshot is taken before the value is converted, so the batched update only writes the columns that
+        // actually changed. Database belongs to the ambient scope and is not thread safe, so it is only touched
+        // here, never from the workers below.
+        var updateBatch = page
+            .Select(propertyDataDto => UpdateBatch.For(propertyDataDto, Database.StartSnapshot(propertyDataDto)))
+            .ToList();
+
+        // Keyed by property data id, which is unique within a page, so a worker's outcome can be looked up
+        // directly rather than by scanning the batch.
+        var results = new ConcurrentDictionary<int, ConversionResult>();
 
         void HandleUpdateBatch(UpdateBatch<PropertyDataDto> update)
         {
             using UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext();
 
-            // The override has to be applied here rather than around the whole loop: the parallelized path below
-            // deliberately does not flow the execution context, which is what an ambient AsyncLocal rides on.
-            using (SingleBlockMigrationEditorAliasOverride.For(singleBlockListDataTypeKeys))
+            var completed = Interlocked.Increment(ref progress.Processed);
+            if (completed % 100 == 0)
             {
-                var completed = Interlocked.Increment(ref progress);
-                if (completed % 100 == 0)
-                {
-                    _logger.LogInformation("  - finished {Progress} of {Total} properties", completed, total);
-                }
-
-                if (FinalizeUpdateItem(updateItems.First(item => Equals(item.PropertyDataDto, update.Poco)), valueEditor) is false)
-                {
-                    updatesToSkip.Add(update);
-                }
+                _logger.LogInformation("  - finished {Progress} of {Total} properties", completed, progress.Total);
             }
+
+            results[update.Poco.Id] = ConvertPropertyDataDto(
+                update.Poco, propertyType, languagesById, valueEditor, singleBlockListDataTypeKeys);
         }
 
         RunUpdateBatch(updateBatch, HandleUpdateBatch);
 
-        var success = true;
-        if (updatesToSkip.IsEmpty is false)
+        var refused = 0;
+        updateBatch.RemoveAll(update =>
         {
-            success = false;
-            updateBatch.RemoveAll(updatesToSkip.Contains);
-        }
+            ConversionResult result = results[update.Poco.Id];
+            if (result is ConversionResult.Refused)
+            {
+                refused++;
+            }
 
-        if (updateBatch.Any() is false)
+            return result is not ConversionResult.Converted;
+        });
+
+        if (updateBatch.Count == 0)
         {
             _logger.LogDebug("  - no properties to convert, continuing");
-            return success;
+            return (refused == 0, 0);
         }
 
         _logger.LogInformation("  - {totalConverted} properties converted, saving...", updateBatch.Count);
@@ -404,16 +466,7 @@ WHERE nodeId IN (@0)";
                 $"The database batch update was supposed to update {updateBatch.Count} property DTO entries, but it updated {result} entries.");
         }
 
-        _logger.LogDebug(
-            "Migration completed for property type: {propertyTypeName} (id: {propertyTypeId}, key: {propertyTypeKey}, alias: {propertyTypeAlias}, editor alias: {propertyTypeEditorAlias}) - {updateCount} property DTO entries updated.",
-            propertyType.Name,
-            propertyType.Id,
-            propertyType.Key,
-            propertyType.Alias,
-            propertyType.PropertyEditorAlias,
-            result);
-
-        return success;
+        return (refused == 0, updateBatch.Count);
     }
 
     private void RunUpdateBatch(
@@ -451,12 +504,15 @@ WHERE nodeId IN (@0)";
         }).GetAwaiter().GetResult();
     }
 
-    private bool ProcessPropertyDataDto(
+    /// <summary>
+    /// Converts a single property data value, setting the converted value on the DTO ready to be persisted.
+    /// </summary>
+    private ConversionResult ConvertPropertyDataDto(
         PropertyDataDto propertyDataDto,
         IPropertyType propertyType,
         IDictionary<int, ILanguage> languagesById,
         IDataValueEditor valueEditor,
-        out UpdateItem? updateItem)
+        IReadOnlySet<Guid> singleBlockListDataTypeKeys)
     {
         var cultureResult = PropertyDataCultureResolver.ResolveCulture(propertyType, propertyDataDto.LanguageId, languagesById);
         if (cultureResult.ShouldSkip)
@@ -469,8 +525,7 @@ WHERE nodeId IN (@0)";
                 propertyType.Id,
                 propertyType.Key,
                 propertyType.Alias);
-            updateItem = null;
-            return false;
+            return ConversionResult.Skipped;
         }
 
         var culture = cultureResult.Culture;
@@ -478,6 +533,9 @@ WHERE nodeId IN (@0)";
         // create a fake property to be able to get a typed value and run it through the processors.
         var segment = propertyType.VariesBySegment() ? propertyDataDto.Segment : null;
         var property = PropertyDataCultureResolver.CreateMigrationProperty(propertyType, propertyDataDto.Value, culture, segment);
+
+        // No editor alias override around this: the value is read as it is still stored, which is exactly what the
+        // property type's own value editor is for.
         var toEditorValue = valueEditor.ToEditor(property, culture, segment);
 
         if (TryTransformValue(toEditorValue, property, out var updatedValue) is false)
@@ -489,12 +547,18 @@ WHERE nodeId IN (@0)";
                 propertyType.Id,
                 propertyType.Key,
                 propertyType.Alias);
-            updateItem = null;
-            return false;
+            return ConversionResult.Skipped;
         }
 
-        updateItem = new UpdateItem(propertyDataDto, propertyType, updatedValue);
-        return true;
+        // The override only affects re-serialization, and it has to be applied per value rather than around the
+        // loop: the parallelized path deliberately does not flow the execution context, which is what an ambient
+        // AsyncLocal rides on.
+        using (SingleBlockMigrationEditorAliasOverride.For(singleBlockListDataTypeKeys))
+        {
+            return FinalizeUpdateItem(new UpdateItem(propertyDataDto, propertyType, updatedValue), valueEditor)
+                ? ConversionResult.Converted
+                : ConversionResult.Refused;
+        }
     }
 
     /// <summary>
@@ -593,6 +657,37 @@ WHERE nodeId IN (@0)";
 
         value = toEditorValue;
         return hasChanged;
+    }
+
+    private enum ConversionResult
+    {
+        /// <summary>There was nothing to convert. The row is left untouched and the migration still succeeds.</summary>
+        Skipped,
+
+        /// <summary>The converted value has been set on the DTO and is ready to be persisted.</summary>
+        Converted,
+
+        /// <summary>
+        /// The value could not be converted safely. The row is left untouched and the migration of its property
+        /// editor alias is reported as failed.
+        /// </summary>
+        Refused,
+    }
+
+    /// <summary>
+    /// Tracks how far through a property type's property data the migration has got, across all of its pages.
+    /// </summary>
+    private sealed class MigrationProgress
+    {
+        public MigrationProgress(long total) => Total = total;
+
+        public long Total { get; }
+
+        /// <summary>
+        /// The number of property data values processed so far. A field rather than a property as it is
+        /// incremented with <see cref="Interlocked" />.
+        /// </summary>
+        public int Processed;
     }
 
     private class UpdateItem

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockListTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockListTests.cs
@@ -2,12 +2,15 @@
 // See LICENSE for more details.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NPoco;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Cache.PropertyEditors;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -16,6 +19,7 @@ using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.Migrations;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_18_0_0;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_18_0_0.SingleBlockList;
@@ -42,6 +46,8 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
     private const string TextPropertyAlias = "text";
     private const string InnerTextValue = "The inner text";
     private const string OuterTextValue = "The outer text";
+
+    private readonly RecordingLogger _migrationLogger = new();
 
     private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
 
@@ -70,6 +76,10 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
             new DeepCloneAppCache(new ObjectCacheAppCache()),
             NoAppCache.Instance,
             new IsolatedCaches(_ => new DeepCloneAppCache(new ObjectCacheAppCache()))));
+
+        // The harness logger factory is registered after this runs and defaults to NullLoggerFactory, so the
+        // closed generic the migration is constructed with is the seam to record what it logged.
+        builder.Services.AddUnique<ILogger<MigrateSingleBlockList>>(_ => _migrationLogger);
     }
 
     [Test]
@@ -221,6 +231,145 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
         Assert.That(outerBlock.Values.Select(x => x.Alias), Does.Contain(NestedPropertyAlias));
     }
 
+    [Test]
+    public async Task Can_Migrate_All_Property_Data_Rows_When_They_Span_Multiple_Pages()
+    {
+        _migrationLogger.Clear();
+
+        TestSchema schema = await CreateSchemaAsync();
+
+        // The single block mode Block List is the document type's own property, so each content item contributes
+        // exactly one property data row and the page boundaries are predictable.
+        IContentType pageContentType = await CreateContentTypeAsync(
+            "topLevelPage",
+            OuterPropertyAlias,
+            schema.NestedDataType.Id,
+            Constants.PropertyEditors.Aliases.BlockList);
+
+        var contentByInnerBlockKey = new Dictionary<Guid, Content>();
+        for (var i = 0; i < 5; i++)
+        {
+            var innerBlockKey = Guid.NewGuid();
+            contentByInnerBlockKey[innerBlockKey] = SaveContent(
+                pageContentType,
+                $"Top level page {i}",
+                BuildNestedSingleBlockListJson(schema, innerBlockKey));
+        }
+
+        // A row holding no string value at all must not be fetched, let alone converted.
+        Content valuelessContent = SaveContent(
+            pageContentType,
+            "Top level page without a value",
+            BuildNestedSingleBlockListJson(schema, Guid.NewGuid()));
+        await ClearStoredValueAsync(valuelessContent.Id, OuterPropertyAlias);
+
+        await ExecuteMigrationAsync<PageSizeOfTwoMigrateSingleBlockList>();
+
+        foreach ((Guid innerBlockKey, Content content) in contentByInnerBlockKey)
+        {
+            var storedValue = await GetStoredValueAsync(content.Id, OuterPropertyAlias);
+            Assert.That(storedValue, Is.Not.Null.And.Not.Empty);
+
+            AssertIsInnerSingleBlock(schema, JsonSerializer.Deserialize<SingleBlockValue>(storedValue!), innerBlockKey);
+        }
+
+        Assert.That(
+            await GetStoredValueAsync(valuelessContent.Id, OuterPropertyAlias),
+            Is.Null,
+            "A row with no stored value was rewritten by the migration.");
+
+        // Five of the six rows, so the valueless one was excluded by the query rather than fetched and skipped.
+        Assert.That(
+            _migrationLogger.MessagesMatching("property data values for property"),
+            Has.One.StartsWith("Migrating 5 property data values"));
+
+        // Five convertible rows at two per page: the work really was paged, rather than fetched in one go.
+        Assert.That(
+            _migrationLogger.MessagesMatching("properties converted, saving"),
+            Is.EqualTo(new[]
+            {
+                "  - 2 properties converted, saving...",
+                "  - 2 properties converted, saving...",
+                "  - 1 properties converted, saving...",
+            }));
+    }
+
+    [Test]
+    public async Task Can_Migrate_Property_Data_Of_Multiple_Property_Types_Whose_Rows_Interleave()
+    {
+        TestSchema schema = await CreateSchemaAsync();
+
+        // A second document type sharing the same container data type, so both contribute property data under the
+        // same property editor alias but under a different property type.
+        IContentType secondPageContentType = await CreateContentTypeAsync(
+            "secondPage",
+            OuterPropertyAlias,
+            schema.ContainerDataType.Id,
+            schema.ContainerDataType.EditorAlias);
+
+        // Saved alternately so the two property types' property data rows interleave by id. That is what makes this
+        // catch a paging cursor that is not reset between property types: were each property type's rows contiguous,
+        // the second type's rows would all sit above the first type's final cursor and the bug would be invisible.
+        var expected = new List<(Content Content, Guid OuterBlockKey, Guid InnerBlockKey)>();
+        for (var i = 0; i < 4; i++)
+        {
+            var outerBlockKey = Guid.NewGuid();
+            var innerBlockKey = Guid.NewGuid();
+
+            Content content = SaveContent(
+                i % 2 == 0 ? schema.PageContentType : secondPageContentType,
+                $"Page {i}",
+                BuildOuterValueJson(schema, outerBlockKey, BuildNestedSingleBlockListJson(schema, innerBlockKey)));
+
+            expected.Add((content, outerBlockKey, innerBlockKey));
+        }
+
+        await ExecuteMigrationAsync<PageSizeOfTwoMigrateSingleBlockList>();
+
+        foreach ((Content content, Guid outerBlockKey, Guid innerBlockKey) in expected)
+        {
+            BlockItemData outerBlock = await GetStoredOuterBlockAsync(schema, content.Id, outerBlockKey);
+            AssertNestedValueIsConvertedSingleBlock(schema, outerBlock, innerBlockKey);
+        }
+    }
+
+    [Test]
+    public async Task Can_Migrate_A_Page_Holding_Both_Convertible_And_Unconvertible_Values()
+    {
+        _migrationLogger.Clear();
+
+        TestSchema schema = await CreateSchemaAsync();
+
+        var convertibleOuterBlockKey = Guid.NewGuid();
+        var innerBlockKey = Guid.NewGuid();
+        Content convertible = SaveContent(
+            schema,
+            BuildOuterValueJson(
+                schema,
+                convertibleOuterBlockKey,
+                BuildNestedSingleBlockListJson(schema, innerBlockKey)));
+
+        // Shares a page with the value above, and holds nothing to convert.
+        var emptyOuterBlockKey = Guid.NewGuid();
+        Content empty = SaveContent(
+            schema,
+            BuildOuterValueJson(schema, emptyOuterBlockKey, JsonSerializer.Serialize(new BlockListValue())));
+        var emptyValueBeforeMigration = await GetStoredValueAsync(empty.Id, OuterPropertyAlias);
+
+        await ExecuteMigrationAsync<PageSizeOfTwoMigrateSingleBlockList>();
+
+        BlockItemData convertedOuterBlock = await GetStoredOuterBlockAsync(schema, convertible.Id, convertibleOuterBlockKey);
+        AssertNestedValueIsConvertedSingleBlock(schema, convertedOuterBlock, innerBlockKey);
+
+        Assert.That(
+            await GetStoredValueAsync(empty.Id, OuterPropertyAlias),
+            Is.EqualTo(emptyValueBeforeMigration),
+            "A value with nothing to convert was rewritten.");
+
+        // Having nothing to convert is a normal outcome, and must not be reported as a failed conversion.
+        Assert.That(_migrationLogger.MessagesAtLevel(LogLevel.Error), Is.Empty);
+    }
+
     private async Task<TestSchema> CreateSchemaAsync(
         ContainerEditor containerEditor = ContainerEditor.BlockList,
         bool addIntermediateLevel = false)
@@ -268,6 +417,7 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
             intermediateElementType,
             outerElementType,
             nestedDataType,
+            containerDataType,
             pageContentType);
     }
 
@@ -550,11 +700,14 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
         return content;
     }
 
-    private async Task ExecuteMigrationAsync()
+    private Task ExecuteMigrationAsync() => ExecuteMigrationAsync<MigrateSingleBlockList>();
+
+    private async Task ExecuteMigrationAsync<TMigration>()
+        where TMigration : AsyncMigrationBase
     {
         MigrationPlan plan = new MigrationPlan(nameof(MigrateSingleBlockListTests))
             .From(string.Empty)
-            .To<MigrateSingleBlockList>("done");
+            .To<TMigration>("done");
 
         var executor = new MigrationPlanExecutor(
             GetRequiredService<ICoreScopeProvider>(),
@@ -614,6 +767,36 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
         return outerValue!.ContentData.SingleOrDefault(x => x.Key == outerBlockKey)
                ?? throw new AssertionException(
                    $"The block {outerBlockKey} is no longer present in the migrated value: {storedValue}");
+    }
+
+    /// <summary>
+    /// Nulls out a stored property value directly, to produce a row that holds nothing the migration could convert.
+    /// </summary>
+    private async Task ClearStoredValueAsync(int contentId, string propertyAlias)
+    {
+        using Cms.Infrastructure.Scoping.IScope scope = ScopeProvider.CreateScope();
+
+        // Built rather than hand written, so the reserved word in "umbracoContentVersion.current" is quoted the way
+        // the configured provider needs it.
+        Sql<ISqlContext> selectSql = scope.Database.SqlContext.Sql()
+            .Select<PropertyDataDto>(propertyData => propertyData.Id)
+            .From<PropertyDataDto>()
+            .InnerJoin<PropertyTypeDto>()
+            .On<PropertyDataDto, PropertyTypeDto>(pd => pd.PropertyTypeId, pt => pt.Id)
+            .InnerJoin<ContentVersionDto>()
+            .On<PropertyDataDto, ContentVersionDto>(pd => pd.VersionId, cv => cv.Id)
+            .Where<PropertyTypeDto>(pt => pt.Alias == propertyAlias)
+            .Where<ContentVersionDto>(cv => cv.NodeId == contentId && cv.Current);
+
+        var propertyDataId = (await scope.Database.FetchAsync<int>(selectSql)).Single();
+
+        var affected = await scope.Database.ExecuteAsync(
+            "UPDATE umbracoPropertyData SET textValue = NULL, varcharValue = NULL WHERE id = @0",
+            propertyDataId);
+
+        Assert.That(affected, Is.EqualTo(1));
+
+        scope.Complete();
     }
 
     private async Task<string?> GetStoredValueAsync(int contentId, string propertyAlias)
@@ -694,7 +877,97 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
         IContentType? IntermediateElementType,
         IContentType OuterElementType,
         IDataType NestedDataType,
+        IDataType ContainerDataType,
         IContentType PageContentType);
+
+    /// <summary>
+    /// Runs the migration two property data rows at a time, so the paging loop can be exercised with a handful of
+    /// content items rather than the thousands the production page size would need.
+    /// </summary>
+    /// <remarks>
+    /// Migrations are activated with <see cref="ActivatorUtilities" />, which cannot use an inherited constructor,
+    /// hence the forwarding one. Only one is declared so the activation stays unambiguous.
+    /// </remarks>
+#pragma warning disable CS0618 // Type or member is obsolete
+    private sealed class PageSizeOfTwoMigrateSingleBlockList : MigrateSingleBlockList
+    {
+        public PageSizeOfTwoMigrateSingleBlockList(IMigrationContext context, IServiceProvider serviceProvider)
+            : base(
+                context,
+                serviceProvider.GetRequiredService<IUmbracoContextFactory>(),
+                serviceProvider.GetRequiredService<ILanguageService>(),
+                serviceProvider.GetRequiredService<IContentTypeService>(),
+                serviceProvider.GetRequiredService<IMediaTypeService>(),
+                serviceProvider.GetRequiredService<IDataTypeService>(),
+                serviceProvider.GetRequiredService<ILogger<MigrateSingleBlockList>>(),
+                serviceProvider.GetRequiredService<ICoreScopeProvider>(),
+                serviceProvider.GetRequiredService<SingleBlockListProcessor>(),
+                serviceProvider.GetRequiredService<IJsonSerializer>(),
+                serviceProvider.GetRequiredService<SingleBlockListConfigurationCache>(),
+                serviceProvider.GetRequiredService<IDataValueEditorFactory>(),
+                serviceProvider.GetRequiredService<IIOHelper>(),
+                serviceProvider.GetRequiredService<IBlockValuePropertyIndexValueFactory>(),
+                serviceProvider.GetRequiredService<IBlockEditorElementTypeCache>(),
+                serviceProvider.GetRequiredService<AppCaches>(),
+                serviceProvider.GetRequiredService<IDataTypeConfigurationCache>())
+        {
+        }
+
+        internal override int PageSize => 2;
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    /// <summary>
+    /// Captures what the migration logged, which is the only place some of its behaviour is observable - the page
+    /// boundaries it actually used, and whether a value was skipped or refused.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger<MigrateSingleBlockList>
+    {
+        private readonly List<(LogLevel Level, string Message)> _entries = new();
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (_entries)
+            {
+                _entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_entries)
+            {
+                _entries.Clear();
+            }
+        }
+
+        public IReadOnlyList<string> MessagesMatching(string fragment)
+        {
+            lock (_entries)
+            {
+                return _entries.Where(x => x.Message.Contains(fragment)).Select(x => x.Message).ToArray();
+            }
+        }
+
+        public IReadOnlyList<string> MessagesAtLevel(LogLevel level)
+        {
+            lock (_entries)
+            {
+                return _entries.Where(x => x.Level == level).Select(x => x.Message).ToArray();
+            }
+        }
+    }
 
     private sealed class NoopDatabaseCacheRebuilder : IDatabaseCacheRebuilder
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockListTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockListTests.cs
@@ -952,7 +952,7 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
             }
         }
 
-        public IReadOnlyList<string> MessagesMatching(string fragment)
+        public string[] MessagesMatching(string fragment)
         {
             lock (_entries)
             {
@@ -960,7 +960,7 @@ internal sealed class MigrateSingleBlockListTests : UmbracoIntegrationTest
             }
         }
 
-        public IReadOnlyList<string> MessagesAtLevel(LogLevel level)
+        public string[] MessagesAtLevel(LogLevel level)
         {
             lock (_entries)
             {


### PR DESCRIPTION
## Description

#23766 reports an out of memory exception when attempting to run the single block migration on upgrade to Umbraco 18.

Fixes #23766

### The problem

`V_18_0_0.MigrateSingleBlockList` fetched **every** current-or-published `umbracoPropertyData` row for a property type in a single `FetchAsync`, and accumulated the converted value of every row, for every property editor alias, before persisting any of it. On a large site that means the deserialised block object graph of every convertible value on the site is held live at once.

The reported `OutOfMemoryException` lands inside the unbounded fetch itself (`TdsParser.TryReadSqlStringValue` → `NPoco.Database.ReadAsync`), with ~500k property data rows on a small App Service instance.

### The change

**Page the work.** Each property type's rows are now fetched, converted and saved a page at a time (1000), so peak memory scales with the page size rather than the site.

**Merge the two per-row phases** into one call inside the already-parallelised worker. This:
- bounds live object graphs to the degree of parallelism rather than the page size (so the fix doesn't just become the same OOM one page later);
- parallelises the `ToEditor` deserialisation, which was previously serial while only the re-serialisation was parallel;
- removes a quadratic `updateItems.First(...)` scan that ran inside the parallel worker.

**Two smaller changes:** rows holding no string value at all are excluded in the query (both `textValue` and `varcharValue` are checked, because `PropertyDataDto.Value` prefers the varchar column), and `EnsureLongCommandTimeout` is now called as six other long-running migrations do.

## Testing

The migration is commented out of the v17 plan (`UmbracoPlan.cs`, `// TODO (V18): Enable on 18 branch`), so on this branch it is only exercised by its tests. A companion PR #23778 against `main` is where the reporter's upgrade is actually fixed.