### PR TITLE
Scoping: Correct WriteLock/ReadLock return behaviour when TimeSpan is passed in

### DIFF
--- a/src/Umbraco.Core/Scoping/CoreScope.cs
+++ b/src/Umbraco.Core/Scoping/CoreScope.cs
@@ -265,7 +265,7 @@ public class CoreScope : ICoreScope
     public void EagerReadLock(TimeSpan timeout, int lockId) => Locks.EagerReadLock(InstanceId, timeout, lockId);
 
     /// <inheritdoc />
-    public void EagerReadLock(params int[] lockIds) => Locks.EagerReadLock(InstanceId, TimeSpan.Zero, lockIds);
+    public void EagerReadLock(params int[] lockIds) => Locks.EagerReadLock(InstanceId, null, lockIds);
 
     /// <summary>
     ///     Disposes the scope, handling file systems, notifications, and parent scope completion.

--- a/src/Umbraco.Core/Scoping/CoreScope.cs
+++ b/src/Umbraco.Core/Scoping/CoreScope.cs
@@ -250,10 +250,10 @@ public class CoreScope : ICoreScope
     public void WriteLock(params int[] lockIds) => Locks.WriteLock(InstanceId, null, lockIds);
 
     /// <inheritdoc />
-    public void WriteLock(TimeSpan timeout, int lockId) => Locks.ReadLock(InstanceId, timeout, lockId);
+    public void WriteLock(TimeSpan timeout, int lockId) => Locks.WriteLock(InstanceId, timeout, lockId);
 
     /// <inheritdoc />
-    public void ReadLock(TimeSpan timeout, int lockId) => Locks.WriteLock(InstanceId, timeout, lockId);
+    public void ReadLock(TimeSpan timeout, int lockId) => Locks.ReadLock(InstanceId, timeout, lockId);
 
     /// <inheritdoc />
     public void EagerWriteLock(params int[] lockIds) => Locks.EagerWriteLock(InstanceId, null, lockIds);

--- a/src/Umbraco.Core/Scoping/ICoreScope.cs
+++ b/src/Umbraco.Core/Scoping/ICoreScope.cs
@@ -14,15 +14,15 @@ public interface ICoreScope : IDisposable, IInstanceIdentifiable
     /// <remarks>
     /// A zero represents a root scope, any value greater than zero represents a child scope.
     /// </remarks>
-    public int Depth => -1;
+    int Depth => -1;
 
     /// <summary>
     ///     Gets the locking mechanism for this scope.
     /// </summary>
-    public ILockingMechanism Locks { get; }
+    ILockingMechanism Locks { get; }
 
     /// <summary>
-    ///     Gets the scope notification publisher
+    ///     Gets the scope notification publisher.
     /// </summary>
     IScopedNotificationPublisher Notifications { get; }
 
@@ -58,14 +58,14 @@ public interface ICoreScope : IDisposable, IInstanceIdentifiable
     /// <summary>
     ///     Write-locks some lock objects.
     /// </summary>
-    /// <param name="timeout">The database timeout in milliseconds</param>
+    /// <param name="timeout">The database timeout.</param>
     /// <param name="lockId">The lock object identifier.</param>
     void WriteLock(TimeSpan timeout, int lockId);
 
     /// <summary>
     ///     Read-locks some lock objects.
     /// </summary>
-    /// <param name="timeout">The database timeout in milliseconds</param>
+    /// <param name="timeout">The database timeout.</param>
     /// <param name="lockId">The lock object identifier.</param>
     void ReadLock(TimeSpan timeout, int lockId);
 

--- a/src/Umbraco.Infrastructure/Scoping/LegacyIScope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/LegacyIScope.cs
@@ -76,14 +76,14 @@ public interface IScope : Infrastructure.Scoping.IScope
     /// <summary>
     /// Write-locks some lock objects.
     /// </summary>
-    /// <param name="timeout">The database timeout in milliseconds</param>
+    /// <param name="timeout">The database timeout.</param>
     /// <param name="lockId">The lock object identifier.</param>
     new void WriteLock(TimeSpan timeout, int lockId);
 
     /// <summary>
     /// Read-locks some lock objects.
     /// </summary>
-    /// <param name="timeout">The database timeout in milliseconds</param>
+    /// <param name="timeout">The database timeout.</param>
     /// <param name="lockId">The lock object identifier.</param>
     new void ReadLock(TimeSpan timeout, int lockId);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
@@ -263,8 +263,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
                 outerScope.Complete();
             }
 
-            syntaxProviderMock.Verify(x => x.WriteLock(Constants.Locks.Domains, It.IsAny<TimeSpan?>()), Times.Once);
-            syntaxProviderMock.Verify(x => x.WriteLock(Constants.Locks.Languages, It.IsAny<TimeSpan?>()), Times.Once);
+            syntaxProviderMock.Verify(x => x.WriteLock(Constants.Locks.Domains, timeout), Times.Once);
+            syntaxProviderMock.Verify(x => x.WriteLock(Constants.Locks.Languages, timeout), Times.Once);
         }
 
         [Test]
@@ -330,8 +330,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
                 outerScope.Complete();
             }
 
-            syntaxProviderMock.Verify(x => x.ReadLock(Constants.Locks.Domains, It.IsAny<TimeSpan?>()), Times.Once);
-            syntaxProviderMock.Verify(x => x.ReadLock(Constants.Locks.Languages, It.IsAny<TimeSpan?>()), Times.Once);
+            syntaxProviderMock.Verify(x => x.ReadLock(Constants.Locks.Domains, timeOut), Times.Once);
+            syntaxProviderMock.Verify(x => x.ReadLock(Constants.Locks.Languages, timeOut), Times.Once);
         }
 
         [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
@@ -335,6 +335,64 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
         }
 
         [Test]
+        public void WriteLock_With_Timeout_Acquires_A_Write_Lock()
+        {
+            var scopeProvider = GetScopeProvider(out var lockingMechanismMock);
+            var timeout = TimeSpan.FromMilliseconds(10000);
+
+            using (var scope = (Scope)scopeProvider.CreateScope())
+            {
+                scope.WriteLock(timeout, Constants.Locks.Domains);
+
+                // The lock is lazy, so it only reaches the locking mechanism once the locks are ensured.
+                scope.GetWriteLocks();
+
+                scope.Complete();
+            }
+
+            lockingMechanismMock.Verify(x => x.WriteLock(Constants.Locks.Domains, timeout), Times.Once);
+            lockingMechanismMock.Verify(x => x.ReadLock(Constants.Locks.Domains, It.IsAny<TimeSpan?>()), Times.Never);
+        }
+
+        [Test]
+        public void ReadLock_With_Timeout_Acquires_A_Read_Lock()
+        {
+            var scopeProvider = GetScopeProvider(out var lockingMechanismMock);
+            var timeout = TimeSpan.FromMilliseconds(10000);
+
+            using (var scope = (Scope)scopeProvider.CreateScope())
+            {
+                scope.ReadLock(timeout, Constants.Locks.Domains);
+
+                // The lock is lazy, so it only reaches the locking mechanism once the locks are ensured.
+                scope.GetReadLocks();
+
+                scope.Complete();
+            }
+
+            lockingMechanismMock.Verify(x => x.ReadLock(Constants.Locks.Domains, timeout), Times.Once);
+            lockingMechanismMock.Verify(x => x.WriteLock(Constants.Locks.Domains, It.IsAny<TimeSpan?>()), Times.Never);
+        }
+
+        [Test]
+        public void EagerLock_Without_Timeout_Leaves_Timeout_Unspecified()
+        {
+            var scopeProvider = GetScopeProvider(out var lockingMechanismMock);
+
+            using (var scope = (Scope)scopeProvider.CreateScope())
+            {
+                scope.EagerReadLock(Constants.Locks.Domains);
+                scope.EagerWriteLock(Constants.Locks.Languages);
+                scope.Complete();
+            }
+
+            // A null timeout lets the distributed locking mechanism apply its configured default;
+            // passing TimeSpan.Zero instead would mean no wait at all.
+            lockingMechanismMock.Verify(x => x.ReadLock(Constants.Locks.Domains, null), Times.Once);
+            lockingMechanismMock.Verify(x => x.WriteLock(Constants.Locks.Languages, null), Times.Once);
+        }
+
+        [Test]
         public void ReadLock_Acquired_Only_Once_When_InnerScope_Disposed()
         {
             var scopeProvider = GetScopeProvider(out var syntaxProviderMock);


### PR DESCRIPTION
Update `CoreScope` so that `ReadLock` requests always returns a `ReadLock` and `WriteLock` always returns a `WriteLock`

see description at: https://github.com/umbraco/Umbraco-CMS/discussions/23772 & associated write-lock issue https://github.com/umbraco/Umbraco-CMS/issues/14195

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

### Description

`ReadLock` sometimes incorrectly returned a `WriteLock`, and `WriteLock` sometimes incorrectly returned a `ReadLock` in `CoreScope.cs`. This PR inverts that behaviour.

Shouldn't be a breaking change, because the only path into this code is already marked as `Obsolete` under a warning.

Previous PR here: https://github.com/umbraco/Umbraco-CMS/pull/23774, needed to close it as it was from the `etive-mor` organisation, and maintainers couldn't make edits there. 

<!-- Thanks for contributing to Umbraco CMS! -->
