### PR TITLE
Content Editing: Map publish failure statuses in SaveAndPublish (closes #23781)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentControllerBase.cs
@@ -14,7 +14,8 @@ namespace Umbraco.Cms.Api.Management.Controllers.Content;
 public abstract class ContentControllerBase : ManagementApiControllerBase
 {
     protected IActionResult ContentEditingOperationStatusResult(ContentEditingOperationStatus status)
-        => OperationStatusResult(status, problemDetailsBuilder => status switch
+        => ContentEditingPublishOperationStatusResult(status)
+           ?? OperationStatusResult(status, problemDetailsBuilder => status switch
         {
             ContentEditingOperationStatus.CancelledByNotification => BadRequest(problemDetailsBuilder
                 .WithTitle("Cancelled by notification")
@@ -97,46 +98,6 @@ public abstract class ContentControllerBase : ManagementApiControllerBase
                 .WithTitle("Cannot move a referenced content item to the recycle bin")
                 .WithDetail("Cannot move a referenced content item to the recycle bin, while the setting ContentSettings.DisableDeleteWhenReferenced is enabled.")
                 .Build()),
-            ContentEditingOperationStatus.AwaitingRelease => BadRequest(problemDetailsBuilder
-                .WithTitle("Content is awaiting release")
-                .WithDetail("The content item could not be published because it is scheduled for release.")
-                .Build()),
-            ContentEditingOperationStatus.CultureAwaitingRelease => BadRequest(problemDetailsBuilder
-                .WithTitle("Culture is awaiting release")
-                .WithDetail("The content item could not be published because one or more cultures are scheduled for release.")
-                .Build()),
-            ContentEditingOperationStatus.HasExpired => BadRequest(problemDetailsBuilder
-                .WithTitle("Content has expired")
-                .WithDetail("The content item could not be published because it has expired.")
-                .Build()),
-            ContentEditingOperationStatus.CultureHasExpired => BadRequest(problemDetailsBuilder
-                .WithTitle("Culture has expired")
-                .WithDetail("The content item could not be published because one or more cultures have expired.")
-                .Build()),
-            ContentEditingOperationStatus.PathNotPublished => BadRequest(problemDetailsBuilder
-                .WithTitle("Path not published")
-                .WithDetail("The content item could not be published because its parent is not published.")
-                .Build()),
-            ContentEditingOperationStatus.ContentInvalid => BadRequest(problemDetailsBuilder
-                .WithTitle("Content is invalid")
-                .WithDetail("The content item could not be published because it is invalid.")
-                .Build()),
-            ContentEditingOperationStatus.NothingToPublish => BadRequest(problemDetailsBuilder
-                .WithTitle("Nothing to publish")
-                .WithDetail("The content item has no publishable values.")
-                .Build()),
-            ContentEditingOperationStatus.MandatoryCultureMissing => BadRequest(problemDetailsBuilder
-                .WithTitle("Mandatory culture missing")
-                .WithDetail("The content item could not be published because a mandatory culture is missing.")
-                .Build()),
-            ContentEditingOperationStatus.ConcurrencyViolation => Conflict(problemDetailsBuilder
-                .WithTitle("Concurrency violation")
-                .WithDetail("The content item was modified by another operation.")
-                .Build()),
-            ContentEditingOperationStatus.UnsavedChanges => BadRequest(problemDetailsBuilder
-                .WithTitle("Unsaved changes")
-                .WithDetail("The content item has unsaved changes that must be saved before publishing.")
-                .Build()),
             ContentEditingOperationStatus.Unknown => StatusCode(
                 StatusCodes.Status500InternalServerError,
                 problemDetailsBuilder
@@ -146,6 +107,62 @@ public abstract class ContentControllerBase : ManagementApiControllerBase
                 .WithTitle("Unknown content operation status.")
                 .Build()),
         });
+
+    private IActionResult? ContentEditingPublishOperationStatusResult(ContentEditingOperationStatus status)
+        => status switch
+        {
+            ContentEditingOperationStatus.AwaitingRelease => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Content is awaiting release")
+                    .WithDetail("The content item could not be published because it is scheduled for release.")
+                    .Build())),
+            ContentEditingOperationStatus.CultureAwaitingRelease => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Culture is awaiting release")
+                    .WithDetail("The content item could not be published because one or more cultures are scheduled for release.")
+                    .Build())),
+            ContentEditingOperationStatus.HasExpired => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Content has expired")
+                    .WithDetail("The content item could not be published because it has expired.")
+                    .Build())),
+            ContentEditingOperationStatus.CultureHasExpired => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Culture has expired")
+                    .WithDetail("The content item could not be published because one or more cultures have expired.")
+                    .Build())),
+            ContentEditingOperationStatus.PathNotPublished => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Path not published")
+                    .WithDetail("The content item could not be published because its parent is not published.")
+                    .Build())),
+            ContentEditingOperationStatus.ContentInvalid => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Content is invalid")
+                    .WithDetail("The content item could not be published because it is invalid.")
+                    .Build())),
+            ContentEditingOperationStatus.NothingToPublish => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Nothing to publish")
+                    .WithDetail("The content item has no publishable values.")
+                    .Build())),
+            ContentEditingOperationStatus.MandatoryCultureMissing => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Mandatory culture missing")
+                    .WithDetail("The content item could not be published because a mandatory culture is missing.")
+                    .Build())),
+            ContentEditingOperationStatus.ConcurrencyViolation => OperationStatusResult(status, problemDetailsBuilder =>
+                Conflict(problemDetailsBuilder
+                    .WithTitle("Concurrency violation")
+                    .WithDetail("The content item was modified by another operation.")
+                    .Build())),
+            ContentEditingOperationStatus.UnsavedChanges => OperationStatusResult(status, problemDetailsBuilder =>
+                BadRequest(problemDetailsBuilder
+                    .WithTitle("Unsaved changes")
+                    .WithDetail("The content item has unsaved changes that must be saved before publishing.")
+                    .Build())),
+            _ => null,
+        };
 
     protected IActionResult GetReferencesOperationStatusResult(GetReferencesOperationStatus status)
         => OperationStatusResult(status, problemDetailsBuilder => status switch

--- a/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentControllerBase.cs
@@ -97,6 +97,46 @@ public abstract class ContentControllerBase : ManagementApiControllerBase
                 .WithTitle("Cannot move a referenced content item to the recycle bin")
                 .WithDetail("Cannot move a referenced content item to the recycle bin, while the setting ContentSettings.DisableDeleteWhenReferenced is enabled.")
                 .Build()),
+            ContentEditingOperationStatus.AwaitingRelease => BadRequest(problemDetailsBuilder
+                .WithTitle("Content is awaiting release")
+                .WithDetail("The content item could not be published because it is scheduled for release.")
+                .Build()),
+            ContentEditingOperationStatus.CultureAwaitingRelease => BadRequest(problemDetailsBuilder
+                .WithTitle("Culture is awaiting release")
+                .WithDetail("The content item could not be published because one or more cultures are scheduled for release.")
+                .Build()),
+            ContentEditingOperationStatus.HasExpired => BadRequest(problemDetailsBuilder
+                .WithTitle("Content has expired")
+                .WithDetail("The content item could not be published because it has expired.")
+                .Build()),
+            ContentEditingOperationStatus.CultureHasExpired => BadRequest(problemDetailsBuilder
+                .WithTitle("Culture has expired")
+                .WithDetail("The content item could not be published because one or more cultures have expired.")
+                .Build()),
+            ContentEditingOperationStatus.PathNotPublished => BadRequest(problemDetailsBuilder
+                .WithTitle("Path not published")
+                .WithDetail("The content item could not be published because its parent is not published.")
+                .Build()),
+            ContentEditingOperationStatus.ContentInvalid => BadRequest(problemDetailsBuilder
+                .WithTitle("Content is invalid")
+                .WithDetail("The content item could not be published because it is invalid.")
+                .Build()),
+            ContentEditingOperationStatus.NothingToPublish => BadRequest(problemDetailsBuilder
+                .WithTitle("Nothing to publish")
+                .WithDetail("The content item has no publishable values.")
+                .Build()),
+            ContentEditingOperationStatus.MandatoryCultureMissing => BadRequest(problemDetailsBuilder
+                .WithTitle("Mandatory culture missing")
+                .WithDetail("The content item could not be published because a mandatory culture is missing.")
+                .Build()),
+            ContentEditingOperationStatus.ConcurrencyViolation => Conflict(problemDetailsBuilder
+                .WithTitle("Concurrency violation")
+                .WithDetail("The content item was modified by another operation.")
+                .Build()),
+            ContentEditingOperationStatus.UnsavedChanges => BadRequest(problemDetailsBuilder
+                .WithTitle("Unsaved changes")
+                .WithDetail("The content item has unsaved changes that must be saved before publishing.")
+                .Build()),
             ContentEditingOperationStatus.Unknown => StatusCode(
                 StatusCodes.Status500InternalServerError,
                 problemDetailsBuilder

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -475,22 +475,7 @@ internal sealed class ContentEditingService
                 return ContentEditingOperationStatus.Success;
             }
 
-            return publishResult.Result switch
-            {
-                PublishResultType.FailedPublishCancelledByEvent => ContentEditingOperationStatus.CancelledByNotification,
-                PublishResultType.FailedPublishAwaitingRelease => ContentEditingOperationStatus.AwaitingRelease,
-                PublishResultType.FailedPublishCultureAwaitingRelease => ContentEditingOperationStatus.CultureAwaitingRelease,
-                PublishResultType.FailedPublishHasExpired => ContentEditingOperationStatus.HasExpired,
-                PublishResultType.FailedPublishCultureHasExpired => ContentEditingOperationStatus.CultureHasExpired,
-                PublishResultType.FailedPublishPathNotPublished => ContentEditingOperationStatus.PathNotPublished,
-                PublishResultType.FailedPublishContentInvalid => ContentEditingOperationStatus.ContentInvalid,
-                PublishResultType.FailedPublishNothingToPublish => ContentEditingOperationStatus.NothingToPublish,
-                PublishResultType.FailedPublishMandatoryCultureMissing => ContentEditingOperationStatus.MandatoryCultureMissing,
-                PublishResultType.FailedPublishConcurrencyViolation => ContentEditingOperationStatus.ConcurrencyViolation,
-                PublishResultType.FailedPublishUnsavedChanges => ContentEditingOperationStatus.UnsavedChanges,
-                PublishResultType.FailedPublishIsTrashed => ContentEditingOperationStatus.InTrash,
-                _ => ContentEditingOperationStatus.Unknown,
-            };
+            return ToContentEditingOperationStatus(publishResult.Result);
         }
         catch (Exception ex)
         {
@@ -498,4 +483,22 @@ internal sealed class ContentEditingService
             return ContentEditingOperationStatus.Unknown;
         }
     }
+
+    private static ContentEditingOperationStatus ToContentEditingOperationStatus(PublishResultType resultType)
+        => resultType switch
+        {
+            PublishResultType.FailedPublishCancelledByEvent => ContentEditingOperationStatus.CancelledByNotification,
+            PublishResultType.FailedPublishAwaitingRelease => ContentEditingOperationStatus.AwaitingRelease,
+            PublishResultType.FailedPublishCultureAwaitingRelease => ContentEditingOperationStatus.CultureAwaitingRelease,
+            PublishResultType.FailedPublishHasExpired => ContentEditingOperationStatus.HasExpired,
+            PublishResultType.FailedPublishCultureHasExpired => ContentEditingOperationStatus.CultureHasExpired,
+            PublishResultType.FailedPublishPathNotPublished => ContentEditingOperationStatus.PathNotPublished,
+            PublishResultType.FailedPublishContentInvalid => ContentEditingOperationStatus.ContentInvalid,
+            PublishResultType.FailedPublishNothingToPublish => ContentEditingOperationStatus.NothingToPublish,
+            PublishResultType.FailedPublishMandatoryCultureMissing => ContentEditingOperationStatus.MandatoryCultureMissing,
+            PublishResultType.FailedPublishConcurrencyViolation => ContentEditingOperationStatus.ConcurrencyViolation,
+            PublishResultType.FailedPublishUnsavedChanges => ContentEditingOperationStatus.UnsavedChanges,
+            PublishResultType.FailedPublishIsTrashed => ContentEditingOperationStatus.InTrash,
+            _ => ContentEditingOperationStatus.Unknown,
+        };
 }

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -478,6 +478,17 @@ internal sealed class ContentEditingService
             return publishResult.Result switch
             {
                 PublishResultType.FailedPublishCancelledByEvent => ContentEditingOperationStatus.CancelledByNotification,
+                PublishResultType.FailedPublishAwaitingRelease => ContentEditingOperationStatus.AwaitingRelease,
+                PublishResultType.FailedPublishCultureAwaitingRelease => ContentEditingOperationStatus.CultureAwaitingRelease,
+                PublishResultType.FailedPublishHasExpired => ContentEditingOperationStatus.HasExpired,
+                PublishResultType.FailedPublishCultureHasExpired => ContentEditingOperationStatus.CultureHasExpired,
+                PublishResultType.FailedPublishPathNotPublished => ContentEditingOperationStatus.PathNotPublished,
+                PublishResultType.FailedPublishContentInvalid => ContentEditingOperationStatus.ContentInvalid,
+                PublishResultType.FailedPublishNothingToPublish => ContentEditingOperationStatus.NothingToPublish,
+                PublishResultType.FailedPublishMandatoryCultureMissing => ContentEditingOperationStatus.MandatoryCultureMissing,
+                PublishResultType.FailedPublishConcurrencyViolation => ContentEditingOperationStatus.ConcurrencyViolation,
+                PublishResultType.FailedPublishUnsavedChanges => ContentEditingOperationStatus.UnsavedChanges,
+                PublishResultType.FailedPublishIsTrashed => ContentEditingOperationStatus.InTrash,
                 _ => ContentEditingOperationStatus.Unknown,
             };
         }

--- a/src/Umbraco.Core/Services/OperationStatus/ContentEditingOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentEditingOperationStatus.cs
@@ -125,4 +125,54 @@ public enum ContentEditingOperationStatus
     ///     One or more property values have a segment variance that does not match the property type's segment variance.
     /// </summary>
     PropertyTypeSegmentVarianceMismatch,
+
+    /// <summary>
+    ///     The content item is awaiting release and cannot be published immediately.
+    /// </summary>
+    AwaitingRelease,
+
+    /// <summary>
+    ///     The specified culture is awaiting release and cannot be published immediately.
+    /// </summary>
+    CultureAwaitingRelease,
+
+    /// <summary>
+    ///     The content item has expired and cannot be published.
+    /// </summary>
+    HasExpired,
+
+    /// <summary>
+    ///     The specified culture has expired and cannot be published.
+    /// </summary>
+    CultureHasExpired,
+
+    /// <summary>
+    ///     The content path is not published; parent content must be published first.
+    /// </summary>
+    PathNotPublished,
+
+    /// <summary>
+    ///     The content item is invalid and cannot be published.
+    /// </summary>
+    ContentInvalid,
+
+    /// <summary>
+    ///     There is nothing to publish for the content item.
+    /// </summary>
+    NothingToPublish,
+
+    /// <summary>
+    ///     A mandatory culture is missing from the content item.
+    /// </summary>
+    MandatoryCultureMissing,
+
+    /// <summary>
+    ///     A concurrency violation occurred; the content was modified by another operation.
+    /// </summary>
+    ConcurrencyViolation,
+
+    /// <summary>
+    ///     The content item has unsaved changes that must be saved before publishing.
+    /// </summary>
+    UnsavedChanges,
 }


### PR DESCRIPTION
## Description

Fixes #23781

Publishing a document with a scheduled release date via Save and Publish returned a 500 "Unknown error" instead of a descriptive 400 response.

**Root cause:** `ContentEditingService.SaveAndPublish` had a switch expression that only mapped `FailedPublishCancelledByEvent` to a meaningful status. All other publish failures (awaiting release, expired, path not published, etc.) fell through to `ContentEditingOperationStatus.Unknown`, which the controller returned as HTTP 500.

**Fix:**

- **`ContentEditingOperationStatus.cs`**: Added 10 new enum values (`AwaitingRelease`, `CultureAwaitingRelease`, `HasExpired`, `CultureHasExpired`, `PathNotPublished`, `ContentInvalid`, `NothingToPublish`, `MandatoryCultureMissing`, `ConcurrencyViolation`, `UnsavedChanges`) mirroring the statuses already defined in `ContentPublishingOperationStatus`.
- **`ContentEditingService.cs`**: Expanded the `publishResult.Result` switch to map all `PublishResultType.Failed*` variants to their corresponding `ContentEditingOperationStatus` values, matching how `ContentPublishingService` already handles them.
- **`ContentControllerBase.cs`**: Added handler cases for all new statuses, returning descriptive 400 Bad Request (or 409 Conflict for concurrency) responses.

## Testing
1. Open a content node
2. Set a scheduled publish date in the future
3. Click Save and Publish
4. Verify the response is a descriptive 400 error (not 500 "Unknown error")
