### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <!-- Global packages (private, build-time packages for all projects) -->
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.94" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <GlobalPackageReference Include="Umbraco.Code" Version="2.4.0" />
     <GlobalPackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" />
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.1" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
-    <PackageVersion Include="BitFaster.Caching" Version="2.6.0" />
+    <PackageVersion Include="BitFaster.Caching" Version="2.6.1" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
     <PackageVersion Include="Examine" Version="3.10.0" />
     <PackageVersion Include="Examine.Core" Version="3.10.0" />
@@ -60,9 +60,9 @@
     <PackageVersion Include="ncrontab" Version="3.4.0" />
     <PackageVersion Include="NPoco" Version="6.2.0" />
     <PackageVersion Include="NPoco.SqlServer" Version="6.2.0" />
-    <PackageVersion Include="OpenIddict.Abstractions" Version="7.6.0" />
-    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.6.0" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.6.0" />
+    <PackageVersion Include="OpenIddict.Abstractions" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.6.1" />
     <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />


### PR DESCRIPTION
## Description

Routine dependency maintenance for the **17.8.0-rc** release. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Nerdbank.GitVersioning (`GlobalPackageReference`) | 3.10.91 | 3.10.94 |
| BitFaster.Caching | 2.6.0 | 2.6.1 |
| OpenIddict.Abstractions | 7.6.0 | 7.6.1 |
| OpenIddict.AspNetCore | 7.6.0 | 7.6.1 |
| OpenIddict.EntityFrameworkCore | 7.6.0 | 7.6.1 |

### Test packages (`tests/Directory.Packages.props`)

No changes.

### Inline / template versions

No changes — none of the bumped packages appear in `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj` or `templates/UmbracoExtension/`.

### Deliberately left unchanged

- `Microsoft.OpenApi` — carries an explicit `HOLD at 2.9.0 - do not bump` comment in `Directory.Packages.props` (tracks an upstream OpenAPI 3.0 nullability regression); a newer minor (2.12.2) is available but intentionally held back.
- `HtmlAgilityPack` (1.12.4 → 1.13.0 available) — reverted after bumping. The 1.13.0 release changed `HtmlAttribute.Value` to a nullable-annotated `string?`, which breaks type inference in `Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs` (`Dictionary<string, object?>` vs. the expected `Dictionary<string, object>`), producing CS8620 build errors. Fixing this needs a production code change, which is out of scope for a routine dependency-only bump. Left at 1.12.4 pending a follow-up that addresses the code change deliberately.
- Any package where only a **major** update is available (out of scope for this PR).

## Testing

Solution builds in Release and the full unit test suite (6337 tests) passes. No known-vulnerable transitive packages introduced (`dotnet list package --vulnerable --include-transitive`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyNatCvKYvtkNCTxoDmkpW)_