### PR TITLE
Fix mock recycle bin restore and tree visibility

### DIFF
--- a/src/Umbraco.Web.UI.Client/mocks/data/mock-data-set.types.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/data/mock-data-set.types.ts
@@ -111,7 +111,12 @@ export type UmbMockDictionaryModel = DictionaryItemResponseModel &
 	DictionaryItemItemResponseModel &
 	DictionaryOverviewResponseModel;
 
-export type UmbMockDocumentModel = DocumentResponseModel & DocumentTreeItemResponseModel & DocumentItemResponseModel;
+export type UmbMockDocumentModel = DocumentResponseModel &
+	DocumentTreeItemResponseModel &
+	DocumentItemResponseModel & {
+		/** Mock-only: the parent before trashing, used to restore it. Not a real response field. */
+		originalParent?: { id: string } | null;
+	};
 
 export type UmbMockDocumentBlueprintModel = DocumentBlueprintResponseModel &
 	DocumentBlueprintItemResponseModel &
@@ -123,7 +128,12 @@ export type UmbMockDocumentTypeModel = DocumentTypeResponseModel &
 
 export type UmbMockLanguageModel = LanguageResponseModel & LanguageItemResponseModel;
 
-export type UmbMockMediaModel = MediaResponseModel & MediaTreeItemResponseModel & MediaItemResponseModel;
+export type UmbMockMediaModel = MediaResponseModel &
+	MediaTreeItemResponseModel &
+	MediaItemResponseModel & {
+		/** Mock-only: the parent before trashing, used to restore it. Not a real response field. */
+		originalParent?: { id: string } | null;
+	};
 
 export type UmbMockMediaTypeModel = MediaTypeResponseModel &
 	MediaTypeTreeItemResponseModel &

--- a/src/Umbraco.Web.UI.Client/mocks/db/document.db.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/document.db.ts
@@ -27,19 +27,13 @@ export class UmbDocumentMockDB extends UmbEntityMockDbBase<UmbMockDocumentModel>
 	tree = new UmbMockEntityTreeManager<UmbMockDocumentModel>(this, treeItemMapper);
 	item = new UmbMockEntityVariantItemManager<UmbMockDocumentModel>(this, itemMapper);
 	detail = new UmbMockEntityDetailManager<UmbMockDocumentModel>(this, createMockDocumentMapper, detailResponseMapper);
-	recycleBin = new UmbEntityRecycleBin<UmbMockDocumentModel>(this.data, treeItemMapper);
+	recycleBin = new UmbEntityRecycleBin<UmbMockDocumentModel>(this, treeItemMapper);
 	publishing = new UmbMockDocumentPublishingManager(this);
 	collection = new UmbMockDocumentCollectionManager(this, collectionMapper);
 	url = new UmbMockEntityVariantUrlManager<UmbMockDocumentModel>(this);
 
 	constructor(data: Array<UmbMockDocumentModel>) {
 		super('document', data);
-	}
-
-	override setData(data: Array<UmbMockDocumentModel>) {
-		super.setData(data);
-		// Update recycleBin's data to match - it has its own data array
-		this.recycleBin.setData(data);
 	}
 
 	// permissions

--- a/src/Umbraco.Web.UI.Client/mocks/db/media.db.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/media.db.ts
@@ -36,18 +36,12 @@ export class UmbMediaMockDB extends UmbEntityMockDbBase<UmbMockMediaModel> {
 	tree = new UmbMockEntityTreeManager<UmbMockMediaModel>(this, treeItemMapper);
 	item = new UmbMockEntityVariantItemManager<UmbMockMediaModel>(this, itemMapper);
 	detail = new UmbMockEntityDetailManager<UmbMockMediaModel>(this, createMockMediaMapper, detailResponseMapper);
-	recycleBin = new UmbEntityRecycleBin<UmbMockMediaModel>(this.data, treeItemMapper);
+	recycleBin = new UmbEntityRecycleBin<UmbMockMediaModel>(this, treeItemMapper);
 	collection = new UmbMockMediaCollectionManager(this, collectionMapper);
 	url = new UmbMockEntityVariantUrlManager<UmbMockMediaModel>(this);
 
 	constructor(data: Array<UmbMockMediaModel>) {
 		super('media', data);
-	}
-
-	override setData(data: Array<UmbMockMediaModel>) {
-		super.setData(data);
-		// Update recycleBin's data to match - it has its own data array
-		this.recycleBin.setData(data);
 	}
 
 	getFileUrls(ids: string[]): GetMediaUrlsResponse {

--- a/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-recycle-bin-tree.manager.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-recycle-bin-tree.manager.ts
@@ -1,0 +1,10 @@
+import { UmbMockEntityTreeManager } from './entity-tree.manager.js';
+
+/** Tree manager for the recycle bin: shows only trashed items — the inverse of the base class's default. */
+export class UmbMockEntityRecycleBinTreeManager<
+	T extends { id: string; parent?: { id: string } | null; hasChildren: boolean; isTrashed: boolean },
+> extends UmbMockEntityTreeManager<T> {
+	protected override _isItemVisible(item: T): boolean {
+		return item.isTrashed === true;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-recycle-bin.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-recycle-bin.ts
@@ -44,6 +44,7 @@ export class UmbEntityRecycleBin<MockType extends UmbMockRecycleBinnableModel> {
 		const models = ids.map((id) => this.read(id)).filter((model) => !!model) as Array<MockType>;
 
 		models.forEach((model) => {
+			if (model.isTrashed) return;
 			model.originalParent = model.parent ?? null;
 			model.parent = null;
 			model.isTrashed = true;

--- a/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-recycle-bin.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-recycle-bin.ts
@@ -72,6 +72,7 @@ export class UmbEntityRecycleBin<MockType extends UmbMockRecycleBinnableModel> {
 		const models = ids.map((id) => this.read(id)).filter((model) => !!model) as Array<MockType>;
 
 		models.forEach((model) => {
+			if (!model.isTrashed) return;
 			model.parent = destination !== undefined ? destination : (model.originalParent ?? null);
 			model.originalParent = null;
 			model.isTrashed = false;

--- a/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-recycle-bin.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-recycle-bin.ts
@@ -1,54 +1,108 @@
-import { UmbMockEntityTreeManager } from './entity-tree.manager.js';
+import { UmbMockEntityRecycleBinTreeManager } from './entity-recycle-bin-tree.manager.js';
+
+// Anchored on `name` (present on every variant type) so TS doesn't reject media's variants as a "weak type" match.
+type UmbMockVariantWithState = { name: string; state?: string };
+
+type UmbMockRecycleBinnableModel = {
+	id: string;
+	parent?: { id: string } | null;
+	originalParent?: { id: string } | null;
+	isTrashed: boolean;
+	hasChildren: boolean;
+	variants?: Array<UmbMockVariantWithState>;
+};
 
 /**
- * Recycle bin helper class for document/media DBs.
- * This is NOT a standalone DB - it shares data with its parent DB.
- * It does not auto-register with the mock DB registry.
+ * Always the parent DB itself, never a private copy — otherwise it drifts out of sync when the active mock set
+ * changes.
  */
-export class UmbEntityRecycleBin<MockType extends { id: string; isTrashed: boolean; hasChildren: boolean }> {
-	protected data: Array<MockType> = [];
-	tree;
+interface UmbMockRecycleBinSource<T> {
+	getAll(): Array<T>;
+	read(id: string): T | undefined;
+	update(id: string, item: T): void;
+}
 
-	constructor(data: Array<MockType>, treeItemMapper: (model: MockType) => any) {
-		this.data = data;
-		this.tree = new UmbMockEntityTreeManager<MockType>(this, treeItemMapper);
-	}
+/**
+ * Recycle bin helper class for document/media DBs. Not a standalone DB — delegates to its parent DB for all
+ * reads/writes. Mirrors the real server's trash/restore behaviour, including keeping each variant's `state` in
+ * sync with `isTrashed`.
+ */
+export class UmbEntityRecycleBin<MockType extends UmbMockRecycleBinnableModel> {
+	#db: UmbMockRecycleBinSource<MockType>;
+	tree: UmbMockEntityRecycleBinTreeManager<MockType>;
 
-	/**
-	 * Update data reference (called by parent DB's setData).
-	 * @param data
-	 */
-	setData(data: Array<MockType>) {
-		this.data = data;
-	}
-
-	clear() {
-		this.data = [];
-	}
-
-	getAll() {
-		return this.data;
+	constructor(db: UmbMockRecycleBinSource<MockType>, treeItemMapper: (model: MockType) => any) {
+		this.#db = db;
+		this.tree = new UmbMockEntityRecycleBinTreeManager<MockType>(db, treeItemMapper);
 	}
 
 	read(id: string) {
-		return this.data.find((item) => item.id === id);
-	}
-
-	update(id: string, updatedItem: MockType) {
-		const itemIndex = this.data.findIndex((item) => item.id === id);
-		if (itemIndex === -1) return;
-		this.data[itemIndex] = updatedItem;
+		return this.#db.read(id);
 	}
 
 	trash(ids: string[]) {
 		const models = ids.map((id) => this.read(id)).filter((model) => !!model) as Array<MockType>;
 
 		models.forEach((model) => {
+			model.originalParent = model.parent ?? null;
+			model.parent = null;
 			model.isTrashed = true;
+			this.#setVariantsState(model, 'Trashed');
+			this.#db.update(model.id, model);
 		});
 
-		models.forEach((model) => {
-			this.update(model.id, model);
+		models.forEach((model) => this.#trashDescendantsOf(model.id));
+	}
+
+	#trashDescendantsOf(parentId: string) {
+		const children = this.#db.getAll().filter((item) => item.parent?.id === parentId);
+		children.forEach((child) => {
+			// No `originalParent` for descendants — restoring one "in place" is meaningless while its ancestor is
+			// still trashed.
+			child.isTrashed = true;
+			this.#setVariantsState(child, 'Trashed');
+			this.#db.update(child.id, child);
+			this.#trashDescendantsOf(child.id);
 		});
+	}
+
+	/** `destination`, when passed (including `null` for root), overrides the item's own `originalParent` fallback. */
+	restore(ids: string[], destination?: { id: string } | null) {
+		const models = ids.map((id) => this.read(id)).filter((model) => !!model) as Array<MockType>;
+
+		models.forEach((model) => {
+			model.parent = destination !== undefined ? destination : (model.originalParent ?? null);
+			model.originalParent = null;
+			model.isTrashed = false;
+			this.#setVariantsState(model, 'Draft');
+			this.#db.update(model.id, model);
+		});
+
+		models.forEach((model) => this.#restoreDescendantsOf(model.id));
+	}
+
+	#restoreDescendantsOf(parentId: string) {
+		const children = this.#db.getAll().filter((item) => item.parent?.id === parentId && item.isTrashed);
+		children.forEach((child) => {
+			child.isTrashed = false;
+			this.#setVariantsState(child, 'Draft');
+			this.#db.update(child.id, child);
+			this.#restoreDescendantsOf(child.id);
+		});
+	}
+
+	/** No-op for media — its variants never have a `state` field. */
+	#setVariantsState(model: MockType, state: string) {
+		model.variants?.forEach((variant) => {
+			if ('state' in variant) variant.state = state;
+		});
+	}
+
+	/** `undefined` for a descendant that was trashed only because its ancestor was — matches the real server. */
+	getOriginalParent(id: string): { id: string } | null | undefined {
+		const model = this.read(id);
+		if (!model?.isTrashed) return undefined;
+		// `null` (root) and `undefined` (never trashed itself) are different answers — don't collapse them.
+		return model.originalParent;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-tree.manager.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-tree.manager.ts
@@ -21,13 +21,22 @@ export class UmbMockEntityTreeManager<T extends { id: string; parent?: { id: str
 		this.#treeItemMapper = treeItemMapper;
 	}
 
+	/** Excludes trashed items by default (no-op if there's no `isTrashed`). Overridden to show only trashed items. */
+	protected _isItemVisible(item: T): boolean {
+		return !('isTrashed' in item) || !(item as { isTrashed?: boolean }).isTrashed;
+	}
+
+	protected _getVisibleItems(): Array<T> {
+		return this.#db.getAll().filter((item) => this._isItemVisible(item));
+	}
+
 	getRoot({ skip = 0, take = 100 }: { skip?: number; take?: number } = {}) {
-		const items = this.#db.getAll().filter((item) => item.parent === null || item.parent === undefined);
+		const items = this._getVisibleItems().filter((item) => item.parent === null || item.parent === undefined);
 		return this.#pagedTreeResult({ items, skip, take });
 	}
 
 	getChildrenOf({ parentId, skip = 0, take = 100 }: { parentId: string; skip?: number; take?: number }) {
-		const items = this.#db.getAll().filter((item) => item.parent?.id === parentId);
+		const items = this._getVisibleItems().filter((item) => item.parent?.id === parentId);
 		return this.#pagedTreeResult({ items, skip, take });
 	}
 
@@ -47,7 +56,7 @@ export class UmbMockEntityTreeManager<T extends { id: string; parent?: { id: str
 		const paged = pagedResult(items, skip, take);
 		const treeItems = paged.items.map((item) => this.#treeItemMapper(item));
 		const treeItemsHasChildren = treeItems.map((item) => {
-			const children = this.#db.getAll().filter((child) => child.parent?.id === item.id);
+			const children = this._getVisibleItems().filter((child) => child.parent?.id === item.id);
 			return {
 				...item,
 				hasChildren: children.length > 0,
@@ -56,17 +65,26 @@ export class UmbMockEntityTreeManager<T extends { id: string; parent?: { id: str
 		return { items: treeItemsHasChildren, total: paged.total };
 	}
 
-	getSiblingsOf({ targetId, before = 0, after = 100 }: { targetId: string; before?: number; after?: number }) {
+	/** Returns `null` (not a hollow empty result) when `targetId` isn't resolvable in this tree, so callers can respond with a proper "not found" instead of masking the failure. */
+	getSiblingsOf({
+		targetId,
+		before = 0,
+		after = 100,
+	}: {
+		targetId: string;
+		before?: number;
+		after?: number;
+	}): { items: Array<unknown>; totalBefore: number; totalAfter: number } | null {
 		const target = this.#db.read(targetId);
-		if (!target) return { items: [], totalBefore: 0, totalAfter: 0 };
+		if (!target || !this._isItemVisible(target)) return null;
 
 		const parentId = target.parent?.id ?? null;
-		const allSiblings = this.#db.getAll().filter((item) =>
+		const allSiblings = this._getVisibleItems().filter((item) =>
 			parentId === null ? item.parent === null || item.parent === undefined : item.parent?.id === parentId,
 		);
 
 		const targetIndex = allSiblings.findIndex((item) => item.id === targetId);
-		if (targetIndex === -1) return { items: [], totalBefore: 0, totalAfter: 0 };
+		if (targetIndex === -1) return null;
 
 		const startIndex = Math.max(0, targetIndex - before);
 		const endIndex = Math.min(allSiblings.length, targetIndex + after + 1);
@@ -78,7 +96,7 @@ export class UmbMockEntityTreeManager<T extends { id: string; parent?: { id: str
 
 		const treeItems = slicedItems.map((item) => this.#treeItemMapper(item));
 		const treeItemsHasChildren = treeItems.map((item) => {
-			const children = this.#db.getAll().filter((child) => child.parent?.id === item.id);
+			const children = this._getVisibleItems().filter((child) => child.parent?.id === item.id);
 			return { ...item, hasChildren: children.length > 0 };
 		});
 

--- a/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-tree.manager.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/utils/entity/entity-tree.manager.ts
@@ -23,7 +23,7 @@ export class UmbMockEntityTreeManager<T extends { id: string; parent?: { id: str
 
 	/** Excludes trashed items by default (no-op if there's no `isTrashed`). Overridden to show only trashed items. */
 	protected _isItemVisible(item: T): boolean {
-		return !('isTrashed' in item) || !(item as { isTrashed?: boolean }).isTrashed;
+		return !(item as { isTrashed?: boolean }).isTrashed;
 	}
 
 	protected _getVisibleItems(): Array<T> {

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/data-type/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/data-type/tree.handlers.ts
@@ -37,6 +37,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbDataTypeMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/dictionary/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/dictionary/tree.handlers.ts
@@ -37,6 +37,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbDictionaryMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document-blueprint/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document-blueprint/tree.handlers.ts
@@ -27,6 +27,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbDocumentBlueprintMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document-type/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document-type/tree.handlers.ts
@@ -37,6 +37,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbDocumentTypeMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document/recycle-bin.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document/recycle-bin.handlers.ts
@@ -28,4 +28,19 @@ export const recycleBinHandlers = [
 		umbDocumentMockDb.recycleBin.trash([id]);
 		return new HttpResponse(null, { status: 200 });
 	}),
+
+	http.get(umbracoPath(`/recycle-bin${UMB_SLUG}/:id/original-parent`), ({ params }) => {
+		const id = params.id as string;
+		const originalParent = umbDocumentMockDb.recycleBin.getOriginalParent(id);
+		if (originalParent === undefined) return new HttpResponse(null, { status: 404 });
+		return HttpResponse.json(originalParent);
+	}),
+
+	http.put(umbracoPath(`/recycle-bin${UMB_SLUG}/:id/restore`), async ({ params, request }) => {
+		const id = params.id as string;
+		if (!id) return new HttpResponse(null, { status: 400 });
+		const body = (await request.json()) as { target?: { id: string } | null };
+		umbDocumentMockDb.recycleBin.restore([id], body.target);
+		return new HttpResponse(null, { status: 200 });
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document/tree.handlers.ts
@@ -38,6 +38,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbDocumentMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/media-type/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/media-type/tree.handlers.ts
@@ -34,6 +34,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbMediaTypeMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/media/recycle-bin.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/media/recycle-bin.handlers.ts
@@ -28,4 +28,19 @@ export const recycleBinHandlers = [
 		umbMediaMockDb.recycleBin.trash([id]);
 		return new HttpResponse(null, { status: 200 });
 	}),
+
+	http.get(umbracoPath(`/recycle-bin${UMB_SLUG}/:id/original-parent`), ({ params }) => {
+		const id = params.id as string;
+		const originalParent = umbMediaMockDb.recycleBin.getOriginalParent(id);
+		if (originalParent === undefined) return new HttpResponse(null, { status: 404 });
+		return HttpResponse.json(originalParent);
+	}),
+
+	http.put(umbracoPath(`/recycle-bin${UMB_SLUG}/:id/restore`), async ({ params, request }) => {
+		const id = params.id as string;
+		if (!id) return new HttpResponse(null, { status: 400 });
+		const body = (await request.json()) as { target?: { id: string } | null };
+		umbMediaMockDb.recycleBin.restore([id], body.target);
+		return new HttpResponse(null, { status: 200 });
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/media/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/media/tree.handlers.ts
@@ -37,6 +37,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbMediaMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/member-type/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/member-type/tree.handlers.ts
@@ -29,6 +29,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbMemberTypeMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/template/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/template/tree.handlers.ts
@@ -27,6 +27,7 @@ export const treeHandlers = [
 		const before = Number(url.searchParams.get('before'));
 		const after = Number(url.searchParams.get('after'));
 		const response = umbTemplateMockDb.tree.getSiblingsOf({ targetId, before, after });
+		if (!response) return new HttpResponse(null, { status: 404, statusText: 'target not found' });
 		return HttpResponse.json(response);
 	}),
 ];


### PR DESCRIPTION
Refactors the mock recycle bin to delegate directly to the parent DB, preventing data drift when mock datasets change. Adds realistic trash/restore behavior (including descendant handling, variant state sync, and original parent lookup), introduces recycle-bin-only tree filtering, and updates tree sibling handlers to return 404 when the target is missing or not visible.
