### PR TITLE
Auth: Refresh the backoffice session on activity

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using OpenIddict.Abstractions;
-using Umbraco.Cms.Api.Common.Security;
 using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -141,15 +140,13 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
                 // ensure the thread culture is set
                 backOfficeIdentity?.EnsureCulture();
 
-                EnsureTicketRenewalIfKeepUserLoggedIn(ctx);
-
-                // An explicit keep-alive request renews the ticket for an actively-working user,
-                // regardless of KeepUserLoggedIn. This is what lets the session-timeout warning offer
-                // a working "Stay logged in" action even when the session has a fixed expiry.
-                // Scoped strictly to this one endpoint so we never set ShouldRenew unconditionally
-                // (see the note below the SecurityStampValidator call — that would break the
-                // validation-interval behaviour and AllowConcurrentLogins enforcement).
-                if (ctx.Request.Path.StartsWithSegments(Paths.BackOfficeApi.KeepAliveEndpoint, StringComparison.OrdinalIgnoreCase))
+                // Any request bearing a valid back-office identity renews the ticket. This is safe for
+                // AllowConcurrentLogins enforcement: ConfigureSecurityStampOptions forces ValidationInterval
+                // to zero when concurrent logins are disallowed, so the stamp check below still runs on
+                // effectively every request (any positive time gap exceeds a zero interval) regardless of
+                // how often we reset IssuedUtc here. What matters is that the reset below stays *after* the
+                // ValidateAsync call, so this request's own interval check reads the pre-renewal IssuedUtc.
+                if (backOfficeIdentity != null)
                 {
                     ctx.ShouldRenew = true;
                 }
@@ -169,14 +166,11 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
 
                 await securityStampValidator.ValidateAsync(ctx);
 
-                // Only reset timestamps when a renewal was already triggered (by the SecurityStampValidator
-                // or by EnsureTicketRenewalIfKeepUserLoggedIn above).
+                // Only reset timestamps when a renewal was actually triggered (i.e. there was a valid
+                // identity, or the SecurityStampValidator decided to refresh the principal on its own).
                 // When the SecurityStampValidator refreshes the principal, it sets ShouldRenew but updates
                 // IssuedUtc without updating ExpiresUtc, causing the effective cookie lifetime to shrink
                 // with each validation. The manual reset here fixes that drift.
-                // IMPORTANT: Do NOT unconditionally set ShouldRenew or reset IssuedUtc - doing so prevents
-                // the SecurityStampValidator from ever exceeding its ValidationInterval during active use,
-                // which breaks AllowConcurrentLogins enforcement.
                 if (ctx.ShouldRenew)
                 {
                     DateTimeOffset now = _timeProvider.GetUtcNow();
@@ -326,33 +320,4 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
     // when authorizing clients like Postman or Swagger UI.
     private static bool ShouldBeTreatedAsXhr(HttpRequest request)
         => IsXhr(request) || (IsManagementApiRequest(request) && HasClientId(request) is false);
-
-    /// <summary>
-    ///     Ensures the ticket is renewed if the <see cref="SecuritySettings.KeepUserLoggedIn" /> is set to true
-    ///     and the current request is for the get user seconds endpoint
-    /// </summary>
-    /// <param name="context">The <see cref="CookieValidatePrincipalContext" /></param>
-    private void EnsureTicketRenewalIfKeepUserLoggedIn(CookieValidatePrincipalContext context)
-    {
-        if (!_securitySettings.KeepUserLoggedIn)
-        {
-            return;
-        }
-
-        DateTimeOffset currentUtc = _timeProvider.GetUtcNow();
-        DateTimeOffset? issuedUtc = context.Properties.IssuedUtc;
-        DateTimeOffset? expiresUtc = context.Properties.ExpiresUtc;
-
-        if (expiresUtc.HasValue && issuedUtc.HasValue)
-        {
-            TimeSpan timeElapsed = currentUtc.Subtract(issuedUtc.Value);
-            TimeSpan timeRemaining = expiresUtc.Value.Subtract(currentUtc);
-
-            // if it's time to renew, then do it
-            if (timeRemaining < timeElapsed)
-            {
-                context.ShouldRenew = true;
-            }
-        }
-    }
 }

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
@@ -140,17 +140,6 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
                 // ensure the thread culture is set
                 backOfficeIdentity?.EnsureCulture();
 
-                // Any request bearing a valid back-office identity renews the ticket. This is safe for
-                // AllowConcurrentLogins enforcement: ConfigureSecurityStampOptions forces ValidationInterval
-                // to zero when concurrent logins are disallowed, so the stamp check below still runs on
-                // effectively every request (any positive time gap exceeds a zero interval) regardless of
-                // how often we reset IssuedUtc here. What matters is that the reset below stays *after* the
-                // ValidateAsync call, so this request's own interval check reads the pre-renewal IssuedUtc.
-                if (backOfficeIdentity != null)
-                {
-                    ctx.ShouldRenew = true;
-                }
-
                 // add or update a claim to track when the cookie expires, we use this to track time remaining
                 // NOTE: this runs before the ExpiresUtc reset below, so on a renewing request the claim
                 // still carries the pre-renewal expiry and only catches up on the next request. That is
@@ -166,16 +155,29 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
 
                 await securityStampValidator.ValidateAsync(ctx);
 
-                // Only reset timestamps when a renewal was actually triggered (i.e. there was a valid
-                // identity, or the SecurityStampValidator decided to refresh the principal on its own).
-                // When the SecurityStampValidator refreshes the principal, it sets ShouldRenew but updates
-                // IssuedUtc without updating ExpiresUtc, causing the effective cookie lifetime to shrink
-                // with each validation. The manual reset here fixes that drift.
+                // ctx.ShouldRenew is true here only when the SecurityStampValidator itself decided to
+                // refresh the principal, i.e. its ValidationInterval had elapsed and the stamp was still
+                // valid. That's a genuine re-validation, so it's safe to reset both timestamps: IssuedUtc
+                // starts a fresh validation interval, and ExpiresUtc is reset alongside it because the
+                // SecurityStampValidator's own renewal updates IssuedUtc without touching ExpiresUtc,
+                // which would otherwise shrink the effective cookie lifetime with each validation.
                 if (ctx.ShouldRenew)
                 {
                     DateTimeOffset now = _timeProvider.GetUtcNow();
                     ctx.Properties.IssuedUtc = now;
                     ctx.Properties.ExpiresUtc = now.Add(_globalSettings.TimeOut);
+                }
+                else if (ctx.Principal != null)
+                {
+                    // No stamp re-validation happened this request (the ValidationInterval hasn't
+                    // elapsed yet), but any request bearing a valid principal should still refresh the
+                    // session on activity. Extend ExpiresUtc only - IssuedUtc must be left untouched, or
+                    // the SecurityStampValidator's interval clock would be reset on every request and the
+                    // stamp would never be re-checked again for the lifetime of an active session (this
+                    // matters most when AllowConcurrentLogins is true, where ValidationInterval stays at
+                    // its non-zero default instead of being forced to zero).
+                    ctx.ShouldRenew = true;
+                    ctx.Properties.ExpiresUtc = _timeProvider.GetUtcNow().Add(_globalSettings.TimeOut);
                 }
             },
             OnSigningIn = ctx =>

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
@@ -167,7 +167,7 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
                     ctx.Properties.IssuedUtc = now;
                     ctx.Properties.ExpiresUtc = now.Add(_globalSettings.TimeOut);
                 }
-                else if (ctx.Principal != null)
+                else if (ctx.Principal is not null)
                 {
                     // No stamp re-validation happened this request (the ValidationInterval hasn't
                     // elapsed yet), but any request bearing a valid principal should still refresh the

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/BackOfficeController.cs
@@ -387,10 +387,10 @@ public class BackOfficeController : SecurityControllerBase
     /// Keeps the current back-office session alive by renewing the authentication ticket.
     /// </summary>
     /// <remarks>
-    /// The renewal itself is performed by the cookie middleware's OnValidatePrincipal, which forces
-    /// a ticket renewal when it sees a request to this endpoint (see ConfigureBackOfficeCookieOptions).
-    /// The cookie is re-issued with a fresh expiry regardless of the KeepUserLoggedIn setting, so an
-    /// actively-working user can dismiss the session-timeout warning without being logged out. The
+    /// The renewal itself is performed by the cookie middleware's OnValidatePrincipal (see
+    /// ConfigureBackOfficeCookieOptions), which renews the ticket for any authenticated request - this
+    /// endpoint is simply an authenticated no-op that lets an idle client trigger that renewal explicitly,
+    /// so an actively-working user can dismiss the session-timeout warning without being logged out. The
     /// updated expiry is observed on the next request (e.g. GET current-user/configuration).
     /// </remarks>
     /// <returns>200 OK once the session ticket has been renewed.</returns>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
@@ -49,9 +49,9 @@ public class ConfigureBackOfficeCookieOptionsTests
     }
 
     [Test]
-    public async Task Cannot_Reset_Timestamps_When_No_Renewal_Triggered()
+    public async Task Can_Renew_Ticket_For_Any_Request_With_Valid_Identity()
     {
-        // Arrange: validator does nothing (ShouldRenew stays false)
+        // Arrange: nothing else would trigger a renewal - validator does nothing, arbitrary path.
         _mockStampValidator
             .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
             .Returns(Task.CompletedTask);
@@ -59,13 +59,45 @@ public class ConfigureBackOfficeCookieOptionsTests
         var originalIssuedUtc = _now.AddMinutes(-5);
         var originalExpiresUtc = _now.AddMinutes(55);
 
-        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(originalIssuedUtc, originalExpiresUtc);
+        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(
+            originalIssuedUtc,
+            originalExpiresUtc,
+            "/umbraco/management/api/v1/document");
         Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
 
         // Act
         await onValidatePrincipal(context);
 
-        // Assert: IssuedUtc should NOT be reset when ShouldRenew was not triggered
+        // Assert: any request with a valid back-office identity renews the ticket
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.ShouldRenew, Is.True);
+            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(_now));
+            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(_now.Add(_globalSettings.TimeOut)));
+        });
+    }
+
+    [Test]
+    public async Task Cannot_Renew_Ticket_When_Identity_Is_Invalid()
+    {
+        // Arrange: principal is missing a required back-office claim, so GetUmbracoIdentity() returns null.
+        _mockStampValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
+            .Returns(Task.CompletedTask);
+
+        var originalIssuedUtc = _now.AddMinutes(-5);
+        var originalExpiresUtc = _now.AddMinutes(55);
+
+        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(
+            originalIssuedUtc,
+            originalExpiresUtc,
+            principal: CreateInvalidBackOfficePrincipal());
+        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
+
+        // Act
+        await onValidatePrincipal(context);
+
+        // Assert: no valid identity means no renewal
         Assert.Multiple(() =>
         {
             Assert.That(context.ShouldRenew, Is.False);
@@ -101,67 +133,6 @@ public class ConfigureBackOfficeCookieOptionsTests
         });
     }
 
-    [Test]
-    public async Task Can_Reset_Timestamps_When_KeepUserLoggedIn_Triggers_Renewal()
-    {
-        // Arrange: KeepUserLoggedIn = true, and timeRemaining < timeElapsed
-        _securitySettings.KeepUserLoggedIn = true;
-
-        _mockStampValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
-            .Returns(Task.CompletedTask);
-
-        // Set IssuedUtc far enough in the past that timeRemaining < timeElapsed
-        // IssuedUtc = now - 40 min, ExpiresUtc = now + 20 min
-        // timeElapsed = 40 min, timeRemaining = 20 min => timeRemaining < timeElapsed => ShouldRenew
-        var originalIssuedUtc = _now.AddMinutes(-40);
-        var originalExpiresUtc = _now.AddMinutes(20);
-
-        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(originalIssuedUtc, originalExpiresUtc);
-        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
-
-        // Act
-        await onValidatePrincipal(context);
-
-        // Assert: ShouldRenew set by EnsureTicketRenewalIfKeepUserLoggedIn, timestamps reset
-        Assert.Multiple(() =>
-        {
-            Assert.That(context.ShouldRenew, Is.True);
-            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(_now));
-            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(_now.Add(_globalSettings.TimeOut)));
-        });
-    }
-
-    [Test]
-    public async Task Cannot_Renew_Ticket_When_KeepUserLoggedIn_And_Time_Remaining_Exceeds_Time_Elapsed()
-    {
-        // Arrange: KeepUserLoggedIn = true, but timeRemaining > timeElapsed
-        _securitySettings.KeepUserLoggedIn = true;
-
-        _mockStampValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
-            .Returns(Task.CompletedTask);
-
-        // IssuedUtc = now - 10 min, ExpiresUtc = now + 50 min
-        // timeElapsed = 10 min, timeRemaining = 50 min => timeRemaining > timeElapsed => no renewal
-        var originalIssuedUtc = _now.AddMinutes(-10);
-        var originalExpiresUtc = _now.AddMinutes(50);
-
-        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(originalIssuedUtc, originalExpiresUtc);
-        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
-
-        // Act
-        await onValidatePrincipal(context);
-
-        // Assert: ShouldRenew stays false, timestamps unchanged
-        Assert.Multiple(() =>
-        {
-            Assert.That(context.ShouldRenew, Is.False);
-            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(originalIssuedUtc));
-            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(originalExpiresUtc));
-        });
-    }
-
     [TestCase("Strict", SameSiteMode.Strict)]
     [TestCase("strict", SameSiteMode.Strict)]
     [TestCase("None", SameSiteMode.None)]
@@ -193,65 +164,6 @@ public class ConfigureBackOfficeCookieOptionsTests
         _securitySettings.AuthCookieSameSite = configured;
 
         Assert.Throws<ConfigurationException>(() => ConfigureOptions());
-    }
-
-    [Test]
-    public async Task Can_Renew_Ticket_For_KeepAlive_Request_When_KeepUserLoggedIn_Is_Disabled()
-    {
-        // Arrange: nothing else triggers a renewal - no KeepUserLoggedIn, validator does nothing.
-        _mockStampValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
-            .Returns(Task.CompletedTask);
-
-        var originalIssuedUtc = _now.AddMinutes(-10);
-        var originalExpiresUtc = _now.AddMinutes(50);
-
-        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(
-            originalIssuedUtc,
-            originalExpiresUtc,
-            Paths.BackOfficeApi.KeepAliveEndpoint);
-        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
-
-        // Act
-        await onValidatePrincipal(context);
-
-        // Assert: the explicit keep-alive renews regardless of KeepUserLoggedIn
-        Assert.Multiple(() =>
-        {
-            Assert.That(context.ShouldRenew, Is.True);
-            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(_now));
-            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(_now.Add(_globalSettings.TimeOut)));
-        });
-    }
-
-    // The renewal is scoped to the keep-alive endpoint on purpose: renewing on every request would stop
-    // the SecurityStampValidator ever exceeding its ValidationInterval during active use.
-    [Test]
-    public async Task Cannot_Renew_Ticket_For_Non_KeepAlive_Request()
-    {
-        _mockStampValidator
-            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
-            .Returns(Task.CompletedTask);
-
-        var originalIssuedUtc = _now.AddMinutes(-10);
-        var originalExpiresUtc = _now.AddMinutes(50);
-
-        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(
-            originalIssuedUtc,
-            originalExpiresUtc,
-            "/umbraco/management/api/v1/document");
-        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
-
-        // Act
-        await onValidatePrincipal(context);
-
-        // Assert
-        Assert.Multiple(() =>
-        {
-            Assert.That(context.ShouldRenew, Is.False);
-            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(originalIssuedUtc));
-            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(originalExpiresUtc));
-        });
     }
 
     // A Management API request is always JSON, so an unauthenticated one must get a status code rather
@@ -344,9 +256,10 @@ public class ConfigureBackOfficeCookieOptionsTests
     private CookieValidatePrincipalContext CreateValidatePrincipalContext(
         DateTimeOffset issuedUtc,
         DateTimeOffset expiresUtc,
-        string? requestPath = null)
+        string? requestPath = null,
+        ClaimsPrincipal? principal = null)
     {
-        ClaimsPrincipal principal = CreateBackOfficePrincipal();
+        principal ??= CreateBackOfficePrincipal();
 
         var properties = new AuthenticationProperties
         {
@@ -395,6 +308,23 @@ public class ConfigureBackOfficeCookieOptionsTests
             new Claim(ClaimTypes.Locality, "en-US", ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
             new Claim(Constants.Security.SecurityStampClaimType, Guid.NewGuid().ToString(), ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
             new Claim(Constants.Security.SessionIdClaimType, Guid.NewGuid().ToString(), ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
+        ]);
+
+        return new ClaimsPrincipal(identity);
+    }
+
+    // Missing the required GivenName claim, so GetUmbracoIdentity() rejects it as not a valid back-office identity.
+    private static ClaimsPrincipal CreateInvalidBackOfficePrincipal()
+    {
+        var identity = new ClaimsIdentity(
+            Constants.Security.BackOfficeAuthenticationType,
+            ClaimTypes.Name,
+            ClaimTypes.Role);
+
+        identity.AddClaims(
+        [
+            new Claim(ClaimTypes.NameIdentifier, "1234", ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
+            new Claim(ClaimTypes.Name, "admin@example.com", ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
         ]);
 
         return new ClaimsPrincipal(identity);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
@@ -49,9 +49,11 @@ public class ConfigureBackOfficeCookieOptionsTests
     }
 
     [Test]
-    public async Task Can_Renew_Ticket_For_Any_Request_With_Valid_Identity()
+    public async Task Can_Extend_Expiry_On_Activity_Without_Resetting_IssuedUtc_When_Stamp_Not_Revalidated()
     {
-        // Arrange: nothing else would trigger a renewal - validator does nothing, arbitrary path.
+        // Arrange: the stamp validator does nothing, i.e. its ValidationInterval has not elapsed yet
+        // (this is the common case for most requests: AllowConcurrentLogins = true keeps a non-zero
+        // interval, so most requests fall in the gap between stamp re-validations).
         _mockStampValidator
             .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
             .Returns(Task.CompletedTask);
@@ -68,11 +70,14 @@ public class ConfigureBackOfficeCookieOptionsTests
         // Act
         await onValidatePrincipal(context);
 
-        // Assert: any request with a valid back-office identity renews the ticket
+        // Assert: the session still gets refreshed on activity (ExpiresUtc slides forward), but
+        // IssuedUtc must be left untouched - resetting it here would reset the SecurityStampValidator's
+        // interval clock on every request and stop it from ever re-checking the stamp again during an
+        // active session (e.g. a password change or a disabled account would go unnoticed).
         Assert.Multiple(() =>
         {
             Assert.That(context.ShouldRenew, Is.True);
-            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(_now));
+            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(originalIssuedUtc));
             Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(_now.Add(_globalSettings.TimeOut)));
         });
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
@@ -313,9 +313,7 @@ public class ConfigureBackOfficeCookieOptionsTests
         return new ClaimsPrincipal(identity);
     }
 
-    // Missing the required GivenName claim, so GetUmbracoIdentity() rejects it as not a valid back-office identity.
-    private static ClaimsPrincipal CreateInvalidBackOfficePrincipal()
-    {
+    // Missing required back-office claims (GivenName, Locality, SecurityStamp), so GetUmbracoIdentity() rejects it as not a valid back-office identity.
         var identity = new ClaimsIdentity(
             Constants.Security.BackOfficeAuthenticationType,
             ClaimTypes.Name,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
@@ -314,6 +314,8 @@ public class ConfigureBackOfficeCookieOptionsTests
     }
 
     // Missing required back-office claims (GivenName, Locality, SecurityStamp), so GetUmbracoIdentity() rejects it as not a valid back-office identity.
+    private static ClaimsPrincipal CreateInvalidBackOfficePrincipal()
+    {
         var identity = new ClaimsIdentity(
             Constants.Security.BackOfficeAuthenticationType,
             ClaimTypes.Name,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In Umbraco 13, _any_ request bearing a valid backoffice identity results in a refreshed session (re-issued auth cookie). This matches the [description](https://docs.umbraco.com/umbraco-cms/17.latest/develop-with-umbraco/configuration/globalsettings) of the global timeout setting:

> Configure the session timeout to determine how much time without a request being made can pass before the user is required to log in again. [...] Any activity within the backoffice will reset the timer.

The [recent rework for cookie auth](https://github.com/umbraco/Umbraco-CMS/pull/23484) does not honour this correctly. It's only by coincidence that the session is kept alive on activity, because the handling of concurrent logins forces a session refresh with the default settings (no concurrent logins).

This PR restores the documented session refresh behavior; any request bearing a valid backoffice identity now refreshes the session explicitly.

The concurrent login handling remains unaffected by this PR.

### Historical note

The stricter conditional renewal was originally introduced to enforce the concurrent login handling, on the assumption that resetting `IssuedUtc` on every request would prevent `SecurityStampValidator` from ever exceeding its `ValidationInterval`. 

That assumption no longer holds: `ConfigureSecurityStampOptions` forces `ValidationInterval` to `TimeSpan.Zero` when concurrent logins are disallowed, so the stamp check fires on effectively every request regardless of how often we reset `IssuedUtc`.

### Testing this PR

1. Verify that the concurrent login handling still works, both with and without concurrent logins allowed (use two different browsers or incognito mode to emulate simultaneous logins).
2. Verify that the session stays alive past the configured timeout when performing some kind of activity in the backoffice (set the timeout value to 2 minutes for a quicker test).
3. Verify that the keep-alive warning ("you're about to be logged out") can refresh the session.
4. Verify that the session expires when ignoring the keep-alive warning.
