### PR TITLE
Members: Add group to member filter item

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/MemberPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MemberPresentationFactory.cs
@@ -194,6 +194,7 @@ internal sealed class MemberPresentationFactory : IMemberPresentationFactory
                 Id = item.MemberTypeKey ?? Guid.Empty,
                 Icon = item.MemberTypeIcon ?? string.Empty,
             },
+            Groups = item.Groups,
         };
 
     private MemberItemResponseModel CreateItemResponseModel<T>(T entity)

--- a/src/Umbraco.Core/Models/Membership/MemberFilterItem.cs
+++ b/src/Umbraco.Core/Models/Membership/MemberFilterItem.cs
@@ -77,4 +77,9 @@ public class MemberFilterItem
     ///     Gets or sets the member kind.
     /// </summary>
     public MemberKind Kind { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the keys of the member groups the member belongs to.
+    /// </summary>
+    public IEnumerable<Guid> Groups { get; set; } = Enumerable.Empty<Guid>();
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberFilterRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberFilterRepository.cs
@@ -83,10 +83,83 @@ internal sealed class MemberFilterRepository : IMemberFilterRepository
         PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
         Page<MemberFilterItemDto> page = await Database.PageAsync<MemberFilterItemDto>(pageNumber + 1, pageSize, combinedSql);
 
-        return new PagedModel<MemberFilterItem>(
-            page.TotalItems,
-            page.Items.Select(MapToItem));
+        var items = page.Items.Select(MapToItem).ToList();
+        Dictionary<Guid, List<Guid>> groupKeysByMemberKey = await GetGroupKeysByMemberKeyAsync(page.Items);
+        foreach (MemberFilterItem item in items)
+        {
+            if (groupKeysByMemberKey.TryGetValue(item.Key, out List<Guid>? groupKeys))
+            {
+                item.Groups = groupKeys;
+            }
+        }
+
+        return new PagedModel<MemberFilterItem>(page.TotalItems, items);
     }
+
+    private async Task<Dictionary<Guid, List<Guid>>> GetGroupKeysByMemberKeyAsync(IReadOnlyCollection<MemberFilterItemDto> items)
+    {
+        var groupKeysByMemberKey = new Dictionary<Guid, List<Guid>>();
+
+        Guid[] contentMemberKeys = items.Where(x => x.IsExternalOnly is false).Select(x => x.Key).ToArray();
+        Guid[] externalMemberKeys = items.Where(x => x.IsExternalOnly).Select(x => x.Key).ToArray();
+
+        if (contentMemberKeys.Length > 0)
+        {
+            await AppendGroupKeysAsync(groupKeysByMemberKey, contentMemberKeys, BuildContentMemberGroupKeysSql);
+        }
+
+        if (externalMemberKeys.Length > 0)
+        {
+            await AppendGroupKeysAsync(groupKeysByMemberKey, externalMemberKeys, BuildExternalMemberGroupKeysSql);
+        }
+
+        return groupKeysByMemberKey;
+    }
+
+    private async Task AppendGroupKeysAsync(
+        Dictionary<Guid, List<Guid>> target,
+        Guid[] memberKeys,
+        Func<IEnumerable<Guid>, Sql<ISqlContext>> sqlFactory)
+    {
+        foreach (IEnumerable<Guid> batch in memberKeys.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            List<MemberGroupKeyDto> rows = await Database.FetchAsync<MemberGroupKeyDto>(sqlFactory(batch));
+            foreach (MemberGroupKeyDto row in rows)
+            {
+                if (target.TryGetValue(row.MemberKey, out List<Guid>? groupKeys) is false)
+                {
+                    groupKeys = new List<Guid>();
+                    target[row.MemberKey] = groupKeys;
+                }
+
+                groupKeys.Add(row.GroupKey);
+            }
+        }
+    }
+
+    private Sql<ISqlContext> BuildContentMemberGroupKeysSql(IEnumerable<Guid> memberKeys) =>
+        SqlContext.Sql()
+            .Append(
+                $@"SELECT
+                    n.{QCol(NodeDto.KeyColumnName)} AS {QName("memberKey")},
+                    mgn.{QCol(NodeDto.KeyColumnName)} AS {QName("groupKey")}
+                FROM {QTab(Member2MemberGroupDto.TableName)} m2mg
+                INNER JOIN {QTab(NodeDto.TableName)} n ON n.{QCol(NodeDto.PrimaryKeyColumnName)} = m2mg.{QCol(Member2MemberGroupDto.MemberColumnName)}
+                INNER JOIN {QTab(NodeDto.TableName)} mgn ON mgn.{QCol(NodeDto.PrimaryKeyColumnName)} = m2mg.{QCol(Member2MemberGroupDto.MemberGroupColumnName)}
+                WHERE n.{QCol(NodeDto.KeyColumnName)} IN (@memberKeys)",
+                new { memberKeys });
+
+    private Sql<ISqlContext> BuildExternalMemberGroupKeysSql(IEnumerable<Guid> memberKeys) =>
+        SqlContext.Sql()
+            .Append(
+                $@"SELECT
+                    em.{QCol("key")} AS {QName("memberKey")},
+                    mgn.{QCol(NodeDto.KeyColumnName)} AS {QName("groupKey")}
+                FROM {QTab(ExternalMember2MemberGroupDto.TableName)} em2mg
+                INNER JOIN {QTab(ExternalMemberDto.TableName)} em ON em.{QCol(ExternalMemberDto.PrimaryKeyColumnName)} = em2mg.{QCol(ExternalMember2MemberGroupDto.ExternalMemberColumnName)}
+                INNER JOIN {QTab(NodeDto.TableName)} mgn ON mgn.{QCol(NodeDto.PrimaryKeyColumnName)} = em2mg.{QCol(ExternalMember2MemberGroupDto.MemberGroupColumnName)}
+                WHERE em.{QCol("key")} IN (@memberKeys)",
+                new { memberKeys });
 
     private Sql<ISqlContext> BuildContentMemberSql(MemberFilter filter)
     {
@@ -279,5 +352,18 @@ internal sealed class MemberFilterRepository : IMemberFilterRepository
 
         [Column("memberTypeIcon")]
         public string? MemberTypeIcon { get; set; }
+    }
+
+    /// <summary>
+    ///     Internal DTO for member-to-group key lookups.
+    /// </summary>
+    [ExplicitColumns]
+    private sealed class MemberGroupKeyDto
+    {
+        [Column("memberKey")]
+        public Guid MemberKey { get; set; }
+
+        [Column("groupKey")]
+        public Guid GroupKey { get; set; }
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberFilterServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberFilterServiceTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
@@ -26,6 +27,34 @@ internal sealed class MemberFilterServiceTests : UmbracoIntegrationTest
     private IMemberService MemberService => GetRequiredService<IMemberService>();
 
     private IMemberTypeService MemberTypeService => GetRequiredService<IMemberTypeService>();
+
+    private IMemberGroupService MemberGroupService => GetRequiredService<IMemberGroupService>();
+
+    [Test]
+    public async Task Filter_Returns_Group_Keys_For_Both_Stores()
+    {
+        // Arrange — one group shared by a content member and an external member.
+        MemberService.AddRole("FilterGroupKeysGroup");
+        IMemberGroup group = MemberGroupService.GetByName("FilterGroupKeysGroup")!;
+
+        await CreateContentMemberAsync("content@test.com", "content-user");
+        IMember? contentMember = MemberService.GetByEmail("content@test.com");
+        MemberService.AssignRoles([contentMember!.Id], ["FilterGroupKeysGroup"]);
+
+        await CreateExternalMemberAsync("external@test.com", "external-user");
+        ExternalMemberIdentity? externalMember = await ExternalMemberService.GetByUsernameAsync("external-user");
+        await ExternalMemberService.AssignRolesAsync(externalMember!.Key, ["FilterGroupKeysGroup"]);
+
+        // Act
+        PagedModel<MemberFilterItem> result = await MemberFilterService.FilterAsync(new MemberFilter());
+
+        // Assert — both members report the shared group's key.
+        Assert.AreEqual(2, result.Total);
+        foreach (MemberFilterItem item in result.Items)
+        {
+            Assert.That(item.Groups, Does.Contain(group.Key));
+        }
+    }
 
     [Test]
     public async Task Filter_Returns_Content_Members()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/MemberPresentationFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/MemberPresentationFactoryTests.cs
@@ -423,6 +423,27 @@ public class MemberPresentationFactoryTests
     }
 
     [Test]
+    public void CreateFilterItemResponseModel_Maps_Group_Keys()
+    {
+        // Arrange
+        var groupKey = Guid.NewGuid();
+        var item = new MemberFilterItem
+        {
+            Key = Guid.NewGuid(),
+            Email = "filter-grouped@test.com",
+            UserName = "filter-grouped",
+            Kind = MemberKind.Default,
+            Groups = [groupKey],
+        };
+
+        // Act
+        MemberResponseModel result = _sut.CreateFilterItemResponseModel(item, CreateMockUser(true).Object);
+
+        // Assert
+        Assert.That(result.Groups.ToList(), Does.Contain(groupKey));
+    }
+
+    [Test]
     public void CreateFilterItemResponseModel_Maps_External_Member_With_Empty_Type()
     {
         // Arrange


### PR DESCRIPTION
# Notes
This bug is something that came up internally, it seems that calling the filter endpoint will always return an empty array for the `group` property. This was a bug, as the group property was never added to the  `MemberFilterItem`.
- Adds the `Group` to the `MemberFilterItem`

# How to test
- Create a member group
- Create a member, and the group to the member
- Call the filter endpoint, it should now return the correct groups for the member.