### PR TITLE
Document Picker: Fix removal of a "not found" reference (closes #23792)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.test.ts
@@ -1,9 +1,15 @@
 import { UmbDocumentPickerInputContext } from './input-document.context.js';
+import { UMB_DOCUMENT_ENTITY_TYPE } from '../../entity.js';
+import { UmbDocumentVariantState } from '../../variant-state.js';
 import type { UmbDocumentItemModel } from '../../item/types.js';
 import { expect } from '@open-wc/testing';
 import { customElement } from 'lit/decorators.js';
 import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
 import { UmbVariantContext } from '@umbraco-cms/backoffice/variant';
+
+// The picker holds items as UmbDocumentItemModel widened with a name, see the HACK on
+// UmbDocumentPickerInputContext.
+type UmbTestPickedDocumentItemModel = UmbDocumentItemModel & { name: string };
 
 @customElement('test-document-picker-input-context-host')
 class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
@@ -11,14 +17,14 @@ class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLEle
 // Exposes the protected _requestItemName method and bypasses the item manager so
 // tests do not need the repository extension to be registered.
 class UmbTestDocumentPickerInputContext extends UmbDocumentPickerInputContext {
-	#testItems = new Map<string, UmbDocumentItemModel>();
+	#testItems = new Map<string, UmbTestPickedDocumentItemModel>();
 
-	setTestItem(item: UmbDocumentItemModel) {
+	setTestItem(item: UmbTestPickedDocumentItemModel) {
 		this.#testItems.set(item.unique, item);
 	}
 
 	override getSelectedItemByUnique(unique: string) {
-		return this.#testItems.get(unique) as (UmbDocumentItemModel & { name: string }) | undefined;
+		return this.#testItems.get(unique);
 	}
 
 	async requestItemName(unique: string): Promise<string> {
@@ -26,33 +32,29 @@ class UmbTestDocumentPickerInputContext extends UmbDocumentPickerInputContext {
 	}
 }
 
-function makeItem(unique: string, name: string): UmbDocumentItemModel {
+function makeItem(unique: string, name: string): UmbTestPickedDocumentItemModel {
 	return {
-		entityType: 'document',
+		entityType: UMB_DOCUMENT_ENTITY_TYPE,
 		unique,
-		isTrashed: false,
-		isProtected: false,
-		createDate: null,
+		name,
 		documentType: {
 			unique: 'document-type-unique',
 			icon: 'icon-document',
-			collection: null,
 		},
 		hasChildren: false,
+		isProtected: false,
+		isTrashed: false,
 		parent: null,
 		flags: [],
 		variants: [
 			{
 				name,
 				culture: 'en-US',
-				segment: null,
-				state: 'Published',
-				createDate: null,
-				updateDate: null,
+				state: UmbDocumentVariantState.PUBLISHED,
 				flags: [],
 			},
 		],
-	} as unknown as UmbDocumentItemModel;
+	};
 }
 
 describe('UmbDocumentPickerInputContext._requestItemName', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.test.ts
@@ -1,0 +1,92 @@
+import { UmbDocumentPickerInputContext } from './input-document.context.js';
+import type { UmbDocumentItemModel } from '../../item/types.js';
+import { expect } from '@open-wc/testing';
+import { customElement } from 'lit/decorators.js';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { UmbVariantContext } from '@umbraco-cms/backoffice/variant';
+
+@customElement('test-document-picker-input-context-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+// Exposes the protected _requestItemName method and bypasses the item manager so
+// tests do not need the repository extension to be registered.
+class UmbTestDocumentPickerInputContext extends UmbDocumentPickerInputContext {
+	#testItems = new Map<string, UmbDocumentItemModel>();
+
+	setTestItem(item: UmbDocumentItemModel) {
+		this.#testItems.set(item.unique, item);
+	}
+
+	override getSelectedItemByUnique(unique: string) {
+		return this.#testItems.get(unique) as (UmbDocumentItemModel & { name: string }) | undefined;
+	}
+
+	async requestItemName(unique: string): Promise<string> {
+		return this._requestItemName(unique);
+	}
+}
+
+function makeItem(unique: string, name: string): UmbDocumentItemModel {
+	return {
+		entityType: 'document',
+		unique,
+		isTrashed: false,
+		isProtected: false,
+		createDate: null,
+		documentType: {
+			unique: 'document-type-unique',
+			icon: 'icon-document',
+			collection: null,
+		},
+		hasChildren: false,
+		parent: null,
+		flags: [],
+		variants: [
+			{
+				name,
+				culture: 'en-US',
+				segment: null,
+				state: 'Published',
+				createDate: null,
+				updateDate: null,
+				flags: [],
+			},
+		],
+	} as unknown as UmbDocumentItemModel;
+}
+
+describe('UmbDocumentPickerInputContext._requestItemName', () => {
+	let hostElement: UmbTestControllerHostElement;
+	let context: UmbTestDocumentPickerInputContext;
+
+	beforeEach(async () => {
+		hostElement = new UmbTestControllerHostElement();
+		document.body.appendChild(hostElement);
+
+		const variantContext = new UmbVariantContext(hostElement);
+		await variantContext.setCulture('en-US');
+		await variantContext.setFallbackCulture('en-US');
+		await variantContext.setAppCulture('en-US');
+
+		context = new UmbTestDocumentPickerInputContext(hostElement);
+	});
+
+	afterEach(() => {
+		context.destroy();
+		document.body.innerHTML = '';
+	});
+
+	it('should return the variant name of a selected item', async () => {
+		context.setTestItem(makeItem('document-1', 'Document One'));
+
+		const name = await context.requestItemName('document-1');
+		expect(name).to.equal('Document One');
+	});
+
+	it('should resolve to the not found label when the unique has no item', async () => {
+		// A selection can reference a deleted document. The name must still resolve, otherwise
+		// everything awaiting it - such as the remove confirmation dialog - never happens.
+		const name = await context.requestItemName('does-not-exist');
+		expect(name).to.equal('#general_notFound');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.ts
@@ -61,13 +61,31 @@ export class UmbDocumentPickerInputContext extends UmbPickerInputContext<
 		await super.openPicker(combinedPickerData);
 	}
 
+	/**
+	 * Resolves the display name for a picked document, using the variant aware item data resolver.
+	 * @param {string} unique The unique identifier of the document.
+	 * @returns {Promise<string>} The resolved display name.
+	 * @memberof UmbDocumentPickerInputContext
+	 */
 	protected override async _requestItemName(unique: string): Promise<string> {
 		const item = this.getSelectedItemByUnique(unique);
-		const resolver = new UmbDocumentItemDataResolver(this);
-		resolver.setData(item);
-		const name = await resolver.getName();
-		this.removeUmbController(resolver);
-		return name ?? '#general_notFound';
+
+		// A selection can hold uniques that no longer resolve to an item. The resolver cannot name
+		// something it has no data for, so let the base implementation supply the fallback label.
+		if (item) {
+			const resolver = new UmbDocumentItemDataResolver(this);
+			resolver.setData(item);
+			try {
+				const name = await resolver.getName();
+				if (name) {
+					return name;
+				}
+			} finally {
+				this.removeUmbController(resolver);
+			}
+		}
+
+		return super._requestItemName(unique);
 	}
 
 	#pickableFilter = (


### PR DESCRIPTION
## Description

Reported in #23792, removing a "not found" reference from a Content Picker no longer worked. This is a regression introduced in the latest code, not yet released, affecting 17 and 18.

### The cause

`UmbPickerInputContext.requestRemoveItem` awaits `_requestItemName(unique)` and only then opens the confirmation modal. The base implementation is synchronous and handles a missing item:

```ts
protected async _requestItemName(unique: string) {
    return this.getSelectedItemByUnique(unique)?.name ?? '#general_notFound';
}
```

`UmbDocumentPickerInputContext` overrides `_requestItemName` (added in #20853, so the confirmation dialog shows the correct variant name) and passed the item straight to a resolver without checking it was there. The resolver for documents will exit if no variants are found, which there won't be for a non-existing item, so the name is not set and the modal doesn't open.

### The fix

`UmbDocumentPickerInputContext._requestItemName` now checks the item is present before building a resolver, and otherwise falls through to `super._requestItemName(unique)`, which supplies `#general_notFound` (localized to "Not found" by the confirm modal). This is the same shape as the already-correct `UmbEntityDataPickerInputContext`.

## Testing

### Automated

An automated unit test was added to verify the behaviour.

The existing acceptance test `ContentWithContentPicker.spec.ts` → "can remove a not-found content picker" (the #21130 regression test) covers this. 

### Manual

1. Add a Content Picker to a document type and create two documents.
2. Pick one in the other's Content Picker property and save.
3. Delete the picked document and empty the recycle bin.
4. Reopen the referencing document — the picker shows "Not found".
5. Click Remove — the confirmation dialog now appears, and confirming removes the reference.
