### PR TITLE
External Login: Prevent auto-linking an external identity to an API user account

### DIFF
--- a/src/Umbraco.Cms.Api.Management/CLAUDE.md
+++ b/src/Umbraco.Cms.Api.Management/CLAUDE.md
@@ -387,6 +387,13 @@ protected async Task<IActionResult> HandleRequest(request, Func<Task<IActionResu
 - Google, Microsoft, OpenID Connect providers
 - Auto-linking with `ExternalSignInAutoLinkOptions`
 - **Critical**: Validate external claims before auto-linking users
+- **Only `UserKind.Default` users can sign in.** Auto-linking matches on the external login's email
+  address, and emails are unique across all users regardless of kind — so the match can be an API
+  user, which is non-interactive by design. Refused both at the link
+  (`AutoLinkSignInResult.FailedUnsupportedUserKind`) and at sign in (`CanSignInAsync`).
+- **Nothing consumes the result types** in `Security/AutoLinkSignInResult.cs`:
+  `BackOfficeController.AuthorizeExternal` collapses every failure into a default challenge, so the
+  reason reaches the logs but not the user. Members have their own same-named nested copies.
 
 ### Input Validation
 **FluentValidation** used throughout:

--- a/src/Umbraco.Cms.Api.Management/Security/AutoLinkSignInResult.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/AutoLinkSignInResult.cs
@@ -36,6 +36,12 @@ public class AutoLinkSignInResult : SignInResult
     public static AutoLinkSignInResult FailedNoName { get; } = new() { Succeeded = false };
 
     /// <summary>
+    /// Gets a result indicating the auto-link sign-in failed because the user matched on the external login's email
+    /// address is of a kind that is not permitted to sign in to the back office.
+    /// </summary>
+    public static AutoLinkSignInResult FailedUnsupportedUserKind { get; } = new() { Succeeded = false };
+
+    /// <summary>
     /// Gets the collection of error messages related to the auto-link sign-in process.
     /// </summary>
     public IReadOnlyCollection<string> Errors { get; } = Array.Empty<string>();

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManager.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Web.Common.Security;
@@ -116,6 +117,30 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
     }
 
     /// <summary>
+    ///     Overridden to ensure that only users of <see cref="UserKind.Default" /> can obtain a back office session.
+    /// </summary>
+    /// <param name="user">The user attempting to sign in.</param>
+    /// <returns><c>true</c> if the user can sign in; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    ///     Users of other kinds are not interactive: they authenticate against the token endpoint using their own
+    ///     credentials and never hold a back office session.
+    /// </remarks>
+    public override async Task<bool> CanSignInAsync(BackOfficeIdentityUser user)
+    {
+        if (user.Kind != UserKind.Default)
+        {
+            Logger.LogWarning(
+                "Sign in refused for a user of kind '{UserKind}', which cannot sign in to the back office. Affected user id: '{UserId}', key: '{UserKey}'",
+                user.Kind,
+                user.Id,
+                user.Key);
+            return false;
+        }
+
+        return await base.CanSignInAsync(user);
+    }
+
+    /// <summary>
     ///     Configures the redirect URL and user identifier for the specified external login <paramref name="provider" />.
     /// </summary>
     /// <param name="provider">The provider to configure.</param>
@@ -218,6 +243,20 @@ public class BackOfficeSignInManager : UmbracoSignInManager<BackOfficeIdentityUs
         BackOfficeIdentityUser? autoLinkUser = await UserManager.FindByEmailAsync(email!);
         if (autoLinkUser != null)
         {
+            // Email addresses are unique across all users regardless of their kind, so the match found here could be a
+            // user that is not permitted to sign in interactively. Auto-linking to such a user would grant an external
+            // identity a back office session under an account that was never intended to have one.
+            if (autoLinkUser.Kind != UserKind.Default)
+            {
+                Logger.LogWarning(
+                    "External login auto-link failed for provider '{LoginProvider}': the user matched on email address is of kind '{UserKind}', which cannot sign in to the back office. Affected user id: '{UserId}', key: '{UserKey}'",
+                    loginInfo.LoginProvider,
+                    autoLinkUser.Kind,
+                    autoLinkUser.Id,
+                    autoLinkUser.Key);
+                return AutoLinkSignInResult.FailedUnsupportedUserKind;
+            }
+
             try
             {
                 // Call the callback if one is assigned

--- a/src/Umbraco.Web.Common/CLAUDE.md
+++ b/src/Umbraco.Web.Common/CLAUDE.md
@@ -249,12 +249,20 @@ ASP.NET Core Identity sign-in manager for members.
 4. Add external login link
 5. Sign in or request 2FA
 
-**Result Types** (lines 320-348):
+**Result Types** — nested in `MemberSignInManager`, consumed by
+`UmbExternalLoginController.ExternalLoginCallback` (Umbraco.Web.Website), which maps each to a
+member-facing error message:
 - `ExternalLoginSignInResult.NotAllowed` - Login refused by callback
+- `AutoLinkSignInResult.FailedNotLinked` - Provider not linked to an account
 - `AutoLinkSignInResult.FailedNoEmail` - No email from provider
 - `AutoLinkSignInResult.FailedNoName` - No name from provider when creating a new account
 - `AutoLinkSignInResult.FailedCreatingUser` - User creation failed
 - `AutoLinkSignInResult.FailedLinkingUser` - Link creation failed
+- `AutoLinkSignInResult.FailedException` - An auto-link callback threw
+
+The back office has its own separate `AutoLinkSignInResult` / `ExternalLoginSignInResult` in
+`Umbraco.Cms.Api.Management.Security`, with an overlapping but not identical set of values — check
+which one you have before adding or handling a value.
 
 ### Middleware
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManagerTests.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -179,6 +180,52 @@ public class BackOfficeSignInManagerTests
             ((AutoLinkSignInResult)actual).Errors);
     }
 
+    /// <remarks>
+    ///     Email addresses are unique across all users regardless of their kind, so the user matched on the external
+    ///     login's email address can be one that is not permitted to sign in to the back office.
+    /// </remarks>
+    [Test]
+    public async Task Cannot_Auto_Link_External_Login_To_A_User_Of_A_Kind_That_Cannot_Sign_In()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut();
+        BackOfficeIdentityUser existingUser = CreateUser(UserKind.Api);
+        _userManager.Setup(x => x.FindByEmailAsync(TestEmail)).ReturnsAsync(existingUser);
+
+        // Act
+        SignInResult actual = await sut.ExternalLoginSignInAsync(CreateExternalLoginInfoWithEmail(), false);
+
+        // Assert
+        Assert.AreSame(AutoLinkSignInResult.FailedUnsupportedUserKind, actual);
+        _userManager.Verify(x => x.AddLoginAsync(existingUser, It.IsAny<UserLoginInfo>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Cannot_Sign_In_A_User_Of_A_Kind_That_Cannot_Sign_In()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut();
+
+        // Act
+        var actual = await sut.CanSignInAsync(CreateUser(UserKind.Api));
+
+        // Assert
+        Assert.IsFalse(actual);
+    }
+
+    [Test]
+    public async Task Can_Sign_In_A_Default_User()
+    {
+        // Arrange
+        BackOfficeSignInManager sut = CreateSut();
+
+        // Act
+        var actual = await sut.CanSignInAsync(CreateUser());
+
+        // Assert
+        Assert.IsTrue(actual);
+    }
+
     private BackOfficeSignInManager CreateSut(ExternalSignInAutoLinkOptions? autoLinkOptions = null)
     {
         _userManager = MockUserManager();
@@ -216,8 +263,8 @@ public class BackOfficeSignInManagerTests
             Mock.Of<IBackOfficeUserPasswordChecker>(),
             Options.Create(new GlobalSettings()));
 
-    private static BackOfficeIdentityUser CreateUser()
-        => BackOfficeIdentityUser.CreateNew(new GlobalSettings(), TestEmail, TestEmail, "en-US", "Test User");
+    private static BackOfficeIdentityUser CreateUser(UserKind kind = UserKind.Default)
+        => BackOfficeIdentityUser.CreateNew(new GlobalSettings(), TestEmail, TestEmail, "en-US", "Test User", kind: kind);
 
     private static IBackOfficeExternalLoginProviders MockExternalLoginProviders(ExternalSignInAutoLinkOptions? autoLinkOptions)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/BackOfficeSignInManagerTests.cs
@@ -185,7 +185,7 @@ public class BackOfficeSignInManagerTests
     ///     login's email address can be one that is not permitted to sign in to the back office.
     /// </remarks>
     [Test]
-    public async Task Cannot_Auto_Link_External_Login_To_A_User_Of_A_Kind_That_Cannot_Sign_In()
+    public async Task Cannot_Auto_Link_External_Login_To_An_Api_User()
     {
         // Arrange
         BackOfficeSignInManager sut = CreateSut();
@@ -201,7 +201,7 @@ public class BackOfficeSignInManagerTests
     }
 
     [Test]
-    public async Task Cannot_Sign_In_A_User_Of_A_Kind_That_Cannot_Sign_In()
+    public async Task Cannot_Sign_In_An_Api_User()
     {
         // Arrange
         BackOfficeSignInManager sut = CreateSut();


### PR DESCRIPTION
## Description

An external login provider could bind an external identity to a `UserKind.Api` user, signing that identity into the back office as the API user.

`BackOfficeSignInManager.AutoLinkAndSignInExternalAccount` locates the user to link by email address.  That lookup does not filter on `UserKind`, so an API user is a valid link target.  API users are meant to be non-interactive, so shouldn't be associated with a backoffice session based account.

### Fix

Two guards, both in `BackOfficeSignInManager`:

1. **`AutoLinkAndSignInExternalAccount`** — after the email lookup, a user whose `Kind` is not `Default` is refused with a new `AutoLinkSignInResult.FailedUnsupportedUserKind`, before any linking or callback invocation. The accompanying warning names the provider, the kind, and the user id and key.
2. **`CanSignInAsync` override** — defence in depth. `PreSignInCheck` calls it on the password sign-in path and on the external path for an already-linked user, so no `UserKind.Api` user can obtain an interactive session by any route, not just a first-time auto-link.

## Testing

### Automated

Three tests added to the existing `BackOfficeSignInManagerTests` to verify this behaviour.

### Manual

Using an Auth0 provider configured against a local install holding an API user on the same email address as the external identity, the sign-in attempt is refused and logs:

```
[09:09:49 WRN] External login auto-link failed for provider 'Umbraco.Auth0': the user matched on
email address is of kind 'Api', which cannot sign in to the back office. Affected user id: '5',
key: '3473dc3c-b3b8-4e81-95ca-6623a54d0046'
```

The browser returns to the back-office login screen.