### PR TITLE
Search: Fix culture-dependent decimal facet parsing and integration tests failing on SQL Server (closes #23783)

### DIFF
--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;
 using Examine;
@@ -674,8 +674,11 @@ public class Searcher : IExamineSearcher
     /// Numeric facet labels are formatted by the search index using the culture of the thread that performed the
     /// indexing, which is not necessarily the culture of the thread performing the search. The format carries a
     /// decimal separator but never group separators, which is what makes replacing a comma safe.
+    /// Known gap: when the indexing culture's decimal separator is neither "." nor "," (for example fa-IR) and
+    /// the search culture differs, the label fails to parse and its bucket is omitted from the facet result.
+    /// Whole numbers are unaffected, as are the matched documents themselves.
     /// </remarks>
-    private static bool TryParseFacetLabelAsDecimal(string label, out decimal value)
+    internal static bool TryParseFacetLabelAsDecimal(string label, out decimal value)
         => decimal.TryParse(label.Replace(',', '.'), NumberStyles.Float, CultureInfo.InvariantCulture, out value)
            || decimal.TryParse(label, NumberStyles.Float, CultureInfo.CurrentCulture, out value);
 

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
+using System.Globalization;
 using System.Reflection;
 using Examine;
 using Examine.Lucene;
@@ -601,7 +602,7 @@ public class Searcher : IExamineSearcher
 
                     foreach (IFacetValue decimalExactFacetValue in examineDecimalFacets)
                     {
-                        if (decimal.TryParse(decimalExactFacetValue.Label, out var labelValue) is false)
+                        if (TryParseFacetLabelAsDecimal(decimalExactFacetValue.Label, out var labelValue) is false)
                         {
                             // Cannot convert the label to decimal, skipping.
                             continue;
@@ -662,6 +663,21 @@ public class Searcher : IExamineSearcher
             }
         }
     }
+
+    /// <summary>
+    /// Attempts to parse a facet label as a decimal value, handling both invariant and current culture formats.
+    /// </summary>
+    /// <param name="label">The facet label to parse.</param>
+    /// <param name="value">The parsed decimal value, if successful.</param>
+    /// <returns>True if the label was successfully parsed as a decimal; otherwise, false.</returns>
+    /// <remarks>
+    /// Numeric facet labels are formatted by the search index using the culture of the thread that performed the
+    /// indexing, which is not necessarily the culture of the thread performing the search. The format carries a
+    /// decimal separator but never group separators, which is what makes replacing a comma safe.
+    /// </remarks>
+    private static bool TryParseFacetLabelAsDecimal(string label, out decimal value)
+        => decimal.TryParse(label.Replace(',', '.'), NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+           || decimal.TryParse(label, NumberStyles.Float, CultureInfo.CurrentCulture, out value);
 
     /// <summary>
     /// Override this method to extract custom <see cref="Facet"/> types to <see cref="FacetResult"/> in derived classes.

--- a/tests/Umbraco.Tests.Integration/Umbraco.Search.Core/LabelPropertyValueHandlerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Search.Core/LabelPropertyValueHandlerTests.cs
@@ -24,7 +24,7 @@ public class LabelPropertyValueHandlerTests : ContentTestBase
                     decimalValue = 56.78m,
                     integerValue = 1234,
                     stringValue = "The label value",
-                    timeValue = DateTime.MinValue.Add(new TimeSpan(1, 2, 3, 4)),
+                    timeValue = new DateTime(1900, 01, 01).Add(new TimeSpan(02, 03, 04)),
                     dateTimeValue = new DateTime(2004, 05, 06, 07, 08, 09)
                 })
             .Build();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Search.Provider.Examine/Tests/ContentTests/IndexService/VariantDocumentTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Search.Provider.Examine/Tests/ContentTests/IndexService/VariantDocumentTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Examine;
 using Examine.Search;
 using NUnit.Framework;
@@ -102,11 +103,14 @@ public class VariantDocumentTests : IndexTestBase
         IOrdering queryBuilder = index.Searcher.CreateQuery().All();
         queryBuilder.SelectField(field);
         ISearchResults results = queryBuilder.Execute();
+
+        // the index stores values culture invariantly, so the expected value must be formatted the same way
+        var expectedValue = Convert.ToString(value, CultureInfo.InvariantCulture);
         var result = results
             .SelectMany(x => x.Values.Values)
-            .First(x => x == value.ToString());
+            .First(x => x == expectedValue);
         Assert.That(results, Is.Not.Empty);
-        Assert.That(result, Is.EqualTo(value.ToString()));
+        Assert.That(result, Is.EqualTo(expectedValue));
     }
 
     [TestCase("title", "updatedTitle", "en-US")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Search.Provider.Examine/Services/SearcherFacetLabelTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Search.Provider.Examine/Services/SearcherFacetLabelTests.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+using NUnit.Framework;
+using Umbraco.Cms.Search.Provider.Examine.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Search.Provider.Examine.Services;
+
+[TestFixture]
+public class SearcherFacetLabelTests
+{
+    // The index is written by a background thread running under the process culture, but read on a request thread
+    // running under the culture of the authenticated back office user, so the two routinely disagree.
+    [TestCase("1.55", "en-US")]
+    [TestCase("1.55", "da-DK")]
+    [TestCase("1,55", "en-US")]
+    [TestCase("1,55", "da-DK")]
+    public void FacetLabel_IsParsedIndependentlyOfTheReadingCulture(string label, string readingCulture)
+    {
+        using var cultureScope = new CultureScope(readingCulture);
+
+        Assert.That(Searcher.TryParseFacetLabelAsDecimal(label, out var value), Is.True);
+        Assert.That(value, Is.EqualTo(1.55m));
+    }
+
+    [TestCase("en-US")]
+    [TestCase("da-DK")]
+    public void NonNumericFacetLabel_IsNotParsed(string readingCulture)
+    {
+        using var cultureScope = new CultureScope(readingCulture);
+
+        Assert.That(Searcher.TryParseFacetLabelAsDecimal("not a number", out _), Is.False);
+    }
+
+    private sealed class CultureScope : IDisposable
+    {
+        private readonly CultureInfo _original = CultureInfo.CurrentCulture;
+
+        public CultureScope(string culture) => CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+
+        public void Dispose() => CultureInfo.CurrentCulture = _original;
+    }
+}


### PR DESCRIPTION
## Description

Three tests in the reported playlist in #23783 were failing for two reasons.

Fixes #23783

### 1. `LabelPropertyValueHandlerTests.AllLabelEditors_CanBeIndexed`, fails on SQL Server

This is due to test data.  The test set the `LabelTime` property to `DateTime.MinValue.Add(new TimeSpan(1, 2, 3, 4))`, i.e. year 0001. `Time` maps to `ValueStorageType.Date`, and `umbracoPropertyData.dateValue` is a SQL Server `datetime` column whose minimum is 1753-01-01, so the insert threw `SqlDateTime overflow`. SQLite stores dates as text and accepted it.

This is fixed in the **test data setup** such that it now uses a value representable on every supported database.

### 2. Decimal tests affected by culture

These failures reproduce whenever the culture that wrote the index differs from the culture that reads it. Locally that is provoked by the test harness: `tests/Umbraco.Tests.Integration/AssemblyAttributes.cs` pins test threads to `en-US`, while background indexing threads run under the OS culture.

This is fixed in the **product in `Searcher.cs`.** Examine writes facet labels with `double.ToString()` — current culture — and we read them back with a bare `decimal.TryParse`, also current culture. When those two cultures differ, `"1.55"` parses as `155`.

Parsing now normalizes the decimal separator and goes through the invariant culture, falling back to the current culture. This is safe because the general numeric format carries a decimal separator but never group separators, and it corrects the mismatch in both directions.

The parsing method is `internal` so that `SearcherFacetLabelTests` can set the reading culture explicitly and assert both directions. Without that the fix would have had no regression guard on CI, since the integration tests inherit the agent's locale and pass either way — reproducing the bug locally required hand-editing `AssemblyAttributes.cs`.

#### Why this is a product bug and not just a test artifact

The two cultures can genuinely differ, because the write and read paths get their culture from different places when considering usage in the backoffice

- **Write** — indexing is always enqueued to `IBackgroundTaskQueue`with the work items running under the server's OS culture.
- **Read** — `UmbracoApplicationBuilder.cs:116` registers `UseRequestLocalization()` so a back-office request runs under the authenticated user's language.

So the two can disagree whenever the server's OS culture differs from the back-office user's language. Concretely, on a Danish-locale server a facet label is written as `"1,55"` and then read by the (default `en-US`) back office, where the comma is treated as a group separator and the facet key comes back as `155`.

The only in-box consumer is `SearchApiController` (the back-office Search section).

## Testing

Run the reporter's playlist; the three tests pass on SQLite and SQL Server, and on both `en-US` and `da-DK`. The new unit tests fail before the `Searcher.cs` change and pass after.
