### PR TITLE
Workspace: Reload workspace structure when an entity's structure changes (e.g. after "Move to")

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -135,6 +135,39 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 			});
 		});
 
+		it('re-requests ancestors when the event matches a currently displayed ancestor (e.g. an ancestor was renamed elsewhere)', async () => {
+			UmbTestTreeRepository.ancestors = [
+				createTestAncestorItem({ unique: 'parent-unique', entityType: 'test-entity-type' }),
+			];
+
+			dispatchReloadStructure();
+			await aTimeout(150);
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
+
+			// The event is for the ancestor, not the open entity itself.
+			dispatchReloadStructure({ unique: 'parent-unique' });
+			await aTimeout(150);
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(3);
+		});
+
+		it('does not re-request ancestors when the event is for an entity that is neither the open entity nor a currently displayed ancestor', async () => {
+			UmbTestTreeRepository.ancestors = [
+				createTestAncestorItem({ unique: 'parent-unique', entityType: 'test-entity-type' }),
+			];
+
+			dispatchReloadStructure();
+			await aTimeout(150);
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
+
+			dispatchReloadStructure({ unique: 'unrelated-unique' });
+			await aTimeout(150);
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
+		});
+
 		it('does not re-request ancestors when the event is for a different unique', async () => {
 			dispatchReloadStructure({ unique: 'some-other-unique' });
 			await aTimeout(150);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -55,6 +55,8 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 	});
 
 	afterEach(() => {
+		// Cancels any pending debounced fetch so it doesn't leak into a later test.
+		context.destroy();
 		document.body.removeChild(host);
 	});
 
@@ -110,9 +112,6 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(callCountBeforeNavigate);
 			expect(parentContext?.getParent()).to.equal(undefined);
 			expect(ancestorContext?.getAncestors()).to.deep.equal([]);
-
-			// Cancel the pending debounced fetch so it doesn't leak into a later test.
-			context.destroy();
 		});
 	});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -6,7 +6,7 @@ import {
 	createTestAncestorItem,
 	createTestTreeRepositoryManifest,
 } from './menu-tree-structure-workspace-context.test-utils.js';
-import { UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
+import { UMB_ANCESTORS_ENTITY_CONTEXT, UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
 import { aTimeout, expect } from '@open-wc/testing';
 import { UmbActionEventContext } from '@umbraco-cms/backoffice/action';
 import { UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
@@ -84,6 +84,36 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 
 		const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
 		expect(parentContext?.getParent()).to.deep.equal({ unique: 'parent-unique', entityType: 'test-entity-type' });
+	});
+
+	describe('navigating to a different entity', () => {
+		it('clears the parent and ancestor state immediately, before the new fetch resolves (avoids a stale breadcrumb)', async () => {
+			UmbTestTreeRepository.ancestors = [
+				createTestAncestorItem({ unique: 'parent-unique', entityType: 'test-entity-type' }),
+			];
+
+			dispatchReloadStructure();
+			await aTimeout(150);
+
+			const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
+			const ancestorContext = await context.getContext(UMB_ANCESTORS_ENTITY_CONTEXT);
+			expect(parentContext?.getParent()).to.deep.equal({ unique: 'parent-unique', entityType: 'test-entity-type' });
+			expect(ancestorContext?.getAncestors()).to.deep.equal([
+				{ unique: 'parent-unique', entityType: 'test-entity-type' },
+			]);
+
+			const callCountBeforeNavigate = UmbTestTreeRepository.requestTreeItemAncestorsCalls.length;
+
+			// Navigate to a different entity. The debounce means the fetch for it hasn't even started yet.
+			workspaceContext.setUnique('other-unique');
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(callCountBeforeNavigate);
+			expect(parentContext?.getParent()).to.equal(undefined);
+			expect(ancestorContext?.getAncestors()).to.deep.equal([]);
+
+			// Cancel the pending debounced fetch so it doesn't leak into a later test.
+			context.destroy();
+		});
 	});
 
 	describe('reload on UmbRequestReloadStructureForEntityEvent', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -1,0 +1,140 @@
+import { UmbMenuTreeStructureWorkspaceContextBase } from './menu-tree-structure-workspace-context-base.js';
+import {
+	UmbTestMenuStructureControllerHostElement,
+	UmbTestSubmittableTreeEntityWorkspaceContext,
+	UmbTestTreeRepository,
+	createTestAncestorItem,
+	createTestTreeRepositoryManifest,
+} from './menu-tree-structure-workspace-context.test-utils.js';
+import { UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
+import { aTimeout, expect } from '@open-wc/testing';
+import { UmbActionEventContext } from '@umbraco-cms/backoffice/action';
+import { UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
+
+const TEST_TREE_REPOSITORY_ALIAS = 'Umb.Test.MenuTreeStructureWorkspaceContextBase.TreeRepository';
+
+class TestMenuTreeStructureWorkspaceContext extends UmbMenuTreeStructureWorkspaceContextBase {
+	constructor(host: UmbControllerHost) {
+		super(host, { treeRepositoryAlias: TEST_TREE_REPOSITORY_ALIAS });
+	}
+}
+
+describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
+	let host: UmbTestMenuStructureControllerHostElement;
+	let actionEventContext: UmbActionEventContext;
+	let workspaceContext: UmbTestSubmittableTreeEntityWorkspaceContext;
+	let context: TestMenuTreeStructureWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.register(createTestTreeRepositoryManifest(TEST_TREE_REPOSITORY_ALIAS));
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregister(TEST_TREE_REPOSITORY_ALIAS);
+	});
+
+	beforeEach(async () => {
+		UmbTestTreeRepository.reset();
+
+		host = new UmbTestMenuStructureControllerHostElement();
+		document.body.appendChild(host);
+
+		actionEventContext = new UmbActionEventContext(host);
+		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
+		new UmbContextProviderController(
+			host,
+			UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT,
+			workspaceContext as never,
+		);
+
+		context = new TestMenuTreeStructureWorkspaceContext(host);
+
+		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setUnique('test-unique');
+		await aTimeout(50);
+	});
+
+	afterEach(() => {
+		document.body.removeChild(host);
+	});
+
+	function dispatchReloadStructure(overrides?: { unique?: string | null; entityType?: string }) {
+		actionEventContext.dispatchEvent(
+			new UmbRequestReloadStructureForEntityEvent({
+				unique: 'test-unique',
+				entityType: 'test-entity-type',
+				...overrides,
+			}),
+		);
+	}
+
+	it('requests ancestors for the open entity on load', async () => {
+		expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.deep.equal([
+			{ unique: 'test-unique', entityType: 'test-entity-type' },
+		]);
+	});
+
+	it('sets UMB_PARENT_ENTITY_CONTEXT from the resolved ancestors', async () => {
+		UmbTestTreeRepository.ancestors = [
+			createTestAncestorItem({ unique: 'parent-unique', entityType: 'test-entity-type' }),
+		];
+
+		dispatchReloadStructure();
+		await aTimeout(50);
+
+		const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
+		expect(parentContext?.getParent()).to.deep.equal({ unique: 'parent-unique', entityType: 'test-entity-type' });
+	});
+
+	describe('reload on UmbRequestReloadStructureForEntityEvent', () => {
+		it('re-requests ancestors when the event matches the open entity (fixes a stale parent after a move)', async () => {
+			// The item was moved to a new parent elsewhere (e.g. via "Move to"), without this workspace reloading.
+			UmbTestTreeRepository.ancestors = [
+				createTestAncestorItem({ unique: 'new-parent-unique', entityType: 'test-entity-type' }),
+			];
+
+			dispatchReloadStructure();
+			await aTimeout(50);
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
+
+			const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
+			expect(parentContext?.getParent()).to.deep.equal({
+				unique: 'new-parent-unique',
+				entityType: 'test-entity-type',
+			});
+		});
+
+		it('does not re-request ancestors when the event is for a different unique', async () => {
+			dispatchReloadStructure({ unique: 'some-other-unique' });
+			await aTimeout(50);
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
+		});
+
+		it('does not re-request ancestors when the event is for a different entity type', async () => {
+			dispatchReloadStructure({ entityType: 'some-other-entity-type' });
+			await aTimeout(50);
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
+		});
+	});
+
+	describe('destroy', () => {
+		it('stops reacting to reload-structure events once destroyed', async () => {
+			context.destroy();
+
+			UmbTestTreeRepository.ancestors = [
+				createTestAncestorItem({ unique: 'new-parent-unique', entityType: 'test-entity-type' }),
+			];
+			dispatchReloadStructure();
+			await aTimeout(50);
+
+			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -45,17 +45,13 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 
 		actionEventContext = new UmbActionEventContext(host);
 		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
-		new UmbContextProviderController(
-			host,
-			UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT,
-			workspaceContext as never,
-		);
+		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
 
 		context = new TestMenuTreeStructureWorkspaceContext(host);
 
 		workspaceContext.setEntityType('test-entity-type');
 		workspaceContext.setUnique('test-unique');
-		await aTimeout(50);
+		await aTimeout(150);
 	});
 
 	afterEach(() => {
@@ -84,7 +80,7 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 		];
 
 		dispatchReloadStructure();
-		await aTimeout(50);
+		await aTimeout(150);
 
 		const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
 		expect(parentContext?.getParent()).to.deep.equal({ unique: 'parent-unique', entityType: 'test-entity-type' });
@@ -98,7 +94,7 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 			];
 
 			dispatchReloadStructure();
-			await aTimeout(50);
+			await aTimeout(150);
 
 			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
 
@@ -111,14 +107,14 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 
 		it('does not re-request ancestors when the event is for a different unique', async () => {
 			dispatchReloadStructure({ unique: 'some-other-unique' });
-			await aTimeout(50);
+			await aTimeout(150);
 
 			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
 		});
 
 		it('does not re-request ancestors when the event is for a different entity type', async () => {
 			dispatchReloadStructure({ entityType: 'some-other-entity-type' });
-			await aTimeout(50);
+			await aTimeout(150);
 
 			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
 		});
@@ -132,7 +128,7 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 				createTestAncestorItem({ unique: 'new-parent-unique', entityType: 'test-entity-type' }),
 			];
 			dispatchReloadStructure();
-			await aTimeout(50);
+			await aTimeout(150);
 
 			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -10,6 +10,8 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbAncestorsEntityContext, UmbParentEntityContext, type UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 
 interface UmbMenuTreeStructureWorkspaceContextBaseArgs {
 	treeRepositoryAlias: string;
@@ -36,6 +38,7 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
 	#isModalContext: boolean = false;
 	#isNew: boolean | undefined = undefined;
+	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 
 	constructor(host: UmbControllerHost, args: UmbMenuTreeStructureWorkspaceContextBaseArgs) {
 		super(host, UMB_MENU_STRUCTURE_WORKSPACE_CONTEXT);
@@ -45,6 +48,12 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 
 		this.consumeContext(UMB_MODAL_CONTEXT, (modalContext) => {
 			this.#isModalContext = modalContext !== undefined;
+		});
+
+		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (instance) => {
+			this.#removeEventListeners();
+			this.#actionEventContext = instance;
+			this.#addEventListeners();
 		});
 
 		this.consumeContext(UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT, (instance) => {
@@ -76,6 +85,26 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 			);
 		});
 	}
+
+	#addEventListeners() {
+		this.#actionEventContext?.addEventListener(
+			UmbRequestReloadStructureForEntityEvent.TYPE,
+			this.#onReloadStructureForEntityRequest as EventListener,
+		);
+	}
+
+	#removeEventListeners() {
+		this.#actionEventContext?.removeEventListener(
+			UmbRequestReloadStructureForEntityEvent.TYPE,
+			this.#onReloadStructureForEntityRequest as EventListener,
+		);
+	}
+
+	#onReloadStructureForEntityRequest = (event: UmbRequestReloadStructureForEntityEvent) => {
+		if (event.getEntityType() !== this.#workspaceContext?.getEntityType()) return;
+		if (event.getUnique() !== this.#workspaceContext?.getUnique()) return;
+		this.#requestStructure();
+	};
 
 	async #requestStructure() {
 		const isNew = this.#workspaceContext?.getIsNew();
@@ -209,6 +238,7 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 	}
 
 	override destroy(): void {
+		this.#removeEventListeners();
 		super.destroy();
 		this.#structure.destroy();
 		this.#parent.destroy();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -107,10 +107,19 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 	}
 
 	#onReloadStructureForEntityRequest = (event: UmbRequestReloadStructureForEntityEvent) => {
-		if (event.getEntityType() !== this.#workspaceContext?.getEntityType()) return;
-		if (event.getUnique() !== this.#workspaceContext?.getUnique()) return;
+		if (!this.#isCurrentEntityOrAncestor(event.getEntityType(), event.getUnique())) return;
 		this.#requestStructure();
 	};
+
+	#isCurrentEntityOrAncestor(entityType: string, unique: string | null): boolean {
+		if (entityType === this.#workspaceContext?.getEntityType() && unique === this.#workspaceContext?.getUnique()) {
+			return true;
+		}
+
+		return this.#ancestorContext
+			.getAncestors()
+			.some((ancestor) => ancestor.entityType === entityType && ancestor.unique === unique);
+	}
 
 	async #requestStructureImpl() {
 		const requestId = ++this.#structureRequestId;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -70,6 +70,8 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 				this.#workspaceContext?.unique,
 				(value) => {
 					if (!value) return;
+					// Clear immediately so the previous entity's breadcrumb/structure isn't shown while the new one loads.
+					this.#clearStructure();
 					this.#requestStructure();
 				},
 				'observeUnique',
@@ -192,6 +194,13 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		if (menuItemAlias && !this.#isModalContext) {
 			this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 		}
+	}
+
+	#clearStructure() {
+		this.#structure.setValue([]);
+		this.#parent.setValue(undefined);
+		this.#parentContext.setParent(undefined);
+		this.#ancestorContext.setAncestors([]);
 	}
 
 	#setParentData(structureItems: Array<UmbStructureItemModel>) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -8,7 +8,7 @@ import { UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/back
 import { UmbArrayState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbAncestorsEntityContext, UmbParentEntityContext, type UmbEntityModel } from '@umbraco-cms/backoffice/entity';
-import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
+import { debounce, linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
@@ -39,6 +39,10 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 	#isModalContext: boolean = false;
 	#isNew: boolean | undefined = undefined;
 	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
+	#structureRequestId = 0;
+
+	// Coalesces the unique/isNew/reload-event triggers when they fire in quick succession.
+	#requestStructure = debounce(() => this.#requestStructureImpl(), 100);
 
 	constructor(host: UmbControllerHost, args: UmbMenuTreeStructureWorkspaceContextBaseArgs) {
 		super(host, UMB_MENU_STRUCTURE_WORKSPACE_CONTEXT);
@@ -106,7 +110,8 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		this.#requestStructure();
 	};
 
-	async #requestStructure() {
+	async #requestStructureImpl() {
+		const requestId = ++this.#structureRequestId;
 		const isNew = this.#workspaceContext?.getIsNew();
 		const uniqueObservable = isNew
 			? this.#workspaceContext?._internal_createUnderParentEntityUnique
@@ -173,6 +178,9 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		// Guard: this context may have been destroyed while the async requests were in flight.
 		if (!this._host) return;
 
+		// Guard: a newer request has superseded this one; its result would already be stale.
+		if (requestId !== this.#structureRequestId) return;
+
 		if (ancestorData) {
 			this.#setAncestorData(ancestorData);
 		}
@@ -238,6 +246,7 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 	}
 
 	override destroy(): void {
+		this.#requestStructure.cancel();
 		this.#removeEventListeners();
 		super.destroy();
 		this.#structure.destroy();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context.test-utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context.test-utils.ts
@@ -26,8 +26,11 @@ export class UmbTestSubmittableTreeEntityWorkspaceContext {
 	readonly unique = this.#unique.asObservable();
 	readonly entityType = this.#entityType.asObservable();
 	readonly isNew = this.#isNew.asObservable();
+	// eslint-disable-next-line @typescript-eslint/naming-convention
 	readonly _internal_createUnderParent = new UmbObjectState<UmbEntityModel | undefined>(undefined).asObservable();
+	// eslint-disable-next-line @typescript-eslint/naming-convention
 	readonly _internal_createUnderParentEntityUnique = this.#createUnderParentUnique.asObservable();
+	// eslint-disable-next-line @typescript-eslint/naming-convention
 	readonly _internal_createUnderParentEntityType = this.#createUnderParentEntityType.asObservable();
 
 	constructor(host: UmbControllerHost) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context.test-utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context.test-utils.ts
@@ -1,0 +1,124 @@
+import type { ManifestApi } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbBooleanState, UmbObjectState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
+import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import type { UmbTreeItemModel, UmbTreeRootModel } from '@umbraco-cms/backoffice/tree';
+
+@customElement('umb-test-menu-structure-controller-host')
+export class UmbTestMenuStructureControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+/**
+ * A minimal `UmbSubmittableTreeEntityWorkspaceContext` stand-in — stands in for a real document/document-type/etc.
+ * workspace context in isolated tests. Only implements what `UmbMenuTreeStructureWorkspaceContextBase` reads, plus
+ * the two properties (`requestSubmit`, `_internal_createUnderParent`) the context token's discriminator checks for.
+ */
+export class UmbTestSubmittableTreeEntityWorkspaceContext {
+	#host: UmbControllerHost;
+	#unique = new UmbObjectState<string | null | undefined>(undefined);
+	#entityType = new UmbStringState<string | undefined>(undefined);
+	#isNew = new UmbBooleanState(undefined);
+	#createUnderParentUnique = new UmbObjectState<string | null | undefined>(undefined);
+	#createUnderParentEntityType = new UmbStringState<string | undefined>(undefined);
+
+	readonly workspaceAlias = 'Umb.Test.Workspace';
+	readonly unique = this.#unique.asObservable();
+	readonly entityType = this.#entityType.asObservable();
+	readonly isNew = this.#isNew.asObservable();
+	readonly _internal_createUnderParent = new UmbObjectState<UmbEntityModel | undefined>(undefined).asObservable();
+	readonly _internal_createUnderParentEntityUnique = this.#createUnderParentUnique.asObservable();
+	readonly _internal_createUnderParentEntityType = this.#createUnderParentEntityType.asObservable();
+
+	constructor(host: UmbControllerHost) {
+		this.#host = host;
+	}
+
+	getHostElement() {
+		return this.#host.getHostElement();
+	}
+
+	getUnique() {
+		return this.#unique.getValue();
+	}
+
+	getEntityType() {
+		return this.#entityType.getValue();
+	}
+
+	getIsNew() {
+		return this.#isNew.getValue();
+	}
+
+	setUnique(unique: string | null) {
+		this.#unique.setValue(unique);
+	}
+
+	setEntityType(entityType: string) {
+		this.#entityType.setValue(entityType);
+	}
+
+	setIsNew(value: boolean | undefined) {
+		this.#isNew.setValue(value);
+	}
+
+	setCreateUnderParent(parent: UmbEntityModel) {
+		this.#createUnderParentUnique.setValue(parent.unique);
+		this.#createUnderParentEntityType.setValue(parent.entityType);
+	}
+
+	async requestSubmit() {}
+
+	destroy() {}
+}
+
+/**
+ * A minimal `UmbTreeRepository` stand-in, registered into `umbExtensionsRegistry` under whichever alias the
+ * context-under-test expects. Root and ancestors are static so a test can configure the response before
+ * triggering a structure request, regardless of which repository alias/instance ends up used.
+ */
+export class UmbTestTreeRepository {
+	static root: UmbTreeRootModel = {
+		unique: null,
+		entityType: 'test-root-entity-type',
+		name: 'Root',
+		isFolder: false,
+		hasChildren: false,
+	} as unknown as UmbTreeRootModel;
+
+	static ancestors: Array<UmbTreeItemModel> = [];
+	static requestTreeItemAncestorsCalls: Array<UmbEntityModel> = [];
+
+	static reset() {
+		UmbTestTreeRepository.ancestors = [];
+		UmbTestTreeRepository.requestTreeItemAncestorsCalls = [];
+	}
+
+	async requestTreeRoot() {
+		return { data: UmbTestTreeRepository.root };
+	}
+
+	async requestTreeItemAncestors(args: { treeItem: UmbEntityModel }) {
+		UmbTestTreeRepository.requestTreeItemAncestorsCalls.push(args.treeItem);
+		return { data: UmbTestTreeRepository.ancestors };
+	}
+
+	destroy() {}
+}
+
+export const createTestTreeRepositoryManifest = (alias: string): ManifestApi => ({
+	type: 'repository',
+	alias,
+	name: 'Test Tree Repository',
+	api: UmbTestTreeRepository,
+});
+
+export function createTestAncestorItem(entity: UmbEntityModel, name = entity.unique ?? 'unnamed'): UmbTreeItemModel {
+	return {
+		...entity,
+		name,
+		isFolder: false,
+		hasChildren: false,
+		parent: { unique: null, entityType: 'test-root-entity-type' },
+	} as unknown as UmbTreeItemModel;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context.test-utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context.test-utils.ts
@@ -80,19 +80,21 @@ export class UmbTestSubmittableTreeEntityWorkspaceContext {
  * context-under-test expects. Root and ancestors are static so a test can configure the response before
  * triggering a structure request, regardless of which repository alias/instance ends up used.
  */
-export class UmbTestTreeRepository {
-	static root: UmbTreeRootModel = {
-		unique: null,
-		entityType: 'test-root-entity-type',
-		name: 'Root',
-		isFolder: false,
-		hasChildren: false,
-	} as unknown as UmbTreeRootModel;
+const DEFAULT_TEST_ROOT: UmbTreeRootModel = {
+	unique: null,
+	entityType: 'test-root-entity-type',
+	name: 'Root',
+	isFolder: false,
+	hasChildren: false,
+} as unknown as UmbTreeRootModel;
 
+export class UmbTestTreeRepository {
+	static root: UmbTreeRootModel = DEFAULT_TEST_ROOT;
 	static ancestors: Array<UmbTreeItemModel> = [];
 	static requestTreeItemAncestorsCalls: Array<UmbEntityModel> = [];
 
 	static reset() {
+		UmbTestTreeRepository.root = DEFAULT_TEST_ROOT;
 		UmbTestTreeRepository.ancestors = [];
 		UmbTestTreeRepository.requestTreeItemAncestorsCalls = [];
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -1,0 +1,140 @@
+import { UmbMenuVariantTreeStructureWorkspaceContextBase } from './menu-variant-tree-structure-workspace-context-base.js';
+import {
+	UmbTestMenuVariantStructureControllerHostElement,
+	UmbTestSubmittableTreeEntityWorkspaceContext,
+	UmbTestVariantTreeRepository,
+	createTestVariantAncestorItem,
+	createTestVariantTreeRepositoryManifest,
+} from './menu-variant-tree-structure-workspace-context.test-utils.js';
+import { UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
+import { aTimeout, expect } from '@open-wc/testing';
+import { UmbActionEventContext } from '@umbraco-cms/backoffice/action';
+import { UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
+
+const TEST_TREE_REPOSITORY_ALIAS = 'Umb.Test.MenuVariantTreeStructureWorkspaceContextBase.TreeRepository';
+
+class TestMenuVariantTreeStructureWorkspaceContext extends UmbMenuVariantTreeStructureWorkspaceContextBase {
+	constructor(host: UmbControllerHost) {
+		super(host, { treeRepositoryAlias: TEST_TREE_REPOSITORY_ALIAS });
+	}
+}
+
+describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
+	let host: UmbTestMenuVariantStructureControllerHostElement;
+	let actionEventContext: UmbActionEventContext;
+	let workspaceContext: UmbTestSubmittableTreeEntityWorkspaceContext;
+	let context: TestMenuVariantTreeStructureWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.register(createTestVariantTreeRepositoryManifest(TEST_TREE_REPOSITORY_ALIAS));
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregister(TEST_TREE_REPOSITORY_ALIAS);
+	});
+
+	beforeEach(async () => {
+		UmbTestVariantTreeRepository.reset();
+
+		host = new UmbTestMenuVariantStructureControllerHostElement();
+		document.body.appendChild(host);
+
+		actionEventContext = new UmbActionEventContext(host);
+		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
+		new UmbContextProviderController(
+			host,
+			UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT,
+			workspaceContext as never,
+		);
+
+		context = new TestMenuVariantTreeStructureWorkspaceContext(host);
+
+		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setUnique('test-unique');
+		await aTimeout(50);
+	});
+
+	afterEach(() => {
+		document.body.removeChild(host);
+	});
+
+	function dispatchReloadStructure(overrides?: { unique?: string | null; entityType?: string }) {
+		actionEventContext.dispatchEvent(
+			new UmbRequestReloadStructureForEntityEvent({
+				unique: 'test-unique',
+				entityType: 'test-entity-type',
+				...overrides,
+			}),
+		);
+	}
+
+	it('requests ancestors for the open entity on load', async () => {
+		expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.deep.equal([
+			{ unique: 'test-unique', entityType: 'test-entity-type' },
+		]);
+	});
+
+	it('sets UMB_PARENT_ENTITY_CONTEXT from the resolved ancestors', async () => {
+		UmbTestVariantTreeRepository.ancestors = [
+			createTestVariantAncestorItem({ unique: 'parent-unique', entityType: 'test-entity-type' }),
+		];
+
+		dispatchReloadStructure();
+		await aTimeout(50);
+
+		const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
+		expect(parentContext?.getParent()).to.deep.equal({ unique: 'parent-unique', entityType: 'test-entity-type' });
+	});
+
+	describe('reload on UmbRequestReloadStructureForEntityEvent', () => {
+		it('re-requests ancestors when the event matches the open entity (fixes a stale parent after a move)', async () => {
+			// The item was moved to a new parent elsewhere (e.g. via "Move to"), without this workspace reloading.
+			UmbTestVariantTreeRepository.ancestors = [
+				createTestVariantAncestorItem({ unique: 'new-parent-unique', entityType: 'test-entity-type' }),
+			];
+
+			dispatchReloadStructure();
+			await aTimeout(50);
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
+
+			const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
+			expect(parentContext?.getParent()).to.deep.equal({
+				unique: 'new-parent-unique',
+				entityType: 'test-entity-type',
+			});
+		});
+
+		it('does not re-request ancestors when the event is for a different unique', async () => {
+			dispatchReloadStructure({ unique: 'some-other-unique' });
+			await aTimeout(50);
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
+		});
+
+		it('does not re-request ancestors when the event is for a different entity type', async () => {
+			dispatchReloadStructure({ entityType: 'some-other-entity-type' });
+			await aTimeout(50);
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
+		});
+	});
+
+	describe('destroy', () => {
+		it('stops reacting to reload-structure events once destroyed', async () => {
+			context.destroy();
+
+			UmbTestVariantTreeRepository.ancestors = [
+				createTestVariantAncestorItem({ unique: 'new-parent-unique', entityType: 'test-entity-type' }),
+			];
+			dispatchReloadStructure();
+			await aTimeout(50);
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -6,7 +6,7 @@ import {
 	createTestVariantAncestorItem,
 	createTestVariantTreeRepositoryManifest,
 } from './menu-variant-tree-structure-workspace-context.test-utils.js';
-import { UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
+import { UMB_ANCESTORS_ENTITY_CONTEXT, UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
 import { aTimeout, expect } from '@open-wc/testing';
 import { UmbActionEventContext } from '@umbraco-cms/backoffice/action';
 import { UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
@@ -84,6 +84,36 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 
 		const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
 		expect(parentContext?.getParent()).to.deep.equal({ unique: 'parent-unique', entityType: 'test-entity-type' });
+	});
+
+	describe('navigating to a different entity', () => {
+		it('clears the parent and ancestor state immediately, before the new fetch resolves (avoids a stale breadcrumb)', async () => {
+			UmbTestVariantTreeRepository.ancestors = [
+				createTestVariantAncestorItem({ unique: 'parent-unique', entityType: 'test-entity-type' }),
+			];
+
+			dispatchReloadStructure();
+			await aTimeout(150);
+
+			const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
+			const ancestorContext = await context.getContext(UMB_ANCESTORS_ENTITY_CONTEXT);
+			expect(parentContext?.getParent()).to.deep.equal({ unique: 'parent-unique', entityType: 'test-entity-type' });
+			expect(ancestorContext?.getAncestors()).to.deep.equal([
+				{ unique: 'parent-unique', entityType: 'test-entity-type' },
+			]);
+
+			const callCountBeforeNavigate = UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls.length;
+
+			// Navigate to a different entity. The debounce means the fetch for it hasn't even started yet.
+			workspaceContext.setUnique('other-unique');
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(callCountBeforeNavigate);
+			expect(parentContext?.getParent()).to.equal(undefined);
+			expect(ancestorContext?.getAncestors()).to.deep.equal([]);
+
+			// Cancel the pending debounced fetch so it doesn't leak into a later test.
+			context.destroy();
+		});
 	});
 
 	describe('reload on UmbRequestReloadStructureForEntityEvent', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -135,6 +135,39 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 			});
 		});
 
+		it('re-requests ancestors when the event matches a currently displayed ancestor (e.g. an ancestor was renamed elsewhere)', async () => {
+			UmbTestVariantTreeRepository.ancestors = [
+				createTestVariantAncestorItem({ unique: 'parent-unique', entityType: 'test-entity-type' }),
+			];
+
+			dispatchReloadStructure();
+			await aTimeout(150);
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
+
+			// The event is for the ancestor, not the open entity itself.
+			dispatchReloadStructure({ unique: 'parent-unique' });
+			await aTimeout(150);
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(3);
+		});
+
+		it('does not re-request ancestors when the event is for an entity that is neither the open entity nor a currently displayed ancestor', async () => {
+			UmbTestVariantTreeRepository.ancestors = [
+				createTestVariantAncestorItem({ unique: 'parent-unique', entityType: 'test-entity-type' }),
+			];
+
+			dispatchReloadStructure();
+			await aTimeout(150);
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
+
+			dispatchReloadStructure({ unique: 'unrelated-unique' });
+			await aTimeout(150);
+
+			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
+		});
+
 		it('does not re-request ancestors when the event is for a different unique', async () => {
 			dispatchReloadStructure({ unique: 'some-other-unique' });
 			await aTimeout(150);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -55,6 +55,8 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 	});
 
 	afterEach(() => {
+		// Cancels any pending debounced fetch so it doesn't leak into a later test.
+		context.destroy();
 		document.body.removeChild(host);
 	});
 
@@ -110,9 +112,6 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(callCountBeforeNavigate);
 			expect(parentContext?.getParent()).to.equal(undefined);
 			expect(ancestorContext?.getAncestors()).to.deep.equal([]);
-
-			// Cancel the pending debounced fetch so it doesn't leak into a later test.
-			context.destroy();
 		});
 	});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -45,17 +45,13 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 
 		actionEventContext = new UmbActionEventContext(host);
 		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
-		new UmbContextProviderController(
-			host,
-			UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT,
-			workspaceContext as never,
-		);
+		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
 
 		context = new TestMenuVariantTreeStructureWorkspaceContext(host);
 
 		workspaceContext.setEntityType('test-entity-type');
 		workspaceContext.setUnique('test-unique');
-		await aTimeout(50);
+		await aTimeout(150);
 	});
 
 	afterEach(() => {
@@ -84,7 +80,7 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 		];
 
 		dispatchReloadStructure();
-		await aTimeout(50);
+		await aTimeout(150);
 
 		const parentContext = await context.getContext(UMB_PARENT_ENTITY_CONTEXT);
 		expect(parentContext?.getParent()).to.deep.equal({ unique: 'parent-unique', entityType: 'test-entity-type' });
@@ -98,7 +94,7 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 			];
 
 			dispatchReloadStructure();
-			await aTimeout(50);
+			await aTimeout(150);
 
 			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(2);
 
@@ -111,14 +107,14 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 
 		it('does not re-request ancestors when the event is for a different unique', async () => {
 			dispatchReloadStructure({ unique: 'some-other-unique' });
-			await aTimeout(50);
+			await aTimeout(150);
 
 			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
 		});
 
 		it('does not re-request ancestors when the event is for a different entity type', async () => {
 			dispatchReloadStructure({ entityType: 'some-other-entity-type' });
-			await aTimeout(50);
+			await aTimeout(150);
 
 			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
 		});
@@ -132,7 +128,7 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 				createTestVariantAncestorItem({ unique: 'new-parent-unique', entityType: 'test-entity-type' }),
 			];
 			dispatchReloadStructure();
-			await aTimeout(50);
+			await aTimeout(150);
 
 			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -17,6 +17,8 @@ import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 
 interface UmbMenuVariantTreeStructureWorkspaceContextBaseArgs {
 	treeRepositoryAlias: string;
@@ -47,6 +49,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	#isNew: boolean | undefined = undefined;
 	#variantWorkspaceContext?: typeof UMB_VARIANT_WORKSPACE_CONTEXT.TYPE;
 	#workspaceActiveVariantId?: UmbVariantId;
+	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 
 	public readonly IS_MENU_VARIANT_STRUCTURE_WORKSPACE_CONTEXT = true;
 
@@ -58,6 +61,12 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 
 		this.consumeContext(UMB_MODAL_CONTEXT, (modalContext) => {
 			this.#isModalContext = modalContext !== undefined;
+		});
+
+		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (instance) => {
+			this.#removeEventListeners();
+			this.#actionEventContext = instance;
+			this.#addEventListeners();
 		});
 
 		this.consumeContext(UMB_SECTION_CONTEXT, (instance) => {
@@ -130,6 +139,26 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 			unique,
 		});
 	}
+
+	#addEventListeners() {
+		this.#actionEventContext?.addEventListener(
+			UmbRequestReloadStructureForEntityEvent.TYPE,
+			this.#onReloadStructureForEntityRequest as EventListener,
+		);
+	}
+
+	#removeEventListeners() {
+		this.#actionEventContext?.removeEventListener(
+			UmbRequestReloadStructureForEntityEvent.TYPE,
+			this.#onReloadStructureForEntityRequest as EventListener,
+		);
+	}
+
+	#onReloadStructureForEntityRequest = (event: UmbRequestReloadStructureForEntityEvent) => {
+		if (event.getEntityType() !== this.#workspaceContext?.getEntityType()) return;
+		if (event.getUnique() !== this.#workspaceContext?.getUnique()) return;
+		this.#requestStructure();
+	};
 
 	async #requestStructure() {
 		const isNew = this.#workspaceContext?.getIsNew();
@@ -271,6 +300,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	}
 
 	override destroy(): void {
+		this.#removeEventListeners();
 		super.destroy();
 		this.#structure.destroy();
 		this.#parent.destroy();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -13,7 +13,7 @@ import {
 	UMB_WORKSPACE_EDIT_PATH_PATTERN,
 	UMB_WORKSPACE_EDIT_VARIANT_PATH_PATTERN,
 } from '@umbraco-cms/backoffice/workspace';
-import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
+import { debounce, linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
@@ -50,6 +50,10 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	#variantWorkspaceContext?: typeof UMB_VARIANT_WORKSPACE_CONTEXT.TYPE;
 	#workspaceActiveVariantId?: UmbVariantId;
 	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
+	#structureRequestId = 0;
+
+	// Coalesces the unique/isNew/reload-event triggers when they fire in quick succession.
+	#requestStructure = debounce(() => this.#requestStructureImpl(), 100);
 
 	public readonly IS_MENU_VARIANT_STRUCTURE_WORKSPACE_CONTEXT = true;
 
@@ -160,7 +164,8 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 		this.#requestStructure();
 	};
 
-	async #requestStructure() {
+	async #requestStructureImpl() {
+		const requestId = ++this.#structureRequestId;
 		const isNew = this.#workspaceContext?.getIsNew();
 		const uniqueObservable = isNew
 			? this.#workspaceContext?._internal_createUnderParentEntityUnique
@@ -223,6 +228,9 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 			// Guard: this context may have been destroyed while the async requests were in flight
 			// (e.g. a condition such as IS_NOT_TRASHED flips before the API response arrives).
 			if (!this._host) return;
+
+			// Guard: a newer request has superseded this one; its result would already be stale.
+			if (requestId !== this.#structureRequestId) return;
 
 			this.#structure.setValue(structureItems);
 			this.#setParentData(structureItems);
@@ -300,6 +308,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	}
 
 	override destroy(): void {
+		this.#requestStructure.cancel();
 		this.#removeEventListeners();
 		super.destroy();
 		this.#structure.destroy();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -93,6 +93,8 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 				this.#workspaceContext?.unique,
 				(value) => {
 					if (!value) return;
+					// Clear immediately so the previous entity's breadcrumb/structure isn't shown while the new one loads.
+					this.#clearStructure();
 					this.#requestStructure();
 				},
 				'observeUnique',
@@ -241,6 +243,13 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 				this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 			}
 		}
+	}
+
+	#clearStructure() {
+		this.#structure.setValue([]);
+		this.#parent.setValue(undefined);
+		this.#parentContext.setParent(undefined);
+		this.#ancestorContext.setAncestors([]);
 	}
 
 	#setParentData(structureItems: Array<UmbVariantStructureItemModel>) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -161,10 +161,19 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	}
 
 	#onReloadStructureForEntityRequest = (event: UmbRequestReloadStructureForEntityEvent) => {
-		if (event.getEntityType() !== this.#workspaceContext?.getEntityType()) return;
-		if (event.getUnique() !== this.#workspaceContext?.getUnique()) return;
+		if (!this.#isCurrentEntityOrAncestor(event.getEntityType(), event.getUnique())) return;
 		this.#requestStructure();
 	};
+
+	#isCurrentEntityOrAncestor(entityType: string, unique: string | null): boolean {
+		if (entityType === this.#workspaceContext?.getEntityType() && unique === this.#workspaceContext?.getUnique()) {
+			return true;
+		}
+
+		return this.#ancestorContext
+			.getAncestors()
+			.some((ancestor) => ancestor.entityType === entityType && ancestor.unique === unique);
+	}
 
 	async #requestStructureImpl() {
 		const requestId = ++this.#structureRequestId;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context.test-utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context.test-utils.ts
@@ -1,0 +1,71 @@
+import { UmbTestSubmittableTreeEntityWorkspaceContext } from './menu-tree-structure-workspace-context.test-utils.js';
+import type { ManifestApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import type { UmbTreeItemModel, UmbTreeRootModel } from '@umbraco-cms/backoffice/tree';
+
+export { UmbTestSubmittableTreeEntityWorkspaceContext };
+
+@customElement('umb-test-menu-variant-structure-controller-host')
+export class UmbTestMenuVariantStructureControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+type UmbTestVariantTreeItemModel = UmbTreeItemModel & {
+	variants: Array<{ name: string; culture: string | null; segment: string | null }>;
+};
+
+/**
+ * A minimal `UmbTreeRepository` stand-in for a variant-aware tree (document/media). Same role as
+ * `UmbTestTreeRepository` in `menu-tree-structure-workspace-context.test-utils.ts`, but its ancestors carry a
+ * `variants` array, since `UmbMenuVariantTreeStructureWorkspaceContextBase` reads `treeItem.variants` when
+ * building the structure.
+ */
+export class UmbTestVariantTreeRepository {
+	static root: UmbTreeRootModel = {
+		unique: null,
+		entityType: 'test-root-entity-type',
+		name: 'Root',
+		isFolder: false,
+		hasChildren: false,
+	} as unknown as UmbTreeRootModel;
+
+	static ancestors: Array<UmbTestVariantTreeItemModel> = [];
+	static requestTreeItemAncestorsCalls: Array<UmbEntityModel> = [];
+
+	static reset() {
+		UmbTestVariantTreeRepository.ancestors = [];
+		UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls = [];
+	}
+
+	async requestTreeRoot() {
+		return { data: UmbTestVariantTreeRepository.root };
+	}
+
+	async requestTreeItemAncestors(args: { treeItem: UmbEntityModel }) {
+		UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls.push(args.treeItem);
+		return { data: UmbTestVariantTreeRepository.ancestors };
+	}
+
+	destroy() {}
+}
+
+export const createTestVariantTreeRepositoryManifest = (alias: string): ManifestApi => ({
+	type: 'repository',
+	alias,
+	name: 'Test Variant Tree Repository',
+	api: UmbTestVariantTreeRepository,
+});
+
+export function createTestVariantAncestorItem(
+	entity: UmbEntityModel,
+	name = entity.unique ?? 'unnamed',
+): UmbTestVariantTreeItemModel {
+	return {
+		...entity,
+		name,
+		isFolder: false,
+		hasChildren: false,
+		parent: { unique: null, entityType: 'test-root-entity-type' },
+		variants: [{ name, culture: null, segment: null }],
+	} as unknown as UmbTestVariantTreeItemModel;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context.test-utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context.test-utils.ts
@@ -20,19 +20,21 @@ type UmbTestVariantTreeItemModel = UmbTreeItemModel & {
  * `variants` array, since `UmbMenuVariantTreeStructureWorkspaceContextBase` reads `treeItem.variants` when
  * building the structure.
  */
-export class UmbTestVariantTreeRepository {
-	static root: UmbTreeRootModel = {
-		unique: null,
-		entityType: 'test-root-entity-type',
-		name: 'Root',
-		isFolder: false,
-		hasChildren: false,
-	} as unknown as UmbTreeRootModel;
+const DEFAULT_TEST_ROOT: UmbTreeRootModel = {
+	unique: null,
+	entityType: 'test-root-entity-type',
+	name: 'Root',
+	isFolder: false,
+	hasChildren: false,
+} as unknown as UmbTreeRootModel;
 
+export class UmbTestVariantTreeRepository {
+	static root: UmbTreeRootModel = DEFAULT_TEST_ROOT;
 	static ancestors: Array<UmbTestVariantTreeItemModel> = [];
 	static requestTreeItemAncestorsCalls: Array<UmbEntityModel> = [];
 
 	static reset() {
+		UmbTestVariantTreeRepository.root = DEFAULT_TEST_ROOT;
 		UmbTestVariantTreeRepository.ancestors = [];
 		UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls = [];
 	}


### PR DESCRIPTION
### Description

`UmbMenuTreeStructureWorkspaceContextBase` and `UmbMenuVariantTreeStructureWorkspaceContextBase` only requested the open entity's ancestors once, on load. If the entity was then moved elsewhere in the tree (e.g. via
"Move to") without the workspace itself reloading, the open workspace kept pointing at the old parent — the
breadcrumb/menu structure went stale even though the move had succeeded.

Both base classes now also listen for `UmbRequestReloadStructureForEntityEvent` on the `UMB_ACTION_EVENT_CONTEXT` and re-request the ancestors whenever the event's `entityType`/`unique` match the currently open entity, keeping the menu structure in sync with the entity's real position.

**How to test:**
1. Open an entity in a Workspace (Document, Document Type, Media, etc.) so its ancestors are shown in the tree/breadcrumb.
2. Move that same item to a different parent using "Move to".
3. Without reloading the page, confirm the open workspace's breadcrumb now reflects the new path.