### PR TITLE
Database: Honour "Command Timeout" from the connection string (closes #23705)

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Configuration/ConfigureSqlServerConnectionStringTimeouts.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Configuration/ConfigureSqlServerConnectionStringTimeouts.cs
@@ -1,0 +1,79 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Persistence.SqlServer.Configuration;
+
+/// <summary>
+///     Applies the configured database timeouts to a SQL Server connection string.
+/// </summary>
+/// <remarks>
+///     A connection string is the only way to set a connect timeout, as <c>DbConnection.ConnectionTimeout</c>
+///     is read-only, so both timeouts are applied the same way for consistency. Doing so here also means every
+///     consumer of the connection string observes them, not just NPoco.
+/// </remarks>
+internal sealed class ConfigureSqlServerConnectionStringTimeouts : IPostConfigureOptions<ConnectionStrings>
+{
+    private readonly IOptions<GlobalSettings> _globalSettings;
+    private readonly ILogger<ConfigureSqlServerConnectionStringTimeouts> _logger;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ConfigureSqlServerConnectionStringTimeouts" /> class.
+    /// </summary>
+    /// <param name="globalSettings">The global settings carrying the configured timeouts.</param>
+    /// <param name="logger">The logger.</param>
+    public ConfigureSqlServerConnectionStringTimeouts(
+        IOptions<GlobalSettings> globalSettings,
+        ILogger<ConfigureSqlServerConnectionStringTimeouts> logger)
+    {
+        _globalSettings = globalSettings;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public void PostConfigure(string? name, ConnectionStrings options)
+    {
+        if (options.IsConnectionStringConfigured() is false
+            || options.ProviderName.InvariantEquals(Constants.ProviderName) is false)
+        {
+            return;
+        }
+
+        GlobalSettings globalSettings = _globalSettings.Value;
+        if (globalSettings.DatabaseCommandTimeout is null && globalSettings.DatabaseConnectTimeout is null)
+        {
+            return;
+        }
+
+        SqlConnectionStringBuilder connectionStringBuilder;
+        try
+        {
+            connectionStringBuilder = new SqlConnectionStringBuilder(options.ConnectionString);
+        }
+        catch (ArgumentException exception)
+        {
+            // The connection string cannot be rewritten, so leave it alone rather than failing to configure
+            // options - which would surface as an obscure startup failure rather than a connection error.
+            _logger.LogWarning(
+                exception,
+                "The configured database timeouts could not be applied, because the connection string could not be "
+                + "parsed. Set \"Command Timeout\" and \"Connect Timeout\" in the connection string instead.");
+            return;
+        }
+
+        if (globalSettings.DatabaseCommandTimeout is { } commandTimeout)
+        {
+            connectionStringBuilder.CommandTimeout = commandTimeout.ToConnectionStringTimeoutSeconds();
+        }
+
+        if (globalSettings.DatabaseConnectTimeout is { } connectTimeout)
+        {
+            connectionStringBuilder.ConnectTimeout = connectTimeout.ToConnectionStringTimeoutSeconds();
+        }
+
+        options.ConnectionString = connectionStringBuilder.ConnectionString;
+    }
+}

--- a/src/Umbraco.Cms.Persistence.SqlServer/Configuration/ConfigureSqlServerConnectionStringTimeouts.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Configuration/ConfigureSqlServerConnectionStringTimeouts.cs
@@ -57,10 +57,10 @@ internal sealed class ConfigureSqlServerConnectionStringTimeouts : IPostConfigur
         {
             // The connection string cannot be rewritten, so leave it alone rather than failing to configure
             // options - which would surface as an obscure startup failure rather than a connection error.
-            _logger.LogWarning(
-                exception,
-                "The configured database timeouts could not be applied, because the connection string could not be "
-                + "parsed. Set \"Command Timeout\" and \"Connect Timeout\" in the connection string instead.");
+            const string message = "The configured database timeouts could not be applied, because the connection "
+                + "string could not be parsed. Set \"Command Timeout\" and \"Connect Timeout\" in the connection "
+                + "string instead.";
+            _logger.LogWarning(exception, message);
             return;
         }
 

--- a/src/Umbraco.Cms.Persistence.SqlServer/Configuration/ConfigureSqlServerConnectionStringTimeouts.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Configuration/ConfigureSqlServerConnectionStringTimeouts.cs
@@ -52,6 +52,16 @@ internal sealed class ConfigureSqlServerConnectionStringTimeouts : IPostConfigur
         try
         {
             connectionStringBuilder = new SqlConnectionStringBuilder(options.ConnectionString);
+
+            if (globalSettings.DatabaseCommandTimeout is { } commandTimeout)
+            {
+                connectionStringBuilder.CommandTimeout = commandTimeout.ToConnectionStringTimeoutSeconds();
+            }
+
+            if (globalSettings.DatabaseConnectTimeout is { } connectTimeout)
+            {
+                connectionStringBuilder.ConnectTimeout = connectTimeout.ToConnectionStringTimeoutSeconds();
+            }
         }
         catch (ArgumentException exception)
         {
@@ -62,16 +72,6 @@ internal sealed class ConfigureSqlServerConnectionStringTimeouts : IPostConfigur
                 + "string instead.";
             _logger.LogWarning(exception, message);
             return;
-        }
-
-        if (globalSettings.DatabaseCommandTimeout is { } commandTimeout)
-        {
-            connectionStringBuilder.CommandTimeout = commandTimeout.ToConnectionStringTimeoutSeconds();
-        }
-
-        if (globalSettings.DatabaseConnectTimeout is { } connectTimeout)
-        {
-            connectionStringBuilder.ConnectTimeout = connectTimeout.ToConnectionStringTimeoutSeconds();
         }
 
         options.ConnectionString = connectionStringBuilder.ConnectionString;

--- a/src/Umbraco.Cms.Persistence.SqlServer/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/UmbracoBuilderExtensions.cs
@@ -2,11 +2,13 @@ using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.DistributedLocking;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
+using Umbraco.Cms.Persistence.SqlServer.Configuration;
 using Umbraco.Cms.Persistence.SqlServer.Interceptors;
 using Umbraco.Cms.Persistence.SqlServer.Services;
 
@@ -57,6 +59,9 @@ public static class UmbracoBuilderExtensions
                 options.ProviderName = Constants.ProviderName;
             }
         });
+
+        builder.Services.TryAddEnumerable(ServiceDescriptor
+            .Singleton<IPostConfigureOptions<ConnectionStrings>, ConfigureSqlServerConnectionStringTimeouts>());
 
         return builder;
     }

--- a/src/Umbraco.Cms.Persistence.Sqlite/Configuration/ConfigureSqliteConnectionStringTimeouts.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Configuration/ConfigureSqliteConnectionStringTimeouts.cs
@@ -1,0 +1,81 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Persistence.Sqlite.Configuration;
+
+/// <summary>
+///     Applies the configured database command timeout to a SQLite connection string.
+/// </summary>
+/// <remarks>
+///     SQLite has no notion of a connect timeout, so <see cref="GlobalSettings.DatabaseConnectTimeout" /> has
+///     nothing to map onto and is reported as inapplicable rather than silently dropped.
+/// </remarks>
+internal sealed class ConfigureSqliteConnectionStringTimeouts : IPostConfigureOptions<ConnectionStrings>
+{
+    private readonly IOptions<GlobalSettings> _globalSettings;
+    private readonly ILogger<ConfigureSqliteConnectionStringTimeouts> _logger;
+    private bool _connectTimeoutReported;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ConfigureSqliteConnectionStringTimeouts" /> class.
+    /// </summary>
+    /// <param name="globalSettings">The global settings carrying the configured timeouts.</param>
+    /// <param name="logger">The logger.</param>
+    public ConfigureSqliteConnectionStringTimeouts(
+        IOptions<GlobalSettings> globalSettings,
+        ILogger<ConfigureSqliteConnectionStringTimeouts> logger)
+    {
+        _globalSettings = globalSettings;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public void PostConfigure(string? name, ConnectionStrings options)
+    {
+        if (options.IsConnectionStringConfigured() is false
+            || options.ProviderName.InvariantEquals(Constants.ProviderName) is false)
+        {
+            return;
+        }
+
+        GlobalSettings globalSettings = _globalSettings.Value;
+
+        if (globalSettings.DatabaseConnectTimeout is not null && _connectTimeoutReported is false)
+        {
+            _connectTimeoutReported = true;
+            _logger.LogInformation(
+                "{ConnectTimeoutSetting} is configured but does not apply to SQLite, which has no connect timeout.",
+                "Umbraco:CMS:Global:DatabaseConnectTimeout");
+        }
+
+        if (globalSettings.DatabaseCommandTimeout is not { } commandTimeout)
+        {
+            return;
+        }
+
+        SqliteConnectionStringBuilder connectionStringBuilder;
+        try
+        {
+            connectionStringBuilder = new SqliteConnectionStringBuilder(options.ConnectionString)
+            {
+                DefaultTimeout = commandTimeout.ToConnectionStringTimeoutSeconds(),
+            };
+        }
+        catch (ArgumentException exception)
+        {
+            // The connection string cannot be rewritten, so leave it alone rather than failing to configure
+            // options - which would surface as an obscure startup failure rather than a connection error.
+            _logger.LogWarning(
+                exception,
+                "The configured database command timeout could not be applied, because the connection string could "
+                + "not be parsed. Set \"Command Timeout\" in the connection string instead.");
+            return;
+        }
+
+        options.ConnectionString = connectionStringBuilder.ConnectionString;
+    }
+}

--- a/src/Umbraco.Cms.Persistence.Sqlite/Configuration/ConfigureSqliteConnectionStringTimeouts.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Configuration/ConfigureSqliteConnectionStringTimeouts.cs
@@ -48,8 +48,7 @@ internal sealed class ConfigureSqliteConnectionStringTimeouts : IPostConfigureOp
         {
             _connectTimeoutReported = true;
             _logger.LogInformation(
-                "{ConnectTimeoutSetting} is configured but does not apply to SQLite, which has no connect timeout.",
-                "Umbraco:CMS:Global:DatabaseConnectTimeout");
+                "Umbraco:CMS:Global:DatabaseConnectTimeout is configured but does not apply to SQLite, which has no connect timeout.");
         }
 
         if (globalSettings.DatabaseCommandTimeout is not { } commandTimeout)
@@ -69,10 +68,9 @@ internal sealed class ConfigureSqliteConnectionStringTimeouts : IPostConfigureOp
         {
             // The connection string cannot be rewritten, so leave it alone rather than failing to configure
             // options - which would surface as an obscure startup failure rather than a connection error.
-            _logger.LogWarning(
-                exception,
-                "The configured database command timeout could not be applied, because the connection string could "
-                + "not be parsed. Set \"Command Timeout\" in the connection string instead.");
+            const string message = "The configured database command timeout could not be applied, because the "
+                + "connection string could not be parsed. Set \"Command Timeout\" in the connection string instead.";
+            _logger.LogWarning(exception, message);
             return;
         }
 

--- a/src/Umbraco.Cms.Persistence.Sqlite/Umbraco.Cms.Persistence.Sqlite.csproj
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Umbraco.Cms.Persistence.Sqlite.csproj
@@ -18,4 +18,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Umbraco.Infrastructure\Umbraco.Infrastructure.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Umbraco.Tests.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Umbraco.Cms.Persistence.Sqlite/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/UmbracoBuilderExtensions.cs
@@ -2,11 +2,13 @@ using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.DistributedLocking;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
+using Umbraco.Cms.Persistence.Sqlite.Configuration;
 using Umbraco.Cms.Persistence.Sqlite.Interceptors;
 using Umbraco.Cms.Persistence.Sqlite.Services;
 using Umbraco.Extensions;
@@ -62,6 +64,9 @@ public static class UmbracoBuilderExtensions
                 options.ConnectionString = connectionStringBuilder.ConnectionString;
             }
         });
+
+        builder.Services.TryAddEnumerable(ServiceDescriptor
+            .Singleton<IPostConfigureOptions<ConnectionStrings>, ConfigureSqliteConnectionStringTimeouts>());
 
         return builder;
     }

--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -209,6 +209,26 @@ public class GlobalSettings
     public string DatabaseFactoryServerVersion { get; set; } = string.Empty;
 
     /// <summary>
+    ///     Gets or sets the maximum time a single database command may run before it is cancelled.
+    /// </summary>
+    /// <remarks>
+    ///     Takes precedence over a command timeout in the connection string. When not set, the connection
+    ///     string's value applies, or the database provider's default. Not every database provider supports
+    ///     a command timeout.
+    /// </remarks>
+    public TimeSpan? DatabaseCommandTimeout { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the maximum time to wait when opening a connection to the database.
+    /// </summary>
+    /// <remarks>
+    ///     Takes precedence over a connect timeout in the connection string. When not set, the connection
+    ///     string's value applies, or the database provider's default. Not every database provider supports
+    ///     a connect timeout.
+    /// </remarks>
+    public TimeSpan? DatabaseConnectTimeout { get; set; }
+
+    /// <summary>
     ///     Gets or sets a value for the main dom lock.
     /// </summary>
     public string MainDomLock { get; set; } = string.Empty;

--- a/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
@@ -82,7 +82,7 @@ public class GlobalSettingsValidator
         return true;
     }
 
-    private bool ValidateDatabaseTimeoutSetting(string settingName, TimeSpan? configuredTimeOut, out string message)
+    private static bool ValidateDatabaseTimeoutSetting(string settingName, TimeSpan? configuredTimeOut, out string message)
     {
         if (configuredTimeOut < TimeSpan.Zero)
         {

--- a/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
@@ -29,6 +29,16 @@ public class GlobalSettingsValidator
             return ValidateOptionsResult.Fail(message3);
         }
 
+        if (!ValidateDatabaseTimeoutSetting(nameof(GlobalSettings.DatabaseCommandTimeout), options.DatabaseCommandTimeout, out var message4))
+        {
+            return ValidateOptionsResult.Fail(message4);
+        }
+
+        if (!ValidateDatabaseTimeoutSetting(nameof(GlobalSettings.DatabaseConnectTimeout), options.DatabaseConnectTimeout, out var message5))
+        {
+            return ValidateOptionsResult.Fail(message5);
+        }
+
         return ValidateOptionsResult.Success;
     }
 
@@ -65,6 +75,20 @@ public class GlobalSettingsValidator
                 $"The `{Constants.Configuration.ConfigGlobal}:{nameof(GlobalSettings.TimeOut)}` must not exceed {maxTimeOut.TotalDays:F0} days. " +
                 $"Values larger than this overflow the browser's maximum timer delay and break session management. " +
                 $"Consider using the `KeepUserLoggedIn` setting instead.";
+            return false;
+        }
+
+        message = string.Empty;
+        return true;
+    }
+
+    private bool ValidateDatabaseTimeoutSetting(string settingName, TimeSpan? configuredTimeOut, out string message)
+    {
+        if (configuredTimeOut < TimeSpan.Zero)
+        {
+            message =
+                $"The `{Constants.Configuration.ConfigGlobal}:{settingName}` must not be negative. " +
+                $"Use `00:00:00` for no limit, or omit the setting to use the value from the connection string.";
             return false;
         }
 

--- a/src/Umbraco.Infrastructure/Migrations/AsyncMigrationBase.Database.cs
+++ b/src/Umbraco.Infrastructure/Migrations/AsyncMigrationBase.Database.cs
@@ -23,9 +23,15 @@ public abstract partial class AsyncMigrationBase
     {
         const int MinimumCommandTimeoutInSeconds = 300;
 
-        var effectiveCommandTimeout = database is UmbracoDatabase umbracoDatabase
-            ? umbracoDatabase.EffectiveCommandTimeout
-            : database.CommandTimeout > 0 ? database.CommandTimeout : null;
+        int? effectiveCommandTimeout;
+        if (database is UmbracoDatabase umbracoDatabase)
+        {
+            effectiveCommandTimeout = umbracoDatabase.EffectiveCommandTimeout;
+        }
+        else
+        {
+            effectiveCommandTimeout = database.CommandTimeout > 0 ? database.CommandTimeout : null;
+        }
 
         if (effectiveCommandTimeout is 0 || effectiveCommandTimeout >= MinimumCommandTimeoutInSeconds)
         {

--- a/src/Umbraco.Infrastructure/Migrations/AsyncMigrationBase.Database.cs
+++ b/src/Umbraco.Infrastructure/Migrations/AsyncMigrationBase.Database.cs
@@ -1,4 +1,5 @@
 using Umbraco.Cms.Infrastructure.Migrations.Expressions.Execute.Expressions;
+using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.DatabaseModelDefinitions;
 using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
 using Umbraco.Extensions;
@@ -11,21 +12,27 @@ namespace Umbraco.Cms.Infrastructure.Migrations;
 public abstract partial class AsyncMigrationBase
 {
     /// <summary>
-    /// Ensures that the command timeout for the specified database is set to a minimum of 300 seconds.
+    /// Ensures that long-running database operations in this migration are allowed at least five minutes.
     /// </summary>
     /// <remarks>
-    /// Adjusts the command timeout to prevent potential timeouts during long-running
-    /// database operations.
-    /// If the command timeout is already longer, applied via the connection string with "Connect Timeout={timeout}" we leave it as is.
+    /// A command timeout that is already at least as long is left alone, whether it was set on the database
+    /// or derived by the provider from the connection string, and including a timeout of no limit at all.
     /// </remarks>
     /// <param name="database">The database instance for which the command timeout is being ensured.</param>
     protected static void EnsureLongCommandTimeout(NPoco.IDatabase database)
     {
-        const int CommandTimeoutInSeconds = 300;
-        if (database.CommandTimeout < CommandTimeoutInSeconds)
+        const int MinimumCommandTimeoutInSeconds = 300;
+
+        var effectiveCommandTimeout = database is UmbracoDatabase umbracoDatabase
+            ? umbracoDatabase.EffectiveCommandTimeout
+            : database.CommandTimeout > 0 ? database.CommandTimeout : null;
+
+        if (effectiveCommandTimeout is 0 || effectiveCommandTimeout >= MinimumCommandTimeoutInSeconds)
         {
-            database.CommandTimeout = CommandTimeoutInSeconds;
+            return;
         }
+
+        database.CommandTimeout = MinimumCommandTimeoutInSeconds;
     }
 
     protected void AddColumn<T>(string columnName)

--- a/src/Umbraco.Infrastructure/Persistence/CommandTimeoutResolver.cs
+++ b/src/Umbraco.Infrastructure/Persistence/CommandTimeoutResolver.cs
@@ -49,9 +49,22 @@ internal static class CommandTimeoutResolver
 
     /// <summary>
     ///     Determines whether the connection string relies on the deprecated convention of taking the command
-    ///     timeout from the connect timeout, which is the case when it sets a connect timeout but no command
-    ///     timeout.
+    ///     timeout from the connect timeout, which is the case when it sets a connect timeout and does not
+    ///     appear to configure a command timeout.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         "Does not appear to" is the accurate phrasing: a configured command timeout is detected by
+    ///         comparing what the provider derives from this connection string against what it derives from no
+    ///         connection string at all. A command timeout explicitly set to the provider's own default is
+    ///         therefore indistinguishable from one that is absent, and the connect timeout wins.
+    ///     </para>
+    ///     <para>
+    ///         That is the conservative choice, because it is what every version before the command timeout was
+    ///         honoured did. Resolving the ambiguity would mean asking each provider which keywords the
+    ///         connection string actually supplied, which is not something the ADO.NET contract exposes.
+    ///     </para>
+    /// </remarks>
     /// <param name="provider">The provider factory, or <c>null</c> when unknown.</param>
     /// <param name="connectionString">The connection string.</param>
     /// <param name="timeoutSeconds">The connect timeout to apply as the command timeout.</param>

--- a/src/Umbraco.Infrastructure/Persistence/CommandTimeoutResolver.cs
+++ b/src/Umbraco.Infrastructure/Persistence/CommandTimeoutResolver.cs
@@ -1,0 +1,164 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Umbraco.Cms.Infrastructure.Persistence;
+
+/// <summary>
+///     Resolves the command timeout that applies to a database connection string.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The command timeout is a concept the ADO.NET provider owns: it decides which connection string
+///         keywords express one, what they are called, and what the default is when none is given. Rather
+///         than model that vocabulary, this type asks the provider directly, by building a command from an
+///         unopened connection and reading the timeout the provider put on it.
+///     </para>
+/// </remarks>
+internal static class CommandTimeoutResolver
+{
+    /// <summary>
+    ///     The connection string keywords Umbraco has historically treated as also setting the command timeout.
+    /// </summary>
+    // TODO (V19): remove, along with the connect timeout fallback it exists to support.
+    private static readonly string[] _deprecatedConnectTimeoutKeywords = ["connection timeout", "connect timeout"];
+
+    private static readonly ConcurrentDictionary<DbProviderFactory, int?> _providerDefaults = new();
+
+    /// <summary>
+    ///     Gets the command timeout, in seconds, that the provider will apply to commands created from the
+    ///     given connection string.
+    /// </summary>
+    /// <param name="provider">The provider factory, or <c>null</c> when unknown.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <returns>
+    ///     The timeout in seconds, where zero means no limit, or <c>null</c> when it cannot be determined.
+    /// </returns>
+    internal static int? GetConfiguredCommandTimeout(DbProviderFactory? provider, string? connectionString)
+    {
+        if (provider is null || string.IsNullOrWhiteSpace(connectionString))
+        {
+            return null;
+        }
+
+        // Deliberately not memoized per connection string: callers already resolve this at most once
+        // each, and caching it would hold credentials in a static for the lifetime of the process.
+        return Probe(provider, connectionString);
+    }
+
+    /// <summary>
+    ///     Determines whether the connection string relies on the deprecated convention of taking the command
+    ///     timeout from the connect timeout, which is the case when it sets a connect timeout but no command
+    ///     timeout.
+    /// </summary>
+    /// <param name="provider">The provider factory, or <c>null</c> when unknown.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="timeoutSeconds">The connect timeout to apply as the command timeout.</param>
+    /// <param name="keyword">The connection string keyword the timeout was read from.</param>
+    /// <returns><c>true</c> when the fallback applies; otherwise, <c>false</c>.</returns>
+    [Obsolete("Deriving the command timeout from the connect timeout is deprecated. Scheduled for removal in Umbraco 19.")]
+    internal static bool TryGetDeprecatedConnectTimeout(
+        DbProviderFactory? provider,
+        string? connectionString,
+        out int timeoutSeconds,
+        [NotNullWhen(true)] out string? keyword)
+    {
+        timeoutSeconds = 0;
+        keyword = null;
+
+        if (TryGetConnectTimeout(connectionString, out timeoutSeconds, out keyword) is false)
+        {
+            return false;
+        }
+
+        int? configuredCommandTimeout = GetConfiguredCommandTimeout(provider, connectionString);
+        int? providerDefault = GetProviderDefaultCommandTimeout(provider);
+
+        // A command timeout in the connection string takes precedence, so the fallback stands down. When
+        // neither value could be determined we cannot tell the two apart, and preserving the long-standing
+        // behaviour is the safer of the two options.
+        if (configuredCommandTimeout is not null && providerDefault is not null && configuredCommandTimeout != providerDefault)
+        {
+            keyword = null;
+            timeoutSeconds = 0;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryGetConnectTimeout(
+        string? connectionString,
+        out int timeoutSeconds,
+        [NotNullWhen(true)] out string? keyword)
+    {
+        timeoutSeconds = 0;
+        keyword = null;
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return false;
+        }
+
+        DbConnectionStringBuilder connectionStringParser;
+        try
+        {
+            connectionStringParser = new DbConnectionStringBuilder { ConnectionString = connectionString };
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        foreach (var candidate in _deprecatedConnectTimeoutKeywords)
+        {
+            if (connectionStringParser.TryGetValue(candidate, out var value)
+                && int.TryParse(value?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                && parsed > 0)
+            {
+                timeoutSeconds = parsed;
+                keyword = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int? GetProviderDefaultCommandTimeout(DbProviderFactory? provider)
+    {
+        if (provider is null)
+        {
+            return null;
+        }
+
+        return _providerDefaults.GetOrAdd(provider, static key => Probe(key, connectionString: null));
+    }
+
+    private static int? Probe(DbProviderFactory provider, string? connectionString)
+    {
+        try
+        {
+            using DbConnection? connection = provider.CreateConnection();
+            if (connection is null)
+            {
+                return null;
+            }
+
+            if (connectionString is not null)
+            {
+                connection.ConnectionString = connectionString;
+            }
+
+            using DbCommand command = connection.CreateCommand();
+            return command.CommandTimeout;
+        }
+        catch (Exception)
+        {
+            // A connection string the provider rejects has to surface as the connection failure it is, when a
+            // connection is actually opened - not as a failure to construct a database.
+            return null;
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/CommandTimeoutResolver.cs
+++ b/src/Umbraco.Infrastructure/Persistence/CommandTimeoutResolver.cs
@@ -127,7 +127,7 @@ internal static class CommandTimeoutResolver
         foreach (var candidate in _deprecatedConnectTimeoutKeywords)
         {
             if (connectionStringParser.TryGetValue(candidate, out var value)
-                && int.TryParse(value?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                && int.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
                 && parsed > 0)
             {
                 timeoutSeconds = parsed;

--- a/src/Umbraco.Infrastructure/Persistence/ConnectionStringTimeoutExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/ConnectionStringTimeoutExtensions.cs
@@ -1,0 +1,20 @@
+namespace Umbraco.Cms.Infrastructure.Persistence;
+
+/// <summary>
+///     Extension methods for expressing a configured timeout in a database connection string.
+/// </summary>
+public static class ConnectionStringTimeoutExtensions
+{
+    /// <summary>
+    ///     Converts a configured timeout to the whole number of seconds that a connection string
+    ///     timeout keyword takes.
+    /// </summary>
+    /// <param name="timeout">The configured timeout.</param>
+    /// <returns>The timeout in whole seconds.</returns>
+    /// <remarks>
+    ///     Rounds up, so that a sub-second timeout cannot become zero seconds - which providers read as
+    ///     no limit at all, the opposite of what was configured.
+    /// </remarks>
+    public static int ToConnectionStringTimeoutSeconds(this TimeSpan timeout)
+        => (int)Math.Ceiling(timeout.TotalSeconds);
+}

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
@@ -128,10 +128,14 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
         if (CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(_provider, ConnectionString, out var timeout, out var keyword))
 #pragma warning restore CS0618 // Type or member is obsolete
         {
-            _logger.LogTrace(
-                "Applying the connection string \"{Keyword}\" value of {Timeout} seconds as the command timeout.",
-                keyword,
-                timeout);
+            if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
+            {
+                _logger.LogTrace(
+                    "Applying the connection string \"{Keyword}\" value of {Timeout} seconds as the command timeout.",
+                    keyword,
+                    timeout);
+            }
+
             CommandTimeout = timeout;
         }
     }

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
@@ -24,6 +24,8 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
     private readonly IBulkSqlInsertProvider? _bulkSqlInsertProvider;
     private readonly DatabaseSchemaCreatorFactory? _databaseSchemaCreatorFactory;
     private readonly IEnumerable<IMapper>? _mapperCollection;
+    private readonly DbProviderFactory? _provider;
+    private readonly Lazy<int?> _configuredCommandTimeout;
     private readonly Guid _instanceGuid = Guid.NewGuid();
     private List<CommandInfo>? _commands;
 
@@ -58,6 +60,8 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
         _bulkSqlInsertProvider = bulkSqlInsertProvider;
         _databaseSchemaCreatorFactory = databaseSchemaCreatorFactory;
         _mapperCollection = mapperCollection;
+        _provider = provider;
+        _configuredCommandTimeout = CreateConfiguredCommandTimeout();
 
         Init();
     }
@@ -76,6 +80,7 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
         SqlContext = sqlContext;
         _logger = logger;
         _bulkSqlInsertProvider = bulkSqlInsertProvider;
+        _configuredCommandTimeout = CreateConfiguredCommandTimeout();
 
         Init();
     }
@@ -95,9 +100,21 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
         InitCommandTimeout();
     }
 
-    // https://github.com/umbraco/Umbraco-CMS/issues/13354
-    // This sets the Database Command to connectionString Connection Timeout /  Connect Timeout
-    // This could be better, ideally the UmbracoDatabaseFactory.CreateDatabase() function would set this based on a setting (global or connectionstring setting)
+    /// <summary>
+    ///     Applies Umbraco's own command timeout override, if it has one.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         NPoco forces a non-zero <see cref="Database.CommandTimeout" /> onto every command, so leaving it
+    ///         at zero is what allows the timeout the provider derived from the connection string to stand.
+    ///     </para>
+    ///     <para>
+    ///         The single remaining override is the deprecated convention, introduced for
+    ///         <see href="https://github.com/umbraco/Umbraco-CMS/issues/13354">#13354</see> before providers
+    ///         exposed a command timeout keyword, by which a connect timeout in the connection string also
+    ///         lengthened the command timeout. It applies only where no command timeout is configured.
+    ///     </para>
+    /// </remarks>
     private void InitCommandTimeout()
     {
         if (CommandTimeout != 0)
@@ -106,42 +123,35 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
             return;
         }
 
-        if (Connection is not null && Connection.ConnectionTimeout > 0)
+        // TODO (V19): remove; deriving the command timeout from the connect timeout is deprecated.
+#pragma warning disable CS0618 // Type or member is obsolete
+        if (CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(_provider, ConnectionString, out var timeout, out var keyword))
+#pragma warning restore CS0618 // Type or member is obsolete
         {
-            CommandTimeout = Connection.ConnectionTimeout;
-            return;
-        }
-
-        // get from ConnectionString
-        var connectionParser = new DbConnectionStringBuilder
-        {
-            ConnectionString = ConnectionString
-        };
-
-        if (connectionParser.TryGetValue("connection timeout", out var connectionTimeoutString))
-        {
-            if (int.TryParse(connectionTimeoutString.ToString(), out var connectionTimeout))
-            {
-                _logger.LogTrace("Setting Command Timeout to value configured in connectionstring Connection Timeout : {TimeOut} seconds", connectionTimeout);
-                CommandTimeout = connectionTimeout;
-                return;
-            }
-        }
-
-        if (connectionParser.TryGetValue("connect timeout", out var connectTimeoutString))
-        {
-            if (int.TryParse(connectTimeoutString.ToString(), out var connectionTimeout))
-            {
-                _logger.LogTrace("Setting Command Timeout to value configured in connectionstring Connect Timeout : {TimeOut} seconds", connectionTimeout);
-                CommandTimeout = connectionTimeout;
-            }
+            _logger.LogTrace(
+                "Applying the connection string \"{Keyword}\" value of {Timeout} seconds as the command timeout.",
+                keyword,
+                timeout);
+            CommandTimeout = timeout;
         }
     }
+
+    private Lazy<int?> CreateConfiguredCommandTimeout()
+        => new(() => CommandTimeoutResolver.GetConfiguredCommandTimeout(_provider, ConnectionString));
 
     #endregion
 
     /// <inheritdoc />
     public ISqlContext SqlContext { get; }
+
+    /// <summary>
+    ///     Gets the command timeout, in seconds, that applies to commands created by this database:
+    ///     <see cref="Database.CommandTimeout" /> when set, otherwise the timeout the underlying provider
+    ///     derives from the connection string.
+    /// </summary>
+    /// <remarks>Zero means no limit. <c>null</c> means the timeout could not be determined.</remarks>
+    internal int? EffectiveCommandTimeout
+        => CommandTimeout > 0 ? CommandTimeout : _configuredCommandTimeout.Value;
 
     #region Testing, Debugging and Troubleshooting
 
@@ -324,12 +334,6 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
 
     protected override void OnExecutingCommand(DbCommand cmd)
     {
-        // if no timeout is specified, and the connection has a longer timeout, use it
-        if (OneTimeCommandTimeout == 0 && CommandTimeout == 0 && cmd.Connection?.ConnectionTimeout > 30)
-        {
-            cmd.CommandTimeout = cmd.Connection.ConnectionTimeout;
-        }
-
         if (EnableSqlTrace)
         {
             if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
@@ -229,6 +229,8 @@ public class UmbracoDatabaseFactory : DisposableObjectSlim, IUmbracoDatabaseFact
             throw new Exception($"Can't find a provider factory for provider name \"{ProviderName}\".");
         }
 
+        WarnOnDeprecatedCommandTimeoutFromConnectTimeout();
+
         _databaseType = DatabaseType.Resolve(DbProviderFactory.GetType().Name, ProviderName);
         if (_databaseType == null)
         {
@@ -287,6 +289,23 @@ public class UmbracoDatabaseFactory : DisposableObjectSlim, IUmbracoDatabaseFact
     // gets initialized poco data builders
     private InitializedPocoDataBuilder GetPocoDataFactoryResolver(Type type, IPocoDataFactory factory)
         => new UmbracoPocoDataBuilder(type, _pocoMappers, _upgrading).Init();
+
+    // TODO (V19): remove with the connect timeout fallback in UmbracoDatabase.
+    private void WarnOnDeprecatedCommandTimeoutFromConnectTimeout()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        if (CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(DbProviderFactory, ConnectionString, out var commandTimeout, out var keyword))
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
+            _logger.LogWarning(
+                "The connection string sets \"{Keyword}\", which Umbraco also applies as the command timeout ({Timeout} seconds). "
+                + "Set \"Command Timeout\" in the connection string, or configure {CommandTimeoutSetting}, instead; deriving the "
+                + "command timeout from the connect timeout is deprecated and will be removed in Umbraco 19.",
+                keyword,
+                commandTimeout,
+                "Umbraco:CMS:Global:DatabaseCommandTimeout");
+        }
+    }
 
     // method used by NPoco's UmbracoDatabaseFactory to actually create the database instance
     private UmbracoDatabase? CreateDatabaseInstance()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/ConfigureSqlServerConnectionStringTimeoutsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/ConfigureSqlServerConnectionStringTimeoutsTests.cs
@@ -25,7 +25,7 @@ public class ConfigureSqlServerConnectionStringTimeoutsTests
     {
         ConnectionStrings options = PostConfigure(new GlobalSettings
         {
-            DatabaseCommandTimeout = TimeSpan.FromMinutes(5)
+            DatabaseCommandTimeout = TimeSpan.FromMinutes(5),
         });
 
         Assert.AreEqual(300, new SqlConnectionStringBuilder(options.ConnectionString).CommandTimeout);
@@ -36,7 +36,7 @@ public class ConfigureSqlServerConnectionStringTimeoutsTests
     {
         ConnectionStrings options = PostConfigure(new GlobalSettings
         {
-            DatabaseConnectTimeout = TimeSpan.FromMinutes(1)
+            DatabaseConnectTimeout = TimeSpan.FromMinutes(1),
         });
 
         Assert.AreEqual(60, new SqlConnectionStringBuilder(options.ConnectionString).ConnectTimeout);
@@ -48,7 +48,7 @@ public class ConfigureSqlServerConnectionStringTimeoutsTests
         ConnectionStrings options = PostConfigure(new GlobalSettings
         {
             DatabaseCommandTimeout = TimeSpan.FromMinutes(5),
-            DatabaseConnectTimeout = TimeSpan.FromSeconds(10)
+            DatabaseConnectTimeout = TimeSpan.FromSeconds(10),
         });
 
         var connectionStringBuilder = new SqlConnectionStringBuilder(options.ConnectionString);
@@ -75,7 +75,7 @@ public class ConfigureSqlServerConnectionStringTimeoutsTests
     {
         ConnectionStrings options = PostConfigure(new GlobalSettings
         {
-            DatabaseCommandTimeout = TimeSpan.Zero
+            DatabaseCommandTimeout = TimeSpan.Zero,
         });
 
         Assert.AreEqual(0, new SqlConnectionStringBuilder(options.ConnectionString).CommandTimeout);
@@ -112,7 +112,7 @@ public class ConfigureSqlServerConnectionStringTimeoutsTests
         var options = new ConnectionStrings
         {
             ConnectionString = unparseableConnectionString,
-            ProviderName = global::Umbraco.Cms.Persistence.SqlServer.Constants.ProviderName
+            ProviderName = global::Umbraco.Cms.Persistence.SqlServer.Constants.ProviderName,
         };
 
         new ConfigureSqlServerConnectionStringTimeouts(
@@ -136,7 +136,7 @@ public class ConfigureSqlServerConnectionStringTimeoutsTests
         var options = new ConnectionStrings
         {
             ConnectionString = connectionString,
-            ProviderName = providerName ?? global::Umbraco.Cms.Persistence.SqlServer.Constants.ProviderName
+            ProviderName = providerName ?? global::Umbraco.Cms.Persistence.SqlServer.Constants.ProviderName,
         };
 
         new ConfigureSqlServerConnectionStringTimeouts(Options.Create(globalSettings), new FakeLogger())

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/ConfigureSqlServerConnectionStringTimeoutsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/ConfigureSqlServerConnectionStringTimeoutsTests.cs
@@ -128,6 +128,31 @@ public class ConfigureSqlServerConnectionStringTimeoutsTests
         });
     }
 
+    [Test]
+    public void Cannot_Change_Connection_String_When_A_Timeout_Is_Rejected_By_The_Builder()
+    {
+        // Validation rejects a negative timeout before it reaches here, so this only asserts that applying the
+        // timeouts is covered by the same guard as parsing the connection string.
+        var logger = new FakeLogger();
+        var options = new ConnectionStrings
+        {
+            ConnectionString = ConnectionString,
+            ProviderName = global::Umbraco.Cms.Persistence.SqlServer.Constants.ProviderName,
+        };
+
+        new ConfigureSqlServerConnectionStringTimeouts(
+                Options.Create(new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromSeconds(-1) }),
+                logger)
+            .PostConfigure(name: null, options);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(ConnectionString, options.ConnectionString);
+            Assert.AreEqual(1, logger.LogEntries.Count);
+            Assert.AreEqual(LogLevel.Warning, logger.LogEntries[0].Level);
+        });
+    }
+
     private static ConnectionStrings PostConfigure(
         GlobalSettings globalSettings,
         string connectionString = ConnectionString,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/ConfigureSqlServerConnectionStringTimeoutsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/ConfigureSqlServerConnectionStringTimeoutsTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Persistence.SqlServer.Configuration;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
+
+[TestFixture]
+public class ConfigureSqlServerConnectionStringTimeoutsTests
+{
+    private const string ConnectionString = "Server=.;Database=x";
+
+    [Test]
+    public void Cannot_Change_Connection_String_When_Neither_Timeout_Is_Configured()
+    {
+        ConnectionStrings options = PostConfigure(new GlobalSettings());
+
+        Assert.AreEqual(ConnectionString, options.ConnectionString);
+    }
+
+    [Test]
+    public void Can_Apply_Configured_Command_Timeout()
+    {
+        ConnectionStrings options = PostConfigure(new GlobalSettings
+        {
+            DatabaseCommandTimeout = TimeSpan.FromMinutes(5)
+        });
+
+        Assert.AreEqual(300, new SqlConnectionStringBuilder(options.ConnectionString).CommandTimeout);
+    }
+
+    [Test]
+    public void Can_Apply_Configured_Connect_Timeout()
+    {
+        ConnectionStrings options = PostConfigure(new GlobalSettings
+        {
+            DatabaseConnectTimeout = TimeSpan.FromMinutes(1)
+        });
+
+        Assert.AreEqual(60, new SqlConnectionStringBuilder(options.ConnectionString).ConnectTimeout);
+    }
+
+    [Test]
+    public void Can_Apply_Both_Timeouts_Independently()
+    {
+        ConnectionStrings options = PostConfigure(new GlobalSettings
+        {
+            DatabaseCommandTimeout = TimeSpan.FromMinutes(5),
+            DatabaseConnectTimeout = TimeSpan.FromSeconds(10)
+        });
+
+        var connectionStringBuilder = new SqlConnectionStringBuilder(options.ConnectionString);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(300, connectionStringBuilder.CommandTimeout);
+            Assert.AreEqual(10, connectionStringBuilder.ConnectTimeout);
+        });
+    }
+
+    [Test]
+    public void Can_Take_Precedence_Over_Connection_String()
+    {
+        ConnectionStrings options = PostConfigure(
+            new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromMinutes(5) },
+            "Server=.;Database=x;Command Timeout=30");
+
+        Assert.AreEqual(300, new SqlConnectionStringBuilder(options.ConnectionString).CommandTimeout);
+    }
+
+    [Test]
+    public void Can_Apply_Command_Timeout_Of_No_Limit()
+    {
+        ConnectionStrings options = PostConfigure(new GlobalSettings
+        {
+            DatabaseCommandTimeout = TimeSpan.Zero
+        });
+
+        Assert.AreEqual(0, new SqlConnectionStringBuilder(options.ConnectionString).CommandTimeout);
+    }
+
+    [Test]
+    public void Cannot_Change_Connection_String_For_Another_Provider()
+    {
+        const string sqliteConnectionString = "Data Source=x.db";
+
+        ConnectionStrings options = PostConfigure(
+            new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromMinutes(5) },
+            sqliteConnectionString,
+            providerName: "Microsoft.Data.Sqlite");
+
+        Assert.AreEqual(sqliteConnectionString, options.ConnectionString);
+    }
+
+    [Test]
+    public void Can_Apply_Configured_Command_Timeout_For_A_Case_Variant_Provider_Name()
+    {
+        ConnectionStrings options = PostConfigure(
+            new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromMinutes(5) },
+            providerName: "microsoft.data.sqlclient");
+
+        Assert.AreEqual(300, new SqlConnectionStringBuilder(options.ConnectionString).CommandTimeout);
+    }
+
+    [Test]
+    public void Cannot_Change_A_Connection_String_That_Cannot_Be_Parsed()
+    {
+        const string unparseableConnectionString = "Server=.;Database=x;NotASqlServerKeyword=1";
+        var logger = new FakeLogger();
+        var options = new ConnectionStrings
+        {
+            ConnectionString = unparseableConnectionString,
+            ProviderName = global::Umbraco.Cms.Persistence.SqlServer.Constants.ProviderName
+        };
+
+        new ConfigureSqlServerConnectionStringTimeouts(
+                Options.Create(new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromMinutes(5) }),
+                logger)
+            .PostConfigure(name: null, options);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(unparseableConnectionString, options.ConnectionString);
+            Assert.AreEqual(1, logger.LogEntries.Count);
+            Assert.AreEqual(LogLevel.Warning, logger.LogEntries[0].Level);
+        });
+    }
+
+    private static ConnectionStrings PostConfigure(
+        GlobalSettings globalSettings,
+        string connectionString = ConnectionString,
+        string? providerName = null)
+    {
+        var options = new ConnectionStrings
+        {
+            ConnectionString = connectionString,
+            ProviderName = providerName ?? global::Umbraco.Cms.Persistence.SqlServer.Constants.ProviderName
+        };
+
+        new ConfigureSqlServerConnectionStringTimeouts(Options.Create(globalSettings), new FakeLogger())
+            .PostConfigure(name: null, options);
+
+        return options;
+    }
+
+    private sealed class FakeLogger : ILogger<ConfigureSqlServerConnectionStringTimeouts>
+    {
+        public List<LogEntry> LogEntries { get; } = [];
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => LogEntries.Add(new LogEntry(logLevel, formatter(state, exception)));
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public record LogEntry(LogLevel Level, string Message);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.Sqlite/ConfigureSqliteConnectionStringTimeoutsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.Sqlite/ConfigureSqliteConnectionStringTimeoutsTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Persistence.Sqlite.Configuration;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.Sqlite;
+
+[TestFixture]
+public class ConfigureSqliteConnectionStringTimeoutsTests
+{
+    private const string ConnectionString = "Data Source=x.db;Cache=Shared;Foreign Keys=True;Pooling=True";
+
+    private static string ProviderName => global::Umbraco.Cms.Persistence.Sqlite.Constants.ProviderName;
+
+    [Test]
+    public void Cannot_Change_Connection_String_When_No_Command_Timeout_Is_Configured()
+    {
+        ConnectionStrings options = PostConfigure(new GlobalSettings(), out _);
+
+        Assert.AreEqual(ConnectionString, options.ConnectionString);
+    }
+
+    [Test]
+    public void Can_Apply_Configured_Command_Timeout()
+    {
+        ConnectionStrings options = PostConfigure(
+            new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromMinutes(5) },
+            out _);
+
+        Assert.AreEqual(300, new SqliteConnectionStringBuilder(options.ConnectionString).DefaultTimeout);
+    }
+
+    [Test]
+    public void Cannot_Apply_Configured_Connect_Timeout_To_Sqlite()
+    {
+        ConnectionStrings options = PostConfigure(
+            new GlobalSettings { DatabaseConnectTimeout = TimeSpan.FromMinutes(1) },
+            out FakeLogger logger);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(ConnectionString, options.ConnectionString);
+            Assert.AreEqual(1, logger.LogEntries.Count);
+            Assert.AreEqual(LogLevel.Information, logger.LogEntries[0].Level);
+            Assert.That(logger.LogEntries[0].Message, Does.Contain("DatabaseConnectTimeout"));
+        });
+    }
+
+    [Test]
+    public void Can_Report_Inapplicable_Connect_Timeout_Only_Once()
+    {
+        var globalSettings = new GlobalSettings { DatabaseConnectTimeout = TimeSpan.FromMinutes(1) };
+        var logger = new FakeLogger();
+        var sut = new ConfigureSqliteConnectionStringTimeouts(Options.Create(globalSettings), logger);
+
+        for (var i = 0; i < 3; i++)
+        {
+            sut.PostConfigure(name: null, NewOptions(ConnectionString, ProviderName));
+        }
+
+        Assert.AreEqual(1, logger.LogEntries.Count);
+    }
+
+    [Test]
+    public void Cannot_Change_Connection_String_For_Another_Provider()
+    {
+        const string sqlServerConnectionString = "Server=.;Database=x";
+
+        ConnectionStrings options = PostConfigure(
+            new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromMinutes(5) },
+            out _,
+            sqlServerConnectionString,
+            providerName: "Microsoft.Data.SqlClient");
+
+        Assert.AreEqual(sqlServerConnectionString, options.ConnectionString);
+    }
+
+    [Test]
+    public void Can_Apply_Configured_Command_Timeout_For_A_Case_Variant_Provider_Name()
+    {
+        ConnectionStrings options = PostConfigure(
+            new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromMinutes(5) },
+            out _,
+            providerName: "microsoft.data.sqlite");
+
+        Assert.AreEqual(300, new SqliteConnectionStringBuilder(options.ConnectionString).DefaultTimeout);
+    }
+
+    [Test]
+    public void Cannot_Change_A_Connection_String_That_Cannot_Be_Parsed()
+    {
+        const string unparseableConnectionString = "Data Source=x.db;NotASqliteKeyword=1";
+
+        ConnectionStrings options = PostConfigure(
+            new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromMinutes(5) },
+            out FakeLogger logger,
+            unparseableConnectionString);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(unparseableConnectionString, options.ConnectionString);
+            Assert.AreEqual(1, logger.LogEntries.Count);
+            Assert.AreEqual(LogLevel.Warning, logger.LogEntries[0].Level);
+        });
+    }
+
+    private static ConnectionStrings NewOptions(string connectionString, string providerName)
+        => new() { ConnectionString = connectionString, ProviderName = providerName };
+
+    private static ConnectionStrings PostConfigure(
+        GlobalSettings globalSettings,
+        out FakeLogger logger,
+        string connectionString = ConnectionString,
+        string? providerName = null)
+    {
+        ConnectionStrings options = NewOptions(connectionString, providerName ?? ProviderName);
+        logger = new FakeLogger();
+
+        new ConfigureSqliteConnectionStringTimeouts(Options.Create(globalSettings), logger)
+            .PostConfigure(name: null, options);
+
+        return options;
+    }
+
+    private sealed class FakeLogger : ILogger<ConfigureSqliteConnectionStringTimeouts>
+    {
+        public List<LogEntry> LogEntries { get; } = [];
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => LogEntries.Add(new LogEntry(logLevel, formatter(state, exception)));
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public record LogEntry(LogLevel Level, string Message);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidatorTests.cs
@@ -97,7 +97,7 @@ public class GlobalSettingsValidatorTests
         var options = new GlobalSettings
         {
             DatabaseCommandTimeout = TimeSpan.Zero,
-            DatabaseConnectTimeout = TimeSpan.Zero
+            DatabaseConnectTimeout = TimeSpan.Zero,
         };
 
         var result = validator.Validate("settings", options);
@@ -111,7 +111,7 @@ public class GlobalSettingsValidatorTests
         var options = new GlobalSettings
         {
             DatabaseCommandTimeout = TimeSpan.FromMinutes(5),
-            DatabaseConnectTimeout = TimeSpan.FromSeconds(30)
+            DatabaseConnectTimeout = TimeSpan.FromSeconds(30),
         };
 
         var result = validator.Validate("settings", options);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidatorTests.cs
@@ -68,4 +68,53 @@ public class GlobalSettingsValidatorTests
         var result = validator.Validate("settings", options);
         Assert.True(result.Succeeded);
     }
+
+    [Test]
+    public void Returns_Fail_For_Configuration_With_Negative_DatabaseCommandTimeout()
+    {
+        var validator = new GlobalSettingsValidator();
+        var options = new GlobalSettings { DatabaseCommandTimeout = TimeSpan.FromSeconds(-1) };
+
+        var result = validator.Validate("settings", options);
+        Assert.False(result.Succeeded);
+    }
+
+    [Test]
+    public void Returns_Fail_For_Configuration_With_Negative_DatabaseConnectTimeout()
+    {
+        var validator = new GlobalSettingsValidator();
+        var options = new GlobalSettings { DatabaseConnectTimeout = TimeSpan.FromSeconds(-1) };
+
+        var result = validator.Validate("settings", options);
+        Assert.False(result.Succeeded);
+    }
+
+    [Test]
+    public void Returns_Success_For_Configuration_With_Zero_DatabaseTimeouts()
+    {
+        // Zero is meaningful: it configures no limit at all.
+        var validator = new GlobalSettingsValidator();
+        var options = new GlobalSettings
+        {
+            DatabaseCommandTimeout = TimeSpan.Zero,
+            DatabaseConnectTimeout = TimeSpan.Zero
+        };
+
+        var result = validator.Validate("settings", options);
+        Assert.True(result.Succeeded);
+    }
+
+    [Test]
+    public void Returns_Success_For_Configuration_With_Valid_DatabaseTimeouts()
+    {
+        var validator = new GlobalSettingsValidator();
+        var options = new GlobalSettings
+        {
+            DatabaseCommandTimeout = TimeSpan.FromMinutes(5),
+            DatabaseConnectTimeout = TimeSpan.FromSeconds(30)
+        };
+
+        var result = validator.Validate("settings", options);
+        Assert.True(result.Succeeded);
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/EnsureLongCommandTimeoutTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/EnsureLongCommandTimeoutTests.cs
@@ -1,0 +1,132 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NPoco;
+using NPoco.DatabaseTypes;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Install;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Migrations;
+
+[TestFixture]
+public class EnsureLongCommandTimeoutTests
+{
+    private const int MinimumCommandTimeoutInSeconds = 300;
+
+    [Test]
+    public void Cannot_Lower_Longer_Command_Timeout_From_Connection_String()
+    {
+        using UmbracoDatabase database = CreateDatabase("Data Source=x.db;Default Timeout=600");
+
+        TestMigration.Invoke(database);
+
+        Assert.AreEqual(0, database.CommandTimeout);
+    }
+
+    [Test]
+    public void Cannot_Lower_Command_Timeout_Of_No_Limit_From_Connection_String()
+    {
+        using UmbracoDatabase database = CreateDatabase("Data Source=x.db;Default Timeout=0");
+
+        TestMigration.Invoke(database);
+
+        Assert.AreEqual(0, database.CommandTimeout);
+    }
+
+    [Test]
+    public void Can_Raise_Shorter_Command_Timeout_From_Connection_String()
+    {
+        using UmbracoDatabase database = CreateDatabase("Data Source=x.db;Default Timeout=60");
+
+        TestMigration.Invoke(database);
+
+        Assert.AreEqual(MinimumCommandTimeoutInSeconds, database.CommandTimeout);
+    }
+
+    [Test]
+    public void Can_Raise_Provider_Default_Command_Timeout()
+    {
+        using UmbracoDatabase database = CreateDatabase("Data Source=x.db");
+
+        TestMigration.Invoke(database);
+
+        Assert.AreEqual(MinimumCommandTimeoutInSeconds, database.CommandTimeout);
+    }
+
+    [Test]
+    public void Cannot_Lower_Longer_Command_Timeout_Set_In_Code()
+    {
+        var database = new Mock<IDatabase>();
+        database.SetupGet(x => x.CommandTimeout).Returns(500);
+
+        TestMigration.Invoke(database.Object);
+
+        database.VerifySet(x => x.CommandTimeout = It.IsAny<int>(), Times.Never);
+    }
+
+    [Test]
+    public void Can_Raise_Shorter_Command_Timeout_Set_In_Code()
+    {
+        var database = new Mock<IDatabase>();
+        database.SetupGet(x => x.CommandTimeout).Returns(60);
+
+        TestMigration.Invoke(database.Object);
+
+        database.VerifySet(x => x.CommandTimeout = MinimumCommandTimeoutInSeconds, Times.Once);
+    }
+
+    [Test]
+    public void Can_Raise_Unset_Command_Timeout_When_Effective_Timeout_Is_Unknown()
+    {
+        var database = new Mock<IDatabase>();
+        database.SetupGet(x => x.CommandTimeout).Returns(0);
+
+        TestMigration.Invoke(database.Object);
+
+        database.VerifySet(x => x.CommandTimeout = MinimumCommandTimeoutInSeconds, Times.Once);
+    }
+
+    private static UmbracoDatabase CreateDatabase(string connectionString)
+    {
+        var sqlSyntax = new Mock<ISqlSyntaxProvider>();
+        sqlSyntax.SetupGet(x => x.DefaultIsolationLevel).Returns(IsolationLevel.ReadCommitted);
+
+        var sqlContext = new Mock<ISqlContext>();
+        sqlContext.SetupGet(x => x.DatabaseType).Returns(new SQLiteDatabaseType());
+        sqlContext.SetupGet(x => x.SqlSyntax).Returns(sqlSyntax.Object);
+
+        return new UmbracoDatabase(
+            connectionString,
+            sqlContext.Object,
+            SqliteFactory.Instance,
+            NullLogger<UmbracoDatabase>.Instance,
+            null,
+            new DatabaseSchemaCreatorFactory(
+                NullLogger<DatabaseSchemaCreator>.Instance,
+                NullLoggerFactory.Instance,
+                Mock.Of<IUmbracoVersion>(),
+                Mock.Of<IEventAggregator>(),
+                Mock.Of<IOptionsMonitor<InstallDefaultDataSettings>>()));
+    }
+
+    private sealed class TestMigration : AsyncMigrationBase
+    {
+        private TestMigration()
+            : base(Mock.Of<IMigrationContext>())
+        {
+        }
+
+        public static void Invoke(IDatabase database) => EnsureLongCommandTimeout(database);
+
+        protected override Task MigrateAsync() => Task.CompletedTask;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/CommandTimeoutResolverTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/CommandTimeoutResolverTests.cs
@@ -6,9 +6,10 @@ using Umbraco.Cms.Infrastructure.Persistence;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence;
 
-[TestFixture]
 // The connect timeout fallback is obsolete but still supported, so it still needs covering.
 #pragma warning disable CS0618 // Type or member is obsolete
+
+[TestFixture]
 public class CommandTimeoutResolverTests
 {
     private static DbProviderFactory SqlServer => SqlClientFactory.Instance;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/CommandTimeoutResolverTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/CommandTimeoutResolverTests.cs
@@ -1,0 +1,110 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Persistence;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence;
+
+[TestFixture]
+// The connect timeout fallback is obsolete but still supported, so it still needs covering.
+#pragma warning disable CS0618 // Type or member is obsolete
+public class CommandTimeoutResolverTests
+{
+    private static DbProviderFactory SqlServer => SqlClientFactory.Instance;
+
+    private static DbProviderFactory Sqlite => SqliteFactory.Instance;
+
+    [Test]
+    [TestCase("Server=.;Database=x", ExpectedResult = 30)]
+    [TestCase("Server=.;Database=x;Command Timeout=300", ExpectedResult = 300)]
+    [TestCase("Server=.;Database=x;Command Timeout=0", ExpectedResult = 0)]
+    [TestCase("Server=.;Database=x;Connect Timeout=600", ExpectedResult = 30)]
+    [TestCase("Server=.;Database=x;Timeout=600", ExpectedResult = 30)]
+    public int? Can_Get_Configured_Command_Timeout_For_Sql_Server(string connectionString)
+        => CommandTimeoutResolver.GetConfiguredCommandTimeout(SqlServer, connectionString);
+
+    [Test]
+    [TestCase("Data Source=x.db", ExpectedResult = 30)]
+    [TestCase("Data Source=x.db;Default Timeout=600", ExpectedResult = 600)]
+    [TestCase("Data Source=x.db;Command Timeout=600", ExpectedResult = 600)]
+    [TestCase("Data Source=x.db;Connection Timeout=30", ExpectedResult = null)]
+    public int? Can_Get_Configured_Command_Timeout_For_Sqlite(string connectionString)
+        => CommandTimeoutResolver.GetConfiguredCommandTimeout(Sqlite, connectionString);
+
+    [Test]
+    public void Cannot_Get_Configured_Command_Timeout_Without_Provider()
+        => Assert.IsNull(CommandTimeoutResolver.GetConfiguredCommandTimeout(null, "Server=.;Database=x"));
+
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Cannot_Get_Configured_Command_Timeout_Without_Connection_String(string connectionString)
+        => Assert.IsNull(CommandTimeoutResolver.GetConfiguredCommandTimeout(SqlServer, connectionString));
+
+    [Test]
+    [TestCase("Server=.;Database=x;Connect Timeout=60", "connect timeout", 60)]
+    [TestCase("Server=.;Database=x;Connection Timeout=60", "connection timeout", 60)]
+    public void Can_Apply_Connect_Timeout_As_Command_Timeout(
+        string connectionString,
+        string expectedKeyword,
+        int expectedTimeout)
+    {
+        var result = CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(
+            SqlServer, connectionString, out var timeout, out var keyword);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(result);
+            Assert.AreEqual(expectedTimeout, timeout);
+            Assert.AreEqual(expectedKeyword, keyword);
+        });
+    }
+
+    [Test]
+    public void Can_Apply_Connect_Timeout_That_Shortens_Command_Timeout()
+    {
+        // The fallback is preserved exactly as it behaved before, in both directions: a connect timeout
+        // shorter than the provider default has always shortened commands too.
+        var result = CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(
+            SqlServer, "Server=.;Database=x;Connect Timeout=15", out var timeout, out _);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(result);
+            Assert.AreEqual(15, timeout);
+        });
+    }
+
+    [Test]
+    [TestCase("Server=.;Database=x", TestName = "no timeout keyword")]
+    [TestCase("Server=.;Database=x;Timeout=45", TestName = "the Timeout synonym is deliberately not honoured")]
+    [TestCase("Server=.;Database=x;Connect Timeout=abc", TestName = "unparseable connect timeout")]
+    [TestCase("Server=.;Database=x;Connect Timeout=0", TestName = "connect timeout of no limit")]
+    [TestCase("Server=.;Database=x;Connect Timeout=60;Command Timeout=300", TestName = "command timeout wins")]
+    [TestCase("Server=.;Database=x;Connect Timeout=60;Command Timeout=0", TestName = "command timeout of no limit wins")]
+    public void Cannot_Apply_Connect_Timeout_As_Command_Timeout(string connectionString)
+    {
+        var result = CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(
+            SqlServer, connectionString, out var timeout, out var keyword);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(result);
+            Assert.AreEqual(0, timeout);
+            Assert.IsNull(keyword);
+        });
+    }
+
+    [Test]
+    public void Cannot_Apply_Connect_Timeout_To_Sqlite_Connection_String()
+    {
+        // SQLite has no connect timeout, so the keyword can never legitimately appear.
+        var result = CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(
+            Sqlite, "Data Source=x.db;Default Timeout=600", out _, out _);
+
+        Assert.IsFalse(result);
+    }
+}
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/ConnectionStringTimeoutExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/ConnectionStringTimeoutExtensionsTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Persistence;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence;
+
+[TestFixture]
+public class ConnectionStringTimeoutExtensionsTests
+{
+    [Test]
+    [TestCase(0, ExpectedResult = 0)]
+    [TestCase(1000, ExpectedResult = 1)]
+    [TestCase(30000, ExpectedResult = 30)]
+    [TestCase(300000, ExpectedResult = 300)]
+    public int Can_Convert_Whole_Number_Of_Seconds_Unchanged(int milliseconds)
+        => TimeSpan.FromMilliseconds(milliseconds).ToConnectionStringTimeoutSeconds();
+
+    [Test]
+    [TestCase(1, ExpectedResult = 1)]
+    [TestCase(500, ExpectedResult = 1)]
+    [TestCase(999, ExpectedResult = 1)]
+    [TestCase(1001, ExpectedResult = 2)]
+    [TestCase(1500, ExpectedResult = 2)]
+    public int Can_Round_Partial_Second_Up(int milliseconds)
+        => TimeSpan.FromMilliseconds(milliseconds).ToConnectionStringTimeoutSeconds();
+
+    [Test]
+    public void Cannot_Convert_Configured_Timeout_To_No_Limit()
+    {
+        // Zero seconds means no limit to supported providers, so the smallest configurable timeout must not
+        // truncate into it.
+        Assert.AreNotEqual(0, TimeSpan.FromTicks(1).ToConnectionStringTimeoutSeconds());
+    }
+
+    [Test]
+    public void Can_Preserve_Explicitly_Configured_No_Limit()
+    {
+        Assert.AreEqual(0, TimeSpan.Zero.ToConnectionStringTimeoutSeconds());
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/UmbracoDatabaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/UmbracoDatabaseTests.cs
@@ -1,0 +1,187 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NPoco;
+using NPoco.DatabaseTypes;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.Migrations.Install;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence;
+
+[TestFixture]
+public class UmbracoDatabaseTests
+{
+    [Test]
+    public void Can_Leave_Command_Timeout_To_Provider_When_Connection_String_Configures_One()
+    {
+        // The connect timeout has to be present for this to have teeth: with "Command Timeout" alone the
+        // pre-fix code found no keyword it recognised and left CommandTimeout at zero anyway.
+        using UmbracoDatabase database = CreateSqlServerDatabase("Server=.;Database=x;Connect Timeout=15;Command Timeout=300");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(0, database.CommandTimeout);
+            Assert.AreEqual(300, database.EffectiveCommandTimeout);
+        });
+    }
+
+    [Test]
+    public void Can_Preserve_Command_Timeout_Of_No_Limit_From_Connection_String()
+    {
+        using UmbracoDatabase database = CreateSqlServerDatabase("Server=.;Database=x;Command Timeout=0;Connect Timeout=60");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(0, database.CommandTimeout);
+            Assert.AreEqual(0, database.EffectiveCommandTimeout);
+        });
+    }
+
+    [Test]
+    public void Can_Apply_Connect_Timeout_As_Command_Timeout_When_None_Configured()
+    {
+        using UmbracoDatabase database = CreateSqlServerDatabase("Server=.;Database=x;Connect Timeout=60");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(60, database.CommandTimeout);
+            Assert.AreEqual(60, database.EffectiveCommandTimeout);
+        });
+    }
+
+    [Test]
+    public void Can_Fall_Back_To_Provider_Default_When_No_Timeout_Configured()
+    {
+        using UmbracoDatabase database = CreateSqlServerDatabase("Server=.;Database=x");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(0, database.CommandTimeout);
+            Assert.AreEqual(30, database.EffectiveCommandTimeout);
+        });
+    }
+
+    [Test]
+    public void Can_Report_Command_Timeout_From_Sqlite_Connection_String()
+    {
+        using UmbracoDatabase database = CreateSqliteDatabase("Data Source=x.db;Default Timeout=600");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(0, database.CommandTimeout);
+            Assert.AreEqual(600, database.EffectiveCommandTimeout);
+        });
+    }
+
+    [Test]
+    public void Can_Report_Command_Timeout_Set_In_Code_In_Preference_To_Connection_String()
+    {
+        using UmbracoDatabase database = CreateSqliteDatabase("Data Source=x.db;Default Timeout=600");
+        database.CommandTimeout = 45;
+
+        Assert.AreEqual(45, database.EffectiveCommandTimeout);
+    }
+
+    [Test]
+    public void Can_Execute_Commands_With_Timeout_From_Connection_String()
+    {
+        // Exercises the whole mechanism against a real database, pinning the NPoco behaviour the fix relies
+        // on: a zero Database.CommandTimeout leaves the provider's value on the command.
+        using var database = new TimeoutCapturingDatabase(
+            "Data Source=:memory:;Default Timeout=600",
+            CreateSqlContext(new SQLiteDatabaseType()),
+            SqliteFactory.Instance,
+            NullLogger<UmbracoDatabase>.Instance,
+            null,
+            CreateSchemaCreatorFactory());
+
+        database.ExecuteScalar<long>("SELECT 1");
+
+        Assert.AreEqual(600, database.AppliedCommandTimeout);
+    }
+
+    [Test]
+    public void Can_Execute_Commands_With_Timeout_Set_In_Code_In_Preference_To_Connection_String()
+    {
+        using var database = new TimeoutCapturingDatabase(
+            "Data Source=:memory:;Default Timeout=600",
+            CreateSqlContext(new SQLiteDatabaseType()),
+            SqliteFactory.Instance,
+            NullLogger<UmbracoDatabase>.Instance,
+            null,
+            CreateSchemaCreatorFactory());
+        database.CommandTimeout = 45;
+
+        database.ExecuteScalar<long>("SELECT 1");
+
+        Assert.AreEqual(45, database.AppliedCommandTimeout);
+    }
+
+    private static UmbracoDatabase CreateSqlServerDatabase(string connectionString)
+        => CreateDatabase(connectionString, SqlClientFactory.Instance, new UmbracoSqlServerDatabaseType());
+
+    private static UmbracoDatabase CreateSqliteDatabase(string connectionString)
+        => CreateDatabase(connectionString, SqliteFactory.Instance, new SQLiteDatabaseType());
+
+    private static UmbracoDatabase CreateDatabase(string connectionString, DbProviderFactory provider, DatabaseType databaseType)
+        => new(
+            connectionString,
+            CreateSqlContext(databaseType),
+            provider,
+            NullLogger<UmbracoDatabase>.Instance,
+            null,
+            CreateSchemaCreatorFactory());
+
+    private static ISqlContext CreateSqlContext(DatabaseType databaseType)
+    {
+        var sqlSyntax = new Mock<ISqlSyntaxProvider>();
+        sqlSyntax.SetupGet(x => x.DefaultIsolationLevel).Returns(IsolationLevel.ReadCommitted);
+
+        var sqlContext = new Mock<ISqlContext>();
+        sqlContext.SetupGet(x => x.DatabaseType).Returns(databaseType);
+        sqlContext.SetupGet(x => x.SqlSyntax).Returns(sqlSyntax.Object);
+
+        return sqlContext.Object;
+    }
+
+    private static DatabaseSchemaCreatorFactory CreateSchemaCreatorFactory()
+        => new(
+            NullLogger<DatabaseSchemaCreator>.Instance,
+            NullLoggerFactory.Instance,
+            Mock.Of<IUmbracoVersion>(),
+            Mock.Of<IEventAggregator>(),
+            Mock.Of<IOptionsMonitor<InstallDefaultDataSettings>>());
+
+    private sealed class TimeoutCapturingDatabase : UmbracoDatabase
+    {
+        public TimeoutCapturingDatabase(
+            string connectionString,
+            ISqlContext sqlContext,
+            DbProviderFactory provider,
+            ILogger<UmbracoDatabase> logger,
+            IBulkSqlInsertProvider? bulkSqlInsertProvider,
+            DatabaseSchemaCreatorFactory databaseSchemaCreatorFactory)
+            : base(connectionString, sqlContext, provider, logger, bulkSqlInsertProvider, databaseSchemaCreatorFactory)
+        {
+        }
+
+        public int? AppliedCommandTimeout { get; private set; }
+
+        protected override void OnExecutingCommand(DbCommand cmd)
+        {
+            base.OnExecutingCommand(cmd);
+            AppliedCommandTimeout = cmd.CommandTimeout;
+        }
+    }
+}


### PR DESCRIPTION
## Description

`Command Timeout` in a database connection currently string has no effect. Every command runs with the value of `Connect Timeout` instead, so [the documented ADO.NET lever](https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnectionstringbuilder.commandtimeout?view=sqlclient-dotnet-core-7.0) for lengthening a slow statement is silently discarded, and the only way to raise a command timeout is to raise the *connect* timeout — a different setting, with its own side effects (a failed connection attempt then waits that long, multiplied by `ConnectRetryCount`).

The fix is to stop overriding the command timeout at all: because NPoco treats a zero `Database.CommandTimeout` as "don't override", leaving it at zero is what allows the timeout the ADO.NET provider derived from the connection string to stand — so `Command Timeout` is honoured, and an explicit `Command Timeout=0` (no limit) is preserved rather than being replaced by the connect timeout.

Deriving the command timeout from the connect timeout is kept as a deprecated fallback that applies only where no command timeout is configured, so nothing that works today changes in 17, with a one-time boot warning pointing affected sites at the supported alternatives before it is removed in 19.

On top of that, a symmetric pair of first-class settings — `DatabaseCommandTimeout` and `DatabaseConnectTimeout` — makes the two concepts independently configurable for administrators who cannot, or would rather not, edit the connection string.

Fixes #23705

### Plan of resolution — backward compatible in 17

The connect-timeout convention is retained as a **deprecated fallback**, applied **only when no command timeout is configured**, so no existing connection string changes behaviour.

**1. `Command Timeout` is honoured.** A new `internal static CommandTimeoutResolver` determines whether the connection string configures a command timeout by **asking the provider** — building a command from an unopened connection with the real connection string, and again with none, and comparing. Synonyms, canonical spellings and per-provider defaults are all resolved by the provider.

Resolution order, highest first:

1. `OneTimeCommandTimeout` — NPoco's, untouched
2. `CommandTimeout` set in code (e.g. `EnsureLongCommandTimeout`, package code)
3. `Umbraco:CMS:Global:DatabaseCommandTimeout` *(new)*
4. the connection string's command timeout — applied **by the provider**, because we now leave `CommandTimeout` at `0`
5. the connect timeout, applied as the command timeout — **deprecated**, and only when (4) is absent
6. the provider default

**2. First-class settings for both timeouts.** Two new `GlobalSettings` properties, `TimeSpan?` with no default so nothing changes on upgrade:

| Setting | Purpose |
|---|---|
| `Umbraco:CMS:Global:DatabaseCommandTimeout` | maximum time a single database command may run |
| `Umbraco:CMS:Global:DatabaseConnectTimeout` | maximum time to wait when opening a connection |

Both are applied by rewriting the connection string in a provider-side `IPostConfigureOptions<ConnectionStrings>`.

**3. A deprecation warning, once per application.** added to warn where no settings are in place and the connection string contains only a `Connect Timeout` value, which will use the historically behaviour compatible but unclear approach of using this also for the command timeout. 

### What needs to happen in 19, once this is merged up

The deprecated fallback should be **removed** in 19 as a breaking change, in a separate PR based on `v19/dev`. Search for  `TODO (V19)` and `Obsolete` in this PR to find everything involved.

**Remove:**
- `CommandTimeoutResolver.TryGetDeprecatedConnectTimeout` (already carries `[Obsolete(... Scheduled for removal in Umbraco 19.)]`) and `_deprecatedConnectTimeoutKeywords`
- `UmbracoDatabase.InitCommandTimeout`, and its call from `Init()` — nothing replaces it; `CommandTimeout` stays at `0` unless code sets it, and the provider owns the value
- `UmbracoDatabaseFactory.WarnOnDeprecatedCommandTimeoutFromConnectTimeout`, and its call site
- the `#pragma warning disable CS0618` suppressions at those call sites
- the `TryGetDeprecatedConnectTimeout` tests in `CommandTimeoutResolverTests`, and `UmbracoDatabaseTests.Can_Apply_Connect_Timeout_As_Command_Timeout_When_None_Configured`

**Keep:** `CommandTimeoutResolver.GetConfiguredCommandTimeout`, `UmbracoDatabase.EffectiveCommandTimeout` and the reworked `EnsureLongCommandTimeout`. None of them exist to serve the fallback.

**Note for release notes:** this adds one piece of public API — `ConnectionStringTimeoutExtensions.ToConnectionStringTimeoutSeconds(this TimeSpan)` in `Umbraco.Cms.Infrastructure.Persistence`. It is public because both provider packages need the same conversion and cannot see Infrastructure's internals, so package developers referencing `Umbraco.Infrastructure` gain an extension method on `TimeSpan`. If reviewers would rather not grow the public surface for a one-line conversion, the alternative is `internal` plus `InternalsVisibleTo` for the two persistence packages, as Infrastructure already does for `Umbraco.PublishedCache.HybridCache`.

**Write up as a breaking change:**
- `Connect Timeout` / `Connection Timeout` / `Timeout` no longer influence the command timeout. A site relying on that gets the provider default (30s on both providers) unless it sets `Command Timeout` in the connection string or `Umbraco:CMS:Global:DatabaseCommandTimeout`.
- **Consider Umbraco Cloud explicitly** if its connection-string templates emit `Connect Timeout` — those sites need `Command Timeout` or the setting in place *before* they reach 19.
- **Consider the distributed-locking interaction.** `SqlServerDistributedLockingMechanism` uses server-side `SET LOCK_TIMEOUT`; the ADO command timeout must be *longer*, or the command aborts first and the caller sees a raw `SqlException` instead of `DistributedReadLockTimeoutException`. `GlobalSettings.DistributedLockingReadLockDefaultTimeout` defaults to **60s** while both providers default the command timeout to **30s**. A site on `Connect Timeout=60` alone currently gets a 60s command timeout and would drop to 30s — *below* its read-lock timeout. This mismatch already exists today for any connection string without a connect-timeout keyword, so it is a pre-existing gap rather than something 19 introduces, but 19 widens who hits it. Worth deciding separately whether the lock mechanism should bound its own command (as the SQLite mechanism already does) rather than relying on whatever `Database.CommandTimeout` happens to be.

## Testing

### Automated

Unit and integration tests are added, verified to fail before the fix.

### Manual

A temporary diagnostics block was added to a template to render, on each boot: both settings, the **effective** (post-configure) connection string, the literal timeout keywords in it, the timeout the provider puts on a real `DbCommand`, and NPoco's `db.CommandTimeout`.

```razor
@using System.Data.Common
@using Microsoft.Extensions.Options
@using Umbraco.Cms.Core.Configuration.Models
@using Umbraco.Cms.Infrastructure.Persistence
@inject IOptions<GlobalSettings> DiagGlobalSettings
@inject IOptionsMonitor<ConnectionStrings> DiagConnectionStrings
@inject IUmbracoDatabaseFactory DiagDatabaseFactory
@{
    GlobalSettings diagSettings = DiagGlobalSettings.Value;
    ConnectionStrings diagConn = DiagConnectionStrings.Get(global::Umbraco.Cms.Core.Constants.System.UmbracoConnectionName);
    var diagConnectionString = diagConn.ConnectionString ?? string.Empty;
    var diagProviderName = diagConn.ProviderName ?? string.Empty;

    var diagLiteralCommand = "(absent)";
    var diagLiteralConnect = "(absent)";
    var diagParser = new DbConnectionStringBuilder { ConnectionString = diagConnectionString };
    if (diagParser.TryGetValue("command timeout", out var dc)) { diagLiteralCommand = dc?.ToString(); }
    if (diagParser.TryGetValue("default timeout", out var dd)) { diagLiteralCommand = dd?.ToString(); }
    if (diagParser.TryGetValue("connect timeout", out var dk)) { diagLiteralConnect = dk?.ToString(); }
    if (diagParser.TryGetValue("connection timeout", out var dk2)) { diagLiteralConnect = dk2?.ToString(); }

    // What the provider will actually put on a command built from this connection string.
    var diagProviderCommandTimeout = "(unknown)";
    DbProviderFactory diagFactory = DbProviderFactories.GetFactory(diagProviderName);
    using (DbConnection diagProbe = diagFactory.CreateConnection())
    {
        diagProbe.ConnectionString = diagConnectionString;
        using (DbCommand diagCmd = diagProbe.CreateCommand())
        {
            diagProviderCommandTimeout = diagCmd.CommandTimeout.ToString();
        }
    }

    // Umbraco's own override.
    var diagUmbracoOverride = "(unknown)";
    using (var diagDb = DiagDatabaseFactory.CreateDatabase())
    {
        diagUmbracoOverride = diagDb.CommandTimeout.ToString();
    }

    var diagEffective = diagUmbracoOverride != "0" ? diagUmbracoOverride : diagProviderCommandTimeout;
}
<pre>
Setting DatabaseCommandTimeout     : @(diagSettings.DatabaseCommandTimeout?.ToString() ?? "(not set)")
Setting DatabaseConnectTimeout     : @(diagSettings.DatabaseConnectTimeout?.ToString() ?? "(not set)")
Provider name                      : @diagProviderName
Effective connection string        : @diagConnectionString
  command timeout keyword          : @diagLiteralCommand
  connect timeout keyword          : @diagLiteralConnect
Provider-derived cmd.CommandTimeout: @diagProviderCommandTimeout
Umbraco override db.CommandTimeout : @diagUmbracoOverride
==> EFFECTIVE COMMAND TIMEOUT      : @diagEffective
</pre>
```

Each run rewrote `appsettings.Local.json`, booted against SQL Server, fetched the page, and counted deprecation warnings in the log.

| # | Connection string | Settings | Provider gives | Umbraco override | **Effective** | Depr. warning |
|---|---|---|---|---|---|---|
| A | `Connect Timeout=60` | — | 30 | **60** | **60** | 1 |
| B | `Connect Timeout=60;Command Timeout=300` | — | **300** | 0 | **300** | 0 |
| C | *(neither keyword)* | — | 30 | 0 | **30** | 0 |
| D | `Connect Timeout=60` | Command `00:05:00` | **300** | 0 | **300** | 0 |
| E | `Connect Timeout=60;Command Timeout=300` | Command `00:02:00` | **120** | 0 | **120** | 0 |
| F | `Connect Timeout=60` | Connect `00:00:45` | 30 | **45** | **45** | 1 |

Confirming the behaviour:

- **B is the fix.** `Command Timeout=300` is honoured, and `db.CommandTimeout` is `0` — Umbraco no longer overrides. On the old code this was 60.
- **A** confirms the legacy fallback still works, with the deprecation warning firing — backward compatibility in 17.
- **C** confirms an unconfigured connection string is untouched and gets the provider default.
- **D** confirms the setting reaches the provider *and* silences the deprecation warning even with `Connect Timeout` still present, so configuring the setting is a complete answer to the deprecation.
- **E** confirms the setting outranks the connection string (300 → 120).
- **F** confirms the two settings are genuinely independent: the connect timeout became 45 while the command timeout stayed on the fallback.

D, E and F also show the expected round-trip normalisation of the rewritten string (`Server=` → `Data Source=`, `Database=` → `Initial Catalog=`, `TrustServerCertificate` → `Trust Server Certificate`). Functionally equivalent, and it only happens when a setting is set.

Two further runs checked the parse guard, with a control:

| | Boot-failed | Unhandled exceptions | `Keyword not supported` | Guard warning |
|---|---|---|---|---|
| bad connection string **+ setting** | 2 | 1 | 4 | **1** |
| bad connection string, **no setting** (control) | 2 | 1 | 3 | 0 |

Identical failure mode — the site fails to boot either way, because the string is genuinely invalid and the provider rejects it at connect time regardless. The extra occurrence is inside the guard's own *caught* and logged exception. So applying a setting does not convert a connection failure into an obscure options-configuration crash; it just adds a warning naming the setting.
