### PR TITLE
Redirect URL Management: Keep the search term applied when paging, and show the create date (closes #23687)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementController.cs
@@ -35,7 +35,7 @@ public class GetAllRedirectUrlManagementController : RedirectUrlManagementContro
     /// Retrieves a paginated list of redirect URLs, optionally filtered by a search string.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <param name="filter">An optional string to filter redirect URLs by matching criteria; if null or empty, all redirect URLs are returned.</param>
+    /// <param name="filter">An optional string to filter redirect URLs by matching criteria; if null, empty or whitespace, all redirect URLs are returned.</param>
     /// <param name="skip">The number of items to skip before starting to collect the result set (used for pagination).</param>
     /// <param name="take">The maximum number of items to return in the result set (used for pagination).</param>
     /// <returns>

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementController.cs
@@ -35,7 +35,7 @@ public class GetAllRedirectUrlManagementController : RedirectUrlManagementContro
     /// Retrieves a paginated list of redirect URLs, optionally filtered by a search string.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <param name="filter">An optional string to filter redirect URLs by matching criteria; if null, all redirect URLs are returned.</param>
+    /// <param name="filter">An optional string to filter redirect URLs by matching criteria; if null or empty, all redirect URLs are returned.</param>
     /// <param name="skip">The number of items to skip before starting to collect the result set (used for pagination).</param>
     /// <param name="take">The maximum number of items to return in the result set (used for pagination).</param>
     /// <returns>
@@ -54,7 +54,7 @@ public class GetAllRedirectUrlManagementController : RedirectUrlManagementContro
         int take = 100)
     {
         long total;
-        IEnumerable<IRedirectUrl> redirects = filter is null
+        IEnumerable<IRedirectUrl> redirects = string.IsNullOrWhiteSpace(filter)
             ? _redirectUrlService.GetAllRedirectUrls(skip, take, out total)
             : _redirectUrlService.SearchRedirectUrls(filter, skip, take, out total);
 

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -58,6 +58,27 @@ namespace Umbraco.Cms.Core.Routing
         /// </summary>
         public UrlMode Mode { get; set; }
 
+        /// <summary>
+        /// Resolves <see cref="UrlMode.Default" /> into the mode a provider should actually apply.
+        /// </summary>
+        /// <param name="mode">The requested mode.</param>
+        /// <returns>A concrete mode; never <see cref="UrlMode.Default" />.</returns>
+        /// <remarks>
+        /// Providers are contracted to receive a concrete mode. <see cref="UrlMode.Default" /> defers to
+        /// <see cref="Mode" />, which configuration and callers can themselves set to
+        /// <see cref="UrlMode.Default" /> - leaving nothing to defer to, so fall back to the mode Umbraco
+        /// ships with.
+        /// </remarks>
+        private UrlMode ResolveMode(UrlMode mode)
+        {
+            if (mode != UrlMode.Default)
+            {
+                return mode;
+            }
+
+            return Mode == UrlMode.Default ? UrlMode.Auto : Mode;
+        }
+
         #endregion
 
         #region GetUrl
@@ -121,10 +142,7 @@ namespace Umbraco.Cms.Core.Routing
                 return Constants.Routing.Unroutable;
             }
 
-            if (mode == UrlMode.Default)
-            {
-                mode = Mode;
-            }
+            mode = ResolveMode(mode);
 
             // this the ONLY place where we deal with default culture - IUrlProvider always receive a culture
             // be nice with tests, assume things can be null, ultimately fall back to invariant
@@ -154,7 +172,7 @@ namespace Umbraco.Cms.Core.Routing
             NewDefaultUrlProvider? provider = _urlProviders.OfType<NewDefaultUrlProvider>().FirstOrDefault();
             var url = provider == null
                 ? route // what else?
-                : provider.GetUrlFromRoute(route, id, umbracoContext.CleanedUmbracoUrl, Mode, culture)?.Url?.ToString();
+                : provider.GetUrlFromRoute(route, id, umbracoContext.CleanedUmbracoUrl, ResolveMode(Mode), culture)?.Url?.ToString();
             return url ?? Constants.Routing.Unroutable;
         }
 
@@ -236,10 +254,7 @@ namespace Umbraco.Cms.Core.Routing
                 return string.Empty;
             }
 
-            if (mode == UrlMode.Default)
-            {
-                mode = Mode;
-            }
+            mode = ResolveMode(mode);
 
             // this the ONLY place where we deal with default culture - IMediaUrlProvider always receive a culture
             // be nice with tests, assume things can be null, ultimately fall back to invariant

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -71,12 +71,12 @@ namespace Umbraco.Cms.Core.Routing
         /// </remarks>
         private UrlMode ResolveMode(UrlMode mode)
         {
-            if (mode != UrlMode.Default)
+            if (mode is not UrlMode.Default)
             {
                 return mode;
             }
 
-            return Mode == UrlMode.Default ? UrlMode.Auto : Mode;
+            return Mode is UrlMode.Default ? UrlMode.Auto : Mode;
         }
 
         #endregion

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -217,7 +217,7 @@ internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedire
     /// <summary>
     /// Searches for redirect URLs whose URL contains the specified search term, with results paged according to the given page index and size.
     /// </summary>
-    /// <param name="searchTerm">The term to search for within redirect URLs. The search is case-insensitive and matches any part of the URL.</param>
+    /// <param name="searchTerm">The term to search for within redirect URLs. The search matches any part of the URL, with case sensitivity determined by the database collation.</param>
     /// <param name="pageIndex">The zero-based index of the page of results to retrieve.</param>
     /// <param name="pageSize">The number of redirect URLs to include in a single page of results.</param>
     /// <param name="total">When this method returns, contains the total number of redirect URLs matching the search term.</param>
@@ -226,7 +226,7 @@ internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedire
     {
         var wcPlaceholder = SqlSyntax.GetWildcardPlaceholder();
         Sql<ISqlContext> sql = GetBaseQuery(false)
-            .WhereLike<RedirectUrlDto>(x => x.Url, wcPlaceholder + searchTerm.Trim().ToLowerInvariant() + wcPlaceholder)
+            .WhereLike<RedirectUrlDto>(x => x.Url, wcPlaceholder + searchTerm.Trim() + wcPlaceholder)
             .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
         Page<RedirectUrlDto> result = Database.Page<RedirectUrlDto>(pageIndex + 1, pageSize, sql);
         total = Convert.ToInt32(result.TotalItems);

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/redirect-management.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/redirect-management.handlers.ts
@@ -104,7 +104,7 @@ const RedirectUrlData: RedirectUrlResponseModel[] = [
 	},
 	{
 		id: '2',
-		created: '2022-13-05T13:59:43.6827244',
+		created: '2022-11-05T13:59:43.6827244',
 		destinationUrl: 'umbraco.com',
 		originalUrl: 'umbraco.dk',
 		document: { id: '7191c911-6747-4824-849e-5208e2b31d9f' },
@@ -118,7 +118,7 @@ const RedirectUrlData: RedirectUrlResponseModel[] = [
 	},
 	{
 		id: '4',
-		created: '2022-13-05T13:59:43.6827244',
+		created: '2022-11-05T13:59:43.6827244',
 		destinationUrl: 'umbracoffee.com',
 		originalUrl: 'umbracoffee.dk',
 		document: { id: '7191c911-6747-4824-849e-5208e2b31d9fdsaa' },
@@ -132,7 +132,7 @@ const RedirectUrlData: RedirectUrlResponseModel[] = [
 	},
 	{
 		id: '6',
-		created: '2022-13-05T13:59:43.6827244',
+		created: '2022-11-05T13:59:43.6827244',
 		destinationUrl: 'dxp.com',
 		originalUrl: 'dxp.dk',
 		document: { id: '7191c911-6747-4824-849e-5208e2b31d9fsafsfd' },
@@ -146,7 +146,7 @@ const RedirectUrlData: RedirectUrlResponseModel[] = [
 	},
 	{
 		id: '8',
-		created: '2022-13-05T13:59:43.6827244',
+		created: '2022-11-05T13:59:43.6827244',
 		destinationUrl: 'unicorns.com',
 		originalUrl: 'unicorns.dk',
 		document: { id: '7191c911-6747-4824-849e-5208e2b31d9fweds' },
@@ -160,14 +160,14 @@ const RedirectUrlData: RedirectUrlResponseModel[] = [
 	},
 	{
 		id: '10',
-		created: '2022-13-05T13:59:43.6827244',
+		created: '2022-11-05T13:59:43.6827244',
 		destinationUrl: 'our.umbraco.com',
 		originalUrl: 'our.umbraco.dk',
 		document: { id: '7191c911-6747-4824-849e-52dsacx08e2b31d9dsafdsff' },
 	},
 	{
 		id: '11',
-		created: '2022-13-05T13:59:43.6827244',
+		created: '2022-11-05T13:59:43.6827244',
 		destinationUrl: 'your.umbraco.com',
 		originalUrl: 'your.umbraco.dk',
 		document: { id: '7191c911-6747-4824-849e-52dsacx08e2b31d9fsda' },

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -38,6 +38,9 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	@state()
 	private _filter?: string;
 
+	@state()
+	private _loading = true;
+
 	@property({ type: Number, attribute: 'items-per-page' })
 	itemsPerPage = 20;
 
@@ -68,6 +71,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 			take: this.itemsPerPage,
 			skip,
 		});
+		this._loading = false;
 		if (!data) return false;
 
 		this._total = data.total;
@@ -173,16 +177,21 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 					</uui-tag>
 				</uui-button>
 			</div>
-			${when(
-				this._redirectData?.length,
-				() => html`
-					<uui-box id="redirect-wrapper">
-						${when(!this._trackerEnabled, () => html`<div id="grey-out"></div>`)} ${this.#renderTable()}
-					</uui-box>
-				`,
-				() => (this._filter !== undefined ? this.#renderZeroResults() : this.#renderNoRedirects()),
-			)}
-			${this.#renderPagination()}
+			${this.#renderContent()} ${this.#renderPagination()}
+		`;
+	}
+
+	#renderContent() {
+		if (this._loading) return html`<uui-loader></uui-loader>`;
+
+		if (!this._redirectData?.length) {
+			return this._filter !== undefined ? this.#renderZeroResults() : this.#renderNoRedirects();
+		}
+
+		return html`
+			<uui-box id="redirect-wrapper">
+				${when(!this._trackerEnabled, () => html`<div id="grey-out"></div>`)} ${this.#renderTable()}
+			</uui-box>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -16,6 +16,9 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbDocumentRedirectUrlModel } from '@umbraco-cms/backoffice/document';
 import type { UUIButtonState, UUIPaginationElement, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 
+// The value the server sends for content it cannot build a URL for (Constants.Routing.Unroutable).
+const UMB_UNROUTABLE_URL = '#';
+
 @customElement('umb-dashboard-redirect-management')
 export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	#repository = new UmbDocumentRedirectManagementRepository(this);
@@ -58,15 +61,17 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		if (data) this._trackerEnabled = data.enabled;
 	}
 
-	async #getRedirectData(filter: string | undefined = undefined) {
+	async #getRedirectData() {
 		const skip = this.page * this.itemsPerPage - this.itemsPerPage;
-		const { data } = await this.#repository.requestRedirects({ filter, take: this.itemsPerPage, skip });
+		const { data } = await this.#repository.requestRedirects({
+			filter: this._filter,
+			take: this.itemsPerPage,
+			skip,
+		});
 		if (!data) return;
 
 		this._total = data.total;
 		this._redirectData = data.items;
-
-		if (filter !== undefined) this._buttonState = 'success';
 	}
 
 	#onPageChange(event: UUIPaginationEvent) {
@@ -97,20 +102,22 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		const { error } = await this.#repository.delete(unique);
 		if (error) return;
 
-		this._redirectData = this._redirectData?.filter((x) => x.unique !== unique);
+		await this.#getRedirectData();
 	}
 
 	#onKeypress(e: KeyboardEvent) {
 		if (e.key === 'Enter') this.#onSearch();
 	}
 
-	#onSearch() {
-		this._buttonState = 'waiting';
-		this._filter = this._search?.value ?? '';
+	async #onSearch() {
+		const filter = this._search?.value.trim();
+		this._filter = filter || undefined;
 		if (this._pagination) this._pagination.current = 1;
 		this.page = 1;
 
-		this.#getRedirectData(this._search.value);
+		this._buttonState = 'waiting';
+		await this.#getRedirectData();
+		this._buttonState = 'success';
 	}
 
 	async #showTrackerInfo() {
@@ -205,6 +212,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 					<uui-table-head-cell>${this.localize.term('redirectUrls_originalUrl')}</uui-table-head-cell>
 					<uui-table-head-cell style="width:10%;"></uui-table-head-cell>
 					<uui-table-head-cell>${this.localize.term('redirectUrls_redirectedTo')}</uui-table-head-cell>
+					<uui-table-head-cell style="width:15%;">${this.localize.term('content_createDate')}</uui-table-head-cell>
 					<uui-table-head-cell style="width:10%;">${this.localize.term('general_actions')}</uui-table-head-cell>
 				</uui-table-head>
 				${this.#renderTableData()}
@@ -221,18 +229,13 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 				(data) => html`
 					<uui-table-row>
 						<uui-table-cell>${data.culture || '*'}</uui-table-cell>
-						<uui-table-cell>
-							<a href=${data.originalUrl || '#'} target="_blank">
-								<span>${data.originalUrl}</span>
-							</a>
-						</uui-table-cell>
+						<uui-table-cell>${this.#renderUrl(data.originalUrl)}</uui-table-cell>
 						<uui-table-cell>
 							<uui-icon name="icon-arrow-right"></uui-icon>
 						</uui-table-cell>
+						<uui-table-cell>${this.#renderUrl(data.destinationUrl)}</uui-table-cell>
 						<uui-table-cell>
-							<a href=${data.destinationUrl || '#'} target="_blank">
-								<span>${data.destinationUrl}</span>
-							</a>
+							<umb-localize-date .date=${data.created}></umb-localize-date>
 						</uui-table-cell>
 						<uui-table-cell>
 							<uui-action-bar>
@@ -248,6 +251,22 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 					</uui-table-row>
 				`,
 			)}
+		`;
+	}
+
+	// The configured UrlProviderMode can make every URL absolute, which crowds out the part of the
+	// URL that differs. Only the host the backoffice itself is served from is redundant, so trim
+	// that one and leave any other host visible - on a multi-domain install it is what tells two
+	// otherwise identical paths apart. The link itself keeps the full URL.
+	#renderUrl(url: string) {
+		if (!url || url === UMB_UNROUTABLE_URL) return html`<span>${url}</span>`;
+
+		const display = url.startsWith(window.location.origin) ? url.slice(window.location.origin.length) || '/' : url;
+
+		return html`
+			<a href=${url} title=${url} target="_blank">
+				<span>${display}</span>
+			</a>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -61,17 +61,18 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		if (data) this._trackerEnabled = data.enabled;
 	}
 
-	async #getRedirectData() {
+	async #getRedirectData(): Promise<boolean> {
 		const skip = this.page * this.itemsPerPage - this.itemsPerPage;
 		const { data } = await this.#repository.requestRedirects({
 			filter: this._filter,
 			take: this.itemsPerPage,
 			skip,
 		});
-		if (!data) return;
+		if (!data) return false;
 
 		this._total = data.total;
 		this._redirectData = data.items;
+		return true;
 	}
 
 	#onPageChange(event: UUIPaginationEvent) {
@@ -116,8 +117,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		this.page = 1;
 
 		this._buttonState = 'waiting';
-		await this.#getRedirectData();
-		this._buttonState = 'success';
+		this._buttonState = (await this.#getRedirectData()) ? 'success' : 'failed';
 	}
 
 	async #showTrackerInfo() {
@@ -264,7 +264,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		const display = url.startsWith(window.location.origin) ? url.slice(window.location.origin.length) || '/' : url;
 
 		return html`
-			<a href=${url} title=${url} target="_blank">
+			<a href=${url} title=${url} target="_blank" rel="noopener noreferrer">
 				<span>${display}</span>
 			</a>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.test.ts
@@ -56,6 +56,20 @@ describe('UmbDashboardRedirectManagement', () => {
 	}
 });
 
+describe('UmbDashboardRedirectManagement initial load', () => {
+	it('does not report an absence of redirects before the first response lands', async () => {
+		const element: UmbDashboardRedirectManagementElement = await fixture(
+			html`<umb-dashboard-redirect-management></umb-dashboard-redirect-management>`,
+		);
+
+		// The request is still in flight: neither the table nor an empty state may be claimed yet.
+		expect(element.shadowRoot!.querySelector('uui-box')).to.not.exist;
+
+		await waitUntil(() => rowsOf(element).length > 0);
+		expect(element.shadowRoot!.querySelector('uui-box')).to.exist;
+	});
+});
+
 describe('UmbDashboardRedirectManagement filtering', () => {
 	let element: UmbDashboardRedirectManagementElement;
 
@@ -108,8 +122,14 @@ describe('UmbDashboardRedirectManagement row rendering', () => {
 		const element: UmbDashboardRedirectManagementElement = await fixture(
 			html`<umb-dashboard-redirect-management></umb-dashboard-redirect-management>`,
 		);
-		// Bypass the repository so the rendering of a single, known row can be asserted.
-		(element as unknown as { _redirectData: Array<UmbDocumentRedirectUrlModel> })._redirectData = data;
+		// Bypass the repository so the rendering of a single, known row can be asserted, standing in
+		// for the response that would otherwise settle the initial load.
+		const internals = element as unknown as {
+			_redirectData: Array<UmbDocumentRedirectUrlModel>;
+			_loading: boolean;
+		};
+		internals._redirectData = data;
+		internals._loading = false;
 		await element.updateComplete;
 		return element;
 	};

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.test.ts
@@ -122,6 +122,13 @@ describe('UmbDashboardRedirectManagement row rendering', () => {
 		expect((created as HTMLElement & { date: string }).date).to.equal('2026-02-17T09:30:00Z');
 	});
 
+	it('renders a redirect with no created date', async () => {
+		const element = await renderWith([redirect({ created: undefined })]);
+
+		const created = rowsOf(element)[0].querySelectorAll('uui-table-cell')[4];
+		expect(created.textContent?.trim()).to.equal('');
+	});
+
 	it('trims the current origin from a URL, keeping the full URL on the link', async () => {
 		const url = `${window.location.origin}/some/where`;
 		const element = await renderWith([redirect({ originalUrl: url })]);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.test.ts
@@ -1,7 +1,42 @@
 import { UmbDashboardRedirectManagementElement } from './dashboard-redirect-management.element.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 
+import type { UmbDocumentRedirectUrlModel } from '@umbraco-cms/backoffice/document';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
+
+const rowsOf = (element: UmbDashboardRedirectManagementElement) =>
+	Array.from(element.shadowRoot!.querySelectorAll('uui-table-row'));
+
+const originalUrlOf = (row: Element) => row.querySelectorAll('uui-table-cell')[1].textContent?.trim() ?? '';
+
+const urlsOf = (element: UmbDashboardRedirectManagementElement) => rowsOf(element).map(originalUrlOf);
+
+const paginationOf = (element: UmbDashboardRedirectManagementElement) =>
+	element.shadowRoot!.querySelector('uui-pagination')!;
+
+// Every action that reaches the server replaces the rows, so waiting for them to change is what
+// tells us the response has been applied - `updateComplete` alone only covers the render that
+// preceded the request.
+const waitForRowsToChange = async (element: UmbDashboardRedirectManagementElement, before: Array<string>) => {
+	await waitUntil(() => urlsOf(element).join() !== before.join(), 'the redirect rows were never replaced');
+	await element.updateComplete;
+};
+
+const search = async (element: UmbDashboardRedirectManagementElement, term: string) => {
+	const before = urlsOf(element);
+	const input = element.shadowRoot!.querySelector<HTMLInputElement>('#search')!;
+	input.value = term;
+	element.shadowRoot!.querySelector<HTMLElement>('#search-wrapper uui-button')!.click();
+	await waitForRowsToChange(element, before);
+};
+
+const goToPage = async (element: UmbDashboardRedirectManagementElement, page: number) => {
+	const before = urlsOf(element);
+	const pagination = paginationOf(element);
+	pagination.current = page;
+	pagination.dispatchEvent(new CustomEvent('change'));
+	await waitForRowsToChange(element, before);
+};
 
 describe('UmbDashboardRedirectManagement', () => {
 	let element: UmbDashboardRedirectManagementElement;
@@ -19,4 +54,96 @@ describe('UmbDashboardRedirectManagement', () => {
 			await expect(element).to.be.accessible(defaultA11yConfig);
 		});
 	}
+});
+
+describe('UmbDashboardRedirectManagement filtering', () => {
+	let element: UmbDashboardRedirectManagementElement;
+
+	beforeEach(async () => {
+		element = await fixture(
+			html`<umb-dashboard-redirect-management items-per-page="2"></umb-dashboard-redirect-management>`,
+		);
+		await waitUntil(() => rowsOf(element).length > 0);
+	});
+
+	// Page 3 is deliberate: the mocked redirects happen to put matching URLs on the second unfiltered
+	// page too, so a page that dropped the search term would still look filtered there.
+	it('keeps the search term applied when paging', async () => {
+		await search(element, 'umbraco');
+		await goToPage(element, 3);
+
+		expect(urlsOf(element)).to.eql(['your.umbraco.dk']);
+	});
+
+	it('counts only matching redirects when paging', async () => {
+		await search(element, 'umbraco');
+		const filteredTotal = paginationOf(element).total;
+
+		await goToPage(element, 3);
+
+		expect(paginationOf(element).total).to.equal(filteredTotal);
+	});
+
+	it('returns all redirects when the search term is cleared', async () => {
+		await search(element, 'umbraco');
+		const filteredTotal = paginationOf(element).total;
+
+		await search(element, '');
+
+		expect(paginationOf(element).total).to.be.greaterThan(filteredTotal);
+	});
+});
+
+describe('UmbDashboardRedirectManagement row rendering', () => {
+	const redirect = (partial: Partial<UmbDocumentRedirectUrlModel>): UmbDocumentRedirectUrlModel => ({
+		unique: '1',
+		originalUrl: '/old',
+		destinationUrl: '/new',
+		created: '2026-02-17T09:30:00Z',
+		culture: null,
+		...partial,
+	});
+
+	const renderWith = async (data: Array<UmbDocumentRedirectUrlModel>) => {
+		const element: UmbDashboardRedirectManagementElement = await fixture(
+			html`<umb-dashboard-redirect-management></umb-dashboard-redirect-management>`,
+		);
+		// Bypass the repository so the rendering of a single, known row can be asserted.
+		(element as unknown as { _redirectData: Array<UmbDocumentRedirectUrlModel> })._redirectData = data;
+		await element.updateComplete;
+		return element;
+	};
+
+	it('renders the created date of a redirect', async () => {
+		const element = await renderWith([redirect({ created: '2026-02-17T09:30:00Z' })]);
+
+		const created = rowsOf(element)[0].querySelector('umb-localize-date');
+		expect(created).to.exist;
+		expect((created as HTMLElement & { date: string }).date).to.equal('2026-02-17T09:30:00Z');
+	});
+
+	it('trims the current origin from a URL, keeping the full URL on the link', async () => {
+		const url = `${window.location.origin}/some/where`;
+		const element = await renderWith([redirect({ originalUrl: url })]);
+
+		const link = rowsOf(element)[0].querySelectorAll('uui-table-cell')[1].querySelector('a')!;
+		expect(link.textContent?.trim()).to.equal('/some/where');
+		expect(link.getAttribute('href')).to.equal(url);
+	});
+
+	it('keeps a URL on another host absolute', async () => {
+		const url = 'https://another.example/some/where';
+		const element = await renderWith([redirect({ originalUrl: url })]);
+
+		const link = rowsOf(element)[0].querySelectorAll('uui-table-cell')[1].querySelector('a')!;
+		expect(link.textContent?.trim()).to.equal(url);
+	});
+
+	it('does not link an unroutable redirect', async () => {
+		const element = await renderWith([redirect({ destinationUrl: '#' })]);
+
+		const cell = rowsOf(element)[0].querySelectorAll('uui-table-cell')[3];
+		expect(cell.querySelector('a')).to.not.exist;
+		expect(cell.textContent?.trim()).to.equal('#');
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
@@ -139,5 +139,6 @@ const mapRedirectUrl = (item: RedirectUrlResponseModel): UmbDocumentRedirectUrlM
 	unique: item.id,
 	originalUrl: item.originalUrl,
 	destinationUrl: item.destinationUrl,
+	created: item.created,
 	culture: item.culture ?? null,
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
@@ -5,7 +5,7 @@ export interface UmbDocumentRedirectUrlModel {
 	unique: string;
 	originalUrl: string;
 	destinationUrl: string;
-	created: string;
+	created?: string;
 	culture: string | null;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
@@ -5,6 +5,7 @@ export interface UmbDocumentRedirectUrlModel {
 	unique: string;
 	originalUrl: string;
 	destinationUrl: string;
+	created: string;
 	culture: string | null;
 }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementControllerTests.cs
@@ -36,10 +36,9 @@ public class GetAllRedirectUrlManagementControllerTests
     {
         await _controller.GetAll(CancellationToken.None, filter);
 
-        long total;
-        _redirectUrlService.Verify(x => x.GetAllRedirectUrls(0, 100, out total), Times.Once);
+        _redirectUrlService.Verify(x => x.GetAllRedirectUrls(0, 100, out It.Ref<long>.IsAny), Times.Once);
         _redirectUrlService.Verify(
-            x => x.SearchRedirectUrls(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), out total),
+            x => x.SearchRedirectUrls(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), out It.Ref<long>.IsAny),
             Times.Never);
     }
 
@@ -48,10 +47,9 @@ public class GetAllRedirectUrlManagementControllerTests
     {
         await _controller.GetAll(CancellationToken.None, "term");
 
-        long total;
-        _redirectUrlService.Verify(x => x.SearchRedirectUrls("term", 0, 100, out total), Times.Once);
+        _redirectUrlService.Verify(x => x.SearchRedirectUrls("term", 0, 100, out It.Ref<long>.IsAny), Times.Once);
         _redirectUrlService.Verify(
-            x => x.GetAllRedirectUrls(It.IsAny<int>(), It.IsAny<int>(), out total),
+            x => x.GetAllRedirectUrls(It.IsAny<int>(), It.IsAny<int>(), out It.Ref<long>.IsAny),
             Times.Never);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/GetAllRedirectUrlManagementControllerTests.cs
@@ -1,0 +1,57 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.RedirectUrlManagement;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
+
+[TestFixture]
+public class GetAllRedirectUrlManagementControllerTests
+{
+    private Mock<IRedirectUrlService> _redirectUrlService = null!;
+    private GetAllRedirectUrlManagementController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _redirectUrlService = new Mock<IRedirectUrlService>();
+
+        var presentationFactory = new Mock<IRedirectUrlPresentationFactory>();
+        presentationFactory
+            .Setup(x => x.CreateMany(It.IsAny<IEnumerable<IRedirectUrl>>()))
+            .Returns([]);
+
+        _controller = new GetAllRedirectUrlManagementController(
+            _redirectUrlService.Object,
+            presentationFactory.Object);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public async Task Get_All_Without_A_Filter_Term_Does_Not_Search(string? filter)
+    {
+        await _controller.GetAll(CancellationToken.None, filter);
+
+        long total;
+        _redirectUrlService.Verify(x => x.GetAllRedirectUrls(0, 100, out total), Times.Once);
+        _redirectUrlService.Verify(
+            x => x.SearchRedirectUrls(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), out total),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task Get_All_With_A_Filter_Term_Searches()
+    {
+        await _controller.GetAll(CancellationToken.None, "term");
+
+        long total;
+        _redirectUrlService.Verify(x => x.SearchRedirectUrls("term", 0, 100, out total), Times.Once);
+        _redirectUrlService.Verify(
+            x => x.GetAllRedirectUrls(It.IsAny<int>(), It.IsAny<int>(), out total),
+            Times.Never);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UrlProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UrlProviderTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services.Navigation;
+using Umbraco.Cms.Core.Web;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Routing;
+
+[TestFixture]
+public class UrlProviderTests
+{
+    private static readonly Uri _currentUri = new("http://localhost", UriKind.Absolute);
+
+    [TestCase(UrlMode.Auto, UrlMode.Auto)]
+    [TestCase(UrlMode.Relative, UrlMode.Relative)]
+    [TestCase(UrlMode.Absolute, UrlMode.Absolute)]
+
+    // UrlMode.Default defers to the configured mode, so configuring Default leaves nothing to defer
+    // to. Providers are contracted to receive a concrete mode, so it must resolve to the shipped one.
+    [TestCase(UrlMode.Default, UrlMode.Auto)]
+    public void Get_Url_Passes_A_Concrete_Mode_To_Providers(UrlMode configuredMode, UrlMode expectedMode)
+    {
+        Mock<IUrlProvider> urlProvider = CreateUrlProvider();
+        UrlProvider sut = CreateSut(configuredMode, urlProvider);
+
+        sut.GetUrl(CreateContent(), UrlMode.Default, "en-US", _currentUri);
+
+        urlProvider.Verify(
+            x => x.GetUrl(It.IsAny<IPublishedContent>(), expectedMode, It.IsAny<string>(), It.IsAny<Uri>()),
+            Times.Once);
+    }
+
+    [Test]
+    public void Get_Url_Prefers_An_Explicitly_Requested_Mode_Over_The_Configured_One()
+    {
+        Mock<IUrlProvider> urlProvider = CreateUrlProvider();
+        UrlProvider sut = CreateSut(UrlMode.Relative, urlProvider);
+
+        sut.GetUrl(CreateContent(), UrlMode.Absolute, "en-US", _currentUri);
+
+        urlProvider.Verify(
+            x => x.GetUrl(It.IsAny<IPublishedContent>(), UrlMode.Absolute, It.IsAny<string>(), It.IsAny<Uri>()),
+            Times.Once);
+    }
+
+    private static Mock<IUrlProvider> CreateUrlProvider()
+    {
+        var urlProvider = new Mock<IUrlProvider>();
+        urlProvider
+            .Setup(x => x.GetUrl(It.IsAny<IPublishedContent>(), It.IsAny<UrlMode>(), It.IsAny<string>(), It.IsAny<Uri>()))
+            .Returns(UrlInfo.AsUrl("/some/where", "test"));
+        return urlProvider;
+    }
+
+    private static IPublishedContent CreateContent()
+    {
+        var contentType = new Mock<IPublishedContentType>();
+        contentType.Setup(x => x.ItemType).Returns(PublishedItemType.Content);
+
+        var content = new Mock<IPublishedContent>();
+        content.Setup(x => x.ContentType).Returns(contentType.Object);
+        return content.Object;
+    }
+
+    private static UrlProvider CreateSut(UrlMode configuredMode, Mock<IUrlProvider> urlProvider)
+        => new(
+            Mock.Of<IUmbracoContextAccessor>(),
+            Options.Create(new WebRoutingSettings { UrlProviderMode = configuredMode }),
+            new UrlProviderCollection(() => [urlProvider.Object]),
+            new MediaUrlProviderCollection(() => []),
+            Mock.Of<IVariationContextAccessor>(),
+            Mock.Of<IDocumentNavigationQueryService>(),
+            Mock.Of<IPublishedContentStatusFilteringService>());
+}


### PR DESCRIPTION
## Description

Three things reported against the redirect URL management dashboard.

Fixes #23687

**Searching then paging showed non-matching redirects.** The dashboard passed the filter only from its search handler, so the pagination handler re-requested with no filter at all and page 2 onwards came back unfiltered — while the total still reflected the search. The filter now lives on the element and every request carries it.

Two supporting server-side changes fell out of the same path:

- An empty or whitespace-only `filter` now counts as "no filter" (`string.IsNullOrWhiteSpace` rather than `is null`), so a blank search term lists all redirects instead of running a `LIKE '%%'` search.
- `RedirectUrlRepository.SearchUrls` no longer lowercases the search term before the `LIKE`. Only one side of the comparison was being lowercased, so on a case-sensitive collation a term the user had typed in the URL's own casing would fail to match. Case sensitivity is now left to the database collation, as it is elsewhere.

**The create date was not shown.** It was already on the response model, just never mapped through or rendered. Added as a column using the existing `content_createDate` key — no new translations needed.

**Absolute URLs crowded out the useful part of the row.** With a `UrlProviderMode` that returns absolute URLs, every row was dominated by the same scheme and host. Displayed URLs now have the backoffice's own origin trimmed. Any *other* host stays visible — on a multi-domain install it is what tells two otherwise identical paths apart — and the link itself keeps the full URL, with the full value in a `title`.

This fix is applied client-side only deliberately, just in case there is some consumer of the management API endpoint that is relying on the absolute URLs.

## Testing

### Automated

Unit tests cover the filter guard and the client behaviour (filter retained across paging, create date, URL display); both were confirmed to fail before the fix.

### Manual

Make a temporary code edit (set `itemsPerPage` to a value lower than 20 in `src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts`) or add sufficient redirects to ensure paging is rendered, and ensure a search filter is carried between pages.

Verify that the create date is displayed in the table.

Verify that when absolute URLs are configured in `WebRoutingSettings` that relative URLs are displayed when the redirect URL matches the backoffice host.