### PR TITLE
Tiptap RTE: Restore the Text Direction toolbar buttons (closes #23806)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -252,6 +252,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		this._editor = new Editor({
 			element: element,
 			editable: !this.readonly,
+			enableCoreExtensions: { textDirection: false }, // Umbraco provides its own `TextDirection` extension. [LK]
 			editorProps: {
 				attributes: {
 					'aria-label': this.label || this.localize.term('rte_label'),

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction-ltr.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction-ltr.tiptap-toolbar-api.ts
@@ -2,8 +2,9 @@ import { UmbTiptapToolbarElementApiBase } from '../tiptap-toolbar-element-api-ba
 import type { Editor } from '../../externals.js';
 
 export default class UmbTiptapToolbarTextDirectionLtrExtensionApi extends UmbTiptapToolbarElementApiBase {
-	override isActive = (editor?: Editor) =>
-		editor?.isActive({ textDirection: 'ltr' }) === true || editor?.isActive({ textDirection: 'auto' }) === true;
+	override isActive(editor?: Editor) {
+		return editor?.isActive({ dir: 'ltr' }) === true || editor?.isActive({ dir: 'auto' }) === true;
+	}
 
 	override execute(editor?: Editor) {
 		if (!this.isActive(editor)) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction-rtl.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction-rtl.tiptap-toolbar-api.ts
@@ -2,7 +2,9 @@ import { UmbTiptapToolbarElementApiBase } from '../tiptap-toolbar-element-api-ba
 import type { Editor } from '../../externals.js';
 
 export default class UmbTiptapToolbarTextDirectionRtlExtensionApi extends UmbTiptapToolbarElementApiBase {
-	override isActive = (editor?: Editor) => editor?.isActive({ textDirection: 'rtl' }) === true;
+	override isActive(editor?: Editor) {
+		return editor?.isActive({ dir: 'rtl' }) === true;
+	}
 
 	override execute(editor?: Editor) {
 		if (!this.isActive(editor)) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-api.ts
@@ -1,8 +1,10 @@
 import { UmbTiptapExtensionApiBase } from '../tiptap-extension-api-base.js';
+import { TextDirection } from './text-direction.tiptap-extension.js';
 
-/** @deprecated No longer required, (since it comes default with Tiptap). This will be removed in Umbraco 19. [LK] */
 export default class UmbTiptapTextDirectionExtensionApi extends UmbTiptapExtensionApiBase {
-	// NOTE: `TextDirection` is now bundled with Tiptap since v3.11.0. [LK]
-	// https://github.com/ueberdosis/tiptap/pull/7207
-	getTiptapExtensions = () => [];
+	getTiptapExtensions = () => [
+		TextDirection.configure({
+			types: ['heading', 'paragraph', 'blockquote', 'orderedList', 'bulletList'],
+		}),
+	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.test.ts
@@ -34,6 +34,20 @@ describe('TextDirection', () => {
 		expect(editor.getHTML()).to.include('dir="rtl"');
 	});
 
+	it('persists an explicitly set direction (ltr)', () => {
+		editor.commands.setContent('<p>Hello</p>');
+		editor.commands.setTextDirection('ltr', { from: 0, to: editor.state.doc.content.size });
+
+		expect(editor.getHTML()).to.include('dir="ltr"');
+	});
+
+	it('persists an explicitly set direction (auto)', () => {
+		editor.commands.setContent('<p>Hello</p>');
+		editor.commands.setTextDirection('auto', { from: 0, to: editor.state.doc.content.size });
+
+		expect(editor.getHTML()).to.include('dir="auto"');
+	});
+
 	it('round-trips an authored dir attribute', () => {
 		editor.commands.setContent('<p dir="rtl">Hello</p>');
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.test.ts
@@ -1,0 +1,61 @@
+import { Document, Editor, Paragraph, Text } from '../../externals.js';
+import { TextDirection } from './text-direction.tiptap-extension.js';
+import { expect } from '@open-wc/testing';
+
+describe('TextDirection', () => {
+	let editor: Editor;
+	let host: HTMLDivElement;
+
+	beforeEach(() => {
+		host = document.createElement('div');
+		document.body.appendChild(host);
+		editor = new Editor({
+			element: host,
+			enableCoreExtensions: { textDirection: false },
+			extensions: [Document, Paragraph, Text, TextDirection],
+		});
+	});
+
+	afterEach(() => {
+		editor.destroy();
+		host.remove();
+	});
+
+	it('does not emit dir when no direction has been set', () => {
+		editor.commands.setContent('<p>Hello</p>');
+
+		expect(editor.getHTML()).to.not.include('dir=');
+	});
+
+	it('persists an explicitly set direction', () => {
+		editor.commands.setContent('<p>Hello</p>');
+		editor.commands.setTextDirection('rtl', { from: 0, to: editor.state.doc.content.size });
+
+		expect(editor.getHTML()).to.include('dir="rtl"');
+	});
+
+	it('round-trips an authored dir attribute', () => {
+		editor.commands.setContent('<p dir="rtl">Hello</p>');
+
+		expect(editor.getHTML()).to.include('dir="rtl"');
+	});
+
+	it('removes dir when the direction is unset', () => {
+		editor.commands.setContent('<p>Hello</p>');
+		const range = { from: 0, to: editor.state.doc.content.size };
+
+		editor.commands.setTextDirection('rtl', range);
+		expect(editor.getHTML()).to.include('dir="rtl"');
+
+		editor.commands.unsetTextDirection(range);
+
+		expect(editor.getHTML()).to.not.include('dir=');
+	});
+
+	it('reports the node as active for the direction that was set (regression)', () => {
+		editor.commands.setContent('<p>Hello</p>');
+		editor.commands.setTextDirection('rtl', { from: 0, to: editor.state.doc.content.size });
+
+		expect(editor.isActive({ dir: 'rtl' })).to.equal(true);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
@@ -1,14 +1,51 @@
-// NOTE: `TextDirection` is now bundled with Tiptap since v3.11.0. [LK]
-// https://github.com/ueberdosis/tiptap/pull/7207
+import { extensions } from '../../externals.js';
+import type { Extension } from '../../externals.js';
 
-// eslint-disable-next-line local-rules/enforce-umbraco-external-imports
-import { extensions as TiptapExtensions } from '@tiptap/core';
-
-/** @deprecated No longer used internally. This will be removed in Umbraco 19. [LK] */
 export interface UmbTiptapTextDirectionOptions {
+	/** @deprecated No longer used internally. This will be removed in Umbraco 19. [LK] */
 	directions: Array<'auto' | 'ltr' | 'rtl'>;
 	types: Array<string>;
 }
 
-/** @deprecated No longer required, (since it comes default with Tiptap). This will be removed in Umbraco 19. [LK] */
-export const TextDirection = TiptapExtensions.TextDirection.extend<UmbTiptapTextDirectionOptions>();
+type UmbTiptapCoreTextDirectionOptions =
+	typeof extensions.TextDirection extends Extension<infer TOptions, any> ? TOptions : never;
+
+// Overrides Tiptap's bundled `TextDirection` extension (https://github.com/ueberdosis/tiptap/pull/7207)
+// to register `dir` unconditionally, defaulting to `null` instead of the editor's `textDirection` option. [LK]
+export const TextDirection = extensions.TextDirection.extend<
+	UmbTiptapTextDirectionOptions & UmbTiptapCoreTextDirectionOptions
+>({
+	addOptions() {
+		return {
+			direction: undefined,
+			directions: ['ltr', 'rtl', 'auto'],
+			types: ['heading', 'paragraph'],
+		};
+	},
+
+	addGlobalAttributes() {
+		return [
+			{
+				types: this.options.types,
+				attributes: {
+					dir: {
+						default: null,
+						parseHTML: (element) => {
+							const dir = element.getAttribute('dir');
+							if (dir === 'ltr' || dir === 'rtl' || dir === 'auto') {
+								return dir;
+							}
+							return null;
+						},
+						renderHTML: (attributes) => {
+							if (!attributes.dir) {
+								return {};
+							}
+							return { dir: attributes.dir };
+						},
+					},
+				},
+			},
+		];
+	},
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
@@ -26,8 +26,8 @@ export const TextDirection = extensions.TextDirection.extend<UmbTiptapTextDirect
 					dir: {
 						default: null,
 						parseHTML: (element) => {
-							const dir = element.getAttribute('dir');
-							return this.options.directions.some((direction) => direction === dir) ? dir : null;
+							const dir = element.getAttribute('dir') as 'ltr' | 'rtl' | 'auto' | null;
+							return dir && this.options.directions.includes(dir) ? dir : null;
 						},
 						renderHTML: (attributes) => {
 							if (!attributes.dir) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
@@ -1,9 +1,16 @@
 import { extensions } from '../../externals.js';
 
 export interface UmbTiptapTextDirectionOptions {
-	/** Mirrors Tiptap's own `TextDirectionOptions['direction']`, which isn't exported for us to reuse directly. [LK] */
-	direction: 'ltr' | 'rtl' | 'auto' | undefined;
+	/**
+	 * Mirrors Tiptap's own `TextDirectionOptions['direction']`, which isn't exported for us to reuse directly.
+	 * Accepted only so `configure({ direction })` calls written against the vanilla Tiptap extension still
+	 * compile against this override — it is never read here.
+	 * TODO (V19): reconsider whether this can be tightened or dropped. [LK]
+	 */
+	direction?: 'ltr' | 'rtl' | 'auto';
+	/** The `dir` values `parseHTML` accepts when reading authored HTML. */
 	directions: Array<'auto' | 'ltr' | 'rtl'>;
+	/** The node type names the `dir` global attribute is registered on. */
 	types: Array<string>;
 }
 
@@ -12,7 +19,6 @@ export interface UmbTiptapTextDirectionOptions {
 export const TextDirection = extensions.TextDirection.extend<UmbTiptapTextDirectionOptions>({
 	addOptions() {
 		return {
-			direction: undefined,
 			directions: ['ltr', 'rtl', 'auto'],
 			types: ['heading', 'paragraph'],
 		};

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
@@ -1,16 +1,7 @@
 import { extensions } from '../../externals.js';
 
 export interface UmbTiptapTextDirectionOptions {
-	/**
-	 * Mirrors Tiptap's own `TextDirectionOptions['direction']`, which isn't exported for us to reuse directly.
-	 * Accepted only so `configure({ direction })` calls written against the vanilla Tiptap extension still
-	 * compile against this override — it is never read here.
-	 * TODO (V19): reconsider whether this can be tightened or dropped. [LK]
-	 */
-	direction?: 'ltr' | 'rtl' | 'auto';
-	/** The `dir` values `parseHTML` accepts when reading authored HTML. */
 	directions: Array<'auto' | 'ltr' | 'rtl'>;
-	/** The node type names the `dir` global attribute is registered on. */
 	types: Array<string>;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
@@ -1,20 +1,15 @@
 import { extensions } from '../../externals.js';
-import type { Extension } from '../../externals.js';
 
 export interface UmbTiptapTextDirectionOptions {
-	/** @deprecated No longer used internally. This will be removed in Umbraco 19. [LK] */
+	/** Mirrors Tiptap's own `TextDirectionOptions['direction']`, which isn't exported for us to reuse directly. [LK] */
+	direction: 'ltr' | 'rtl' | 'auto' | undefined;
 	directions: Array<'auto' | 'ltr' | 'rtl'>;
 	types: Array<string>;
 }
 
-type UmbTiptapCoreTextDirectionOptions =
-	typeof extensions.TextDirection extends Extension<infer TOptions, any> ? TOptions : never;
-
 // Overrides Tiptap's bundled `TextDirection` extension (https://github.com/ueberdosis/tiptap/pull/7207)
 // to register `dir` unconditionally, defaulting to `null` instead of the editor's `textDirection` option. [LK]
-export const TextDirection = extensions.TextDirection.extend<
-	UmbTiptapTextDirectionOptions & UmbTiptapCoreTextDirectionOptions
->({
+export const TextDirection = extensions.TextDirection.extend<UmbTiptapTextDirectionOptions>({
 	addOptions() {
 		return {
 			direction: undefined,
@@ -32,10 +27,8 @@ export const TextDirection = extensions.TextDirection.extend<
 						default: null,
 						parseHTML: (element) => {
 							const dir = element.getAttribute('dir');
-							if (dir === 'ltr' || dir === 'rtl' || dir === 'auto') {
-								return dir;
-							}
-							return null;
+							const isValidDirection = (this.options.directions as ReadonlyArray<string>).includes(dir ?? '');
+							return isValidDirection ? dir : null;
 						},
 						renderHTML: (attributes) => {
 							if (!attributes.dir) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-direction/text-direction.tiptap-extension.ts
@@ -27,8 +27,7 @@ export const TextDirection = extensions.TextDirection.extend<UmbTiptapTextDirect
 						default: null,
 						parseHTML: (element) => {
 							const dir = element.getAttribute('dir');
-							const isValidDirection = (this.options.directions as ReadonlyArray<string>).includes(dir ?? '');
-							return isValidDirection ? dir : null;
+							return this.options.directions.some((direction) => direction === dir) ? dir : null;
 						},
 						renderHTML: (attributes) => {
 							if (!attributes.dir) {


### PR DESCRIPTION
## Description

The Right to left / Left to right buttons in the Tiptap RTE toolbar weren't doing anything — no matter what you clicked, the text direction never actually changed and the buttons never lit up.

Turns out this has been broken since PR #21493, when Tiptap's bundled text direction extension replaced our own and quietly stopped applying without some extra editor configuration we weren't providing.

This PR restores our own Text Direction extension, so the buttons work again: clicking sets the direction, the content reflows, and the button highlights to show it's active.

Fixes #23806.

### How to test?

1. Create (or edit) an RTE (Tiptap) data type, enable **Text Direction** under Extensions, and add the **Right to left** / **Left to right** buttons to the toolbar.
2. On a document using that data type, type a paragraph and click **Right to left** — the text should flip direction and the button should highlight. Click it again to toggle back to left-to-right.
3. Save and reload the page to confirm the direction sticks around.