### PR TITLE
Members: Restore the external-only member workspace view (closes #23824)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace-editor.element.ts
@@ -1,5 +1,4 @@
 import type { UmbMemberVariantOptionModel } from '../../types.js';
-import { UmbMemberKind } from '../../utils/index.js';
 import { UMB_MEMBER_WORKSPACE_CONTEXT } from './member-workspace.context-token.js';
 import { UmbMemberWorkspaceSplitViewElement } from './member-workspace-split-view.element.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -25,9 +24,6 @@ export class UmbMemberWorkspaceEditorElement extends UmbLitElement {
 	@state()
 	private _loading?: boolean = true;
 
-	@state()
-	private _isExternalOnly = false;
-
 	constructor() {
 		super();
 
@@ -35,17 +31,6 @@ export class UmbMemberWorkspaceEditorElement extends UmbLitElement {
 			this.#workspaceContext = instance;
 			this.#observeVariants();
 			this.#observeLoading();
-			this.observe(
-				this.#workspaceContext?.kind,
-				(kind) => {
-					this._isExternalOnly = kind === UmbMemberKind.EXTERNAL_ONLY;
-					if (this._isExternalOnly) {
-						this.#variants = [{ unique: 'invariant', culture: null, segment: null }];
-						this._generateRoutes();
-					}
-				},
-				'_observeKind',
-			);
 		});
 	}
 
@@ -54,7 +39,6 @@ export class UmbMemberWorkspaceEditorElement extends UmbLitElement {
 		this.observe(
 			this.#workspaceContext?.variantOptions,
 			(variants) => {
-				if (this._isExternalOnly) return;
 				this.#variants = variants;
 				this._generateRoutes();
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -198,11 +198,16 @@ export class UmbMemberWorkspaceContext
 		// content type loading which would 404 on the empty Guid. Instead, give the structure an
 		// invariant, property-less type, so this member still resolves a single invariant variant.
 		if (data.kind === UmbMemberKind.EXTERNAL_ONLY) {
-			await this.structure.createScaffold({
+			const { error } = await this.structure.createScaffold({
 				unique: data.memberType.unique,
 				variesByCulture: false,
 				variesBySegment: false,
 			});
+
+			if (error) {
+				// Without a structure there are no variant options, and the workspace resolves to "not found".
+				console.error('Failed to scaffold the invariant member type for an external-only member:', error);
+			}
 
 			return data;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -195,8 +195,15 @@ export class UmbMemberWorkspaceContext
 
 	protected override async _processIncomingData(data: ContentModel): Promise<ContentModel> {
 		// External-only members have no content type — skip the base class's
-		// content type loading which would 404 on the empty Guid.
+		// content type loading which would 404 on the empty Guid. Instead, give the structure an
+		// invariant, property-less type, so this member still resolves a single invariant variant.
 		if (data.kind === UmbMemberKind.EXTERNAL_ONLY) {
+			await this.structure.createScaffold({
+				unique: data.memberType.unique,
+				variesByCulture: false,
+				variesBySegment: false,
+			});
+
 			return data;
 		}
 


### PR DESCRIPTION
## Description

The backoffice workspace for a lightweight external-only member (`kind: ExternalOnly`, introduced in #22162) renders "Not found" instead of the read-only External member view. Regression in 17.6.0.

### Why it regressed

An external-only member has no member type — `memberType.unique` is `Guid.Empty` — so `UmbMemberWorkspaceContext` deliberately never calls `structure.loadType`. That leaves `variesByCulture` / `variesBySegment` (observable parts of the owner content type) permanently `undefined`, and so `UmbContentDetailWorkspaceContextBase.variantOptions` returns an empty array on its first guard.

That was harmless until #23342, which made the split view derive its state from `variantOptions`.

With no options to match against, `notFound` is set and the dataset/validation contexts are never created. `umb-workspace-editor` reacts by dropping every workspace-view route in favour of its `**` catch-all (`UmbRouteNotFoundElement`) and by hiding the header, back button and views.

The member workspace editor already special-cased this by injecting an `invariant` variant straight into its own route generation, but that variant only ever existed inside the editor element. The split view asks the *workspace context* for its variant options, so it could never see it.

### The fix

The fix moves the knowledge to the layer that owns it. `UmbMemberWorkspaceContext` now seeds the structure with an invariant, property-less member type when the member is external-only.

Fixes #23824.

## Testing

I've already carried out the following, as evidenced with this screenshot:

<img width="1644" height="734" alt="image" src="https://github.com/user-attachments/assets/0dfbca9e-b25c-4928-9d83-1a7cebb182aa" />

Previously I would see the "not found" route as shown in the linked issue.

Hence I don't think the reviewer needs to repeat, give there's a quite a bit of setup.

---

1. Configure a member external login provider with `ExternalOnly = true` on the auto-link options:
   ```csharp
   options.AutoLinkOptions = new MemberExternalSignInAutoLinkOptions(
       autoLinkExternalAccount: true,
       defaultCulture: null,
       defaultIsApproved: true,
       defaultMemberTypeAlias: Constants.Security.DefaultMemberTypeAlias)
   {
       ExternalOnly = true,
   };
   ```
2. Log in once on the front-end as a member through that provider, so Umbraco creates the lightweight member.
3. In the backoffice, go to **Members** and open that member.

**Before:** the workspace shows "Not found — The requested route could not be found."

**After:** the read-only External member view renders — External member banner, read-only Username/Email, member group, and the info panel (Created, Last edited, Kind, Id).
