### PR TITLE
Database: Remove the connect-timeout fallback for the command timeout

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/CommandTimeoutResolver.cs
+++ b/src/Umbraco.Infrastructure/Persistence/CommandTimeoutResolver.cs
@@ -1,7 +1,4 @@
-using System.Collections.Concurrent;
 using System.Data.Common;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 
 namespace Umbraco.Cms.Infrastructure.Persistence;
 
@@ -19,14 +16,6 @@ namespace Umbraco.Cms.Infrastructure.Persistence;
 internal static class CommandTimeoutResolver
 {
     /// <summary>
-    ///     The connection string keywords Umbraco has historically treated as also setting the command timeout.
-    /// </summary>
-    // TODO (V19): remove, along with the connect timeout fallback it exists to support.
-    private static readonly string[] _deprecatedConnectTimeoutKeywords = ["connection timeout", "connect timeout"];
-
-    private static readonly ConcurrentDictionary<DbProviderFactory, int?> _providerDefaults = new();
-
-    /// <summary>
     ///     Gets the command timeout, in seconds, that the provider will apply to commands created from the
     ///     given connection string.
     /// </summary>
@@ -35,6 +24,10 @@ internal static class CommandTimeoutResolver
     /// <returns>
     ///     The timeout in seconds, where zero means no limit, or <c>null</c> when it cannot be determined.
     /// </returns>
+    /// <remarks>
+    ///     Deliberately not memoized: callers resolve this at most once each, and caching it would hold
+    ///     credentials in a static for the lifetime of the process.
+    /// </remarks>
     internal static int? GetConfiguredCommandTimeout(DbProviderFactory? provider, string? connectionString)
     {
         if (provider is null || string.IsNullOrWhiteSpace(connectionString))
@@ -42,115 +35,6 @@ internal static class CommandTimeoutResolver
             return null;
         }
 
-        // Deliberately not memoized per connection string: callers already resolve this at most once
-        // each, and caching it would hold credentials in a static for the lifetime of the process.
-        return Probe(provider, connectionString);
-    }
-
-    /// <summary>
-    ///     Determines whether the connection string relies on the deprecated convention of taking the command
-    ///     timeout from the connect timeout, which is the case when it sets a connect timeout and does not
-    ///     appear to configure a command timeout.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         "Does not appear to" is the accurate phrasing: a configured command timeout is detected by
-    ///         comparing what the provider derives from this connection string against what it derives from no
-    ///         connection string at all. A command timeout explicitly set to the provider's own default is
-    ///         therefore indistinguishable from one that is absent, and the connect timeout wins.
-    ///     </para>
-    ///     <para>
-    ///         That is the conservative choice, because it is what every version before the command timeout was
-    ///         honoured did. Resolving the ambiguity would mean asking each provider which keywords the
-    ///         connection string actually supplied, which is not something the ADO.NET contract exposes.
-    ///     </para>
-    /// </remarks>
-    /// <param name="provider">The provider factory, or <c>null</c> when unknown.</param>
-    /// <param name="connectionString">The connection string.</param>
-    /// <param name="timeoutSeconds">The connect timeout to apply as the command timeout.</param>
-    /// <param name="keyword">The connection string keyword the timeout was read from.</param>
-    /// <returns><c>true</c> when the fallback applies; otherwise, <c>false</c>.</returns>
-    [Obsolete("Deriving the command timeout from the connect timeout is deprecated. Scheduled for removal in Umbraco 19.")]
-    internal static bool TryGetDeprecatedConnectTimeout(
-        DbProviderFactory? provider,
-        string? connectionString,
-        out int timeoutSeconds,
-        [NotNullWhen(true)] out string? keyword)
-    {
-        timeoutSeconds = 0;
-        keyword = null;
-
-        if (TryGetConnectTimeout(connectionString, out timeoutSeconds, out keyword) is false)
-        {
-            return false;
-        }
-
-        int? configuredCommandTimeout = GetConfiguredCommandTimeout(provider, connectionString);
-        int? providerDefault = GetProviderDefaultCommandTimeout(provider);
-
-        // A command timeout in the connection string takes precedence, so the fallback stands down. When
-        // neither value could be determined we cannot tell the two apart, and preserving the long-standing
-        // behaviour is the safer of the two options.
-        if (configuredCommandTimeout is not null && providerDefault is not null && configuredCommandTimeout != providerDefault)
-        {
-            keyword = null;
-            timeoutSeconds = 0;
-            return false;
-        }
-
-        return true;
-    }
-
-    private static bool TryGetConnectTimeout(
-        string? connectionString,
-        out int timeoutSeconds,
-        [NotNullWhen(true)] out string? keyword)
-    {
-        timeoutSeconds = 0;
-        keyword = null;
-
-        if (string.IsNullOrWhiteSpace(connectionString))
-        {
-            return false;
-        }
-
-        DbConnectionStringBuilder connectionStringParser;
-        try
-        {
-            connectionStringParser = new DbConnectionStringBuilder { ConnectionString = connectionString };
-        }
-        catch (ArgumentException)
-        {
-            return false;
-        }
-
-        foreach (var candidate in _deprecatedConnectTimeoutKeywords)
-        {
-            if (connectionStringParser.TryGetValue(candidate, out var value)
-                && int.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
-                && parsed > 0)
-            {
-                timeoutSeconds = parsed;
-                keyword = candidate;
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static int? GetProviderDefaultCommandTimeout(DbProviderFactory? provider)
-    {
-        if (provider is null)
-        {
-            return null;
-        }
-
-        return _providerDefaults.GetOrAdd(provider, static key => Probe(key, connectionString: null));
-    }
-
-    private static int? Probe(DbProviderFactory provider, string? connectionString)
-    {
         try
         {
             using DbConnection? connection = provider.CreateConnection();
@@ -159,10 +43,7 @@ internal static class CommandTimeoutResolver
                 return null;
             }
 
-            if (connectionString is not null)
-            {
-                connection.ConnectionString = connectionString;
-            }
+            connection.ConnectionString = connectionString;
 
             using DbCommand command = connection.CreateCommand();
             return command.CommandTimeout;

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabase.cs
@@ -96,48 +96,6 @@ public class UmbracoDatabase : Database, IUmbracoDatabase
                 Mappers.Add(mapper);
             }
         }
-
-        InitCommandTimeout();
-    }
-
-    /// <summary>
-    ///     Applies Umbraco's own command timeout override, if it has one.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         NPoco forces a non-zero <see cref="Database.CommandTimeout" /> onto every command, so leaving it
-    ///         at zero is what allows the timeout the provider derived from the connection string to stand.
-    ///     </para>
-    ///     <para>
-    ///         The single remaining override is the deprecated convention, introduced for
-    ///         <see href="https://github.com/umbraco/Umbraco-CMS/issues/13354">#13354</see> before providers
-    ///         exposed a command timeout keyword, by which a connect timeout in the connection string also
-    ///         lengthened the command timeout. It applies only where no command timeout is configured.
-    ///     </para>
-    /// </remarks>
-    private void InitCommandTimeout()
-    {
-        if (CommandTimeout != 0)
-        {
-            // CommandTimeout configured elsewhere, so we'll skip
-            return;
-        }
-
-        // TODO (V19): remove; deriving the command timeout from the connect timeout is deprecated.
-#pragma warning disable CS0618 // Type or member is obsolete
-        if (CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(_provider, ConnectionString, out var timeout, out var keyword))
-#pragma warning restore CS0618 // Type or member is obsolete
-        {
-            if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
-            {
-                _logger.LogTrace(
-                    "Applying the connection string \"{Keyword}\" value of {Timeout} seconds as the command timeout.",
-                    keyword,
-                    timeout);
-            }
-
-            CommandTimeout = timeout;
-        }
     }
 
     private Lazy<int?> CreateConfiguredCommandTimeout()

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoDatabaseFactory.cs
@@ -229,8 +229,6 @@ public class UmbracoDatabaseFactory : DisposableObjectSlim, IUmbracoDatabaseFact
             throw new Exception($"Can't find a provider factory for provider name \"{ProviderName}\".");
         }
 
-        WarnOnDeprecatedCommandTimeoutFromConnectTimeout();
-
         _databaseType = DatabaseType.Resolve(DbProviderFactory.GetType().Name, ProviderName);
         if (_databaseType == null)
         {
@@ -289,23 +287,6 @@ public class UmbracoDatabaseFactory : DisposableObjectSlim, IUmbracoDatabaseFact
     // gets initialized poco data builders
     private InitializedPocoDataBuilder GetPocoDataFactoryResolver(Type type, IPocoDataFactory factory)
         => new UmbracoPocoDataBuilder(type, _pocoMappers, _upgrading).Init();
-
-    // TODO (V19): remove with the connect timeout fallback in UmbracoDatabase.
-    private void WarnOnDeprecatedCommandTimeoutFromConnectTimeout()
-    {
-#pragma warning disable CS0618 // Type or member is obsolete
-        if (CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(DbProviderFactory, ConnectionString, out var commandTimeout, out var keyword))
-#pragma warning restore CS0618 // Type or member is obsolete
-        {
-            _logger.LogWarning(
-                "The connection string sets \"{Keyword}\", which Umbraco also applies as the command timeout ({Timeout} seconds). "
-                + "Set \"Command Timeout\" in the connection string, or configure {CommandTimeoutSetting}, instead; deriving the "
-                + "command timeout from the connect timeout is deprecated and will be removed in Umbraco 19.",
-                keyword,
-                commandTimeout,
-                "Umbraco:CMS:Global:DatabaseCommandTimeout");
-        }
-    }
 
     // method used by NPoco's UmbracoDatabaseFactory to actually create the database instance
     private UmbracoDatabase? CreateDatabaseInstance()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/CommandTimeoutResolverTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/CommandTimeoutResolverTests.cs
@@ -6,9 +6,6 @@ using Umbraco.Cms.Infrastructure.Persistence;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence;
 
-// The connect timeout fallback is obsolete but still supported, so it still needs covering.
-#pragma warning disable CS0618 // Type or member is obsolete
-
 [TestFixture]
 public class CommandTimeoutResolverTests
 {
@@ -43,69 +40,4 @@ public class CommandTimeoutResolverTests
     [TestCase("   ")]
     public void Cannot_Get_Configured_Command_Timeout_Without_Connection_String(string connectionString)
         => Assert.IsNull(CommandTimeoutResolver.GetConfiguredCommandTimeout(SqlServer, connectionString));
-
-    [Test]
-    [TestCase("Server=.;Database=x;Connect Timeout=60", "connect timeout", 60)]
-    [TestCase("Server=.;Database=x;Connection Timeout=60", "connection timeout", 60)]
-    public void Can_Apply_Connect_Timeout_As_Command_Timeout(
-        string connectionString,
-        string expectedKeyword,
-        int expectedTimeout)
-    {
-        var result = CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(
-            SqlServer, connectionString, out var timeout, out var keyword);
-
-        Assert.Multiple(() =>
-        {
-            Assert.IsTrue(result);
-            Assert.AreEqual(expectedTimeout, timeout);
-            Assert.AreEqual(expectedKeyword, keyword);
-        });
-    }
-
-    [Test]
-    public void Can_Apply_Connect_Timeout_That_Shortens_Command_Timeout()
-    {
-        // The fallback is preserved exactly as it behaved before, in both directions: a connect timeout
-        // shorter than the provider default has always shortened commands too.
-        var result = CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(
-            SqlServer, "Server=.;Database=x;Connect Timeout=15", out var timeout, out _);
-
-        Assert.Multiple(() =>
-        {
-            Assert.IsTrue(result);
-            Assert.AreEqual(15, timeout);
-        });
-    }
-
-    [Test]
-    [TestCase("Server=.;Database=x", TestName = "no timeout keyword")]
-    [TestCase("Server=.;Database=x;Timeout=45", TestName = "the Timeout synonym is deliberately not honoured")]
-    [TestCase("Server=.;Database=x;Connect Timeout=abc", TestName = "unparseable connect timeout")]
-    [TestCase("Server=.;Database=x;Connect Timeout=0", TestName = "connect timeout of no limit")]
-    [TestCase("Server=.;Database=x;Connect Timeout=60;Command Timeout=300", TestName = "command timeout wins")]
-    [TestCase("Server=.;Database=x;Connect Timeout=60;Command Timeout=0", TestName = "command timeout of no limit wins")]
-    public void Cannot_Apply_Connect_Timeout_As_Command_Timeout(string connectionString)
-    {
-        var result = CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(
-            SqlServer, connectionString, out var timeout, out var keyword);
-
-        Assert.Multiple(() =>
-        {
-            Assert.IsFalse(result);
-            Assert.AreEqual(0, timeout);
-            Assert.IsNull(keyword);
-        });
-    }
-
-    [Test]
-    public void Cannot_Apply_Connect_Timeout_To_Sqlite_Connection_String()
-    {
-        // SQLite has no connect timeout, so the keyword can never legitimately appear.
-        var result = CommandTimeoutResolver.TryGetDeprecatedConnectTimeout(
-            Sqlite, "Data Source=x.db;Default Timeout=600", out _, out _);
-
-        Assert.IsFalse(result);
-    }
 }
-#pragma warning restore CS0618 // Type or member is obsolete

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/UmbracoDatabaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/UmbracoDatabaseTests.cs
@@ -25,8 +25,6 @@ public class UmbracoDatabaseTests
     [Test]
     public void Can_Leave_Command_Timeout_To_Provider_When_Connection_String_Configures_One()
     {
-        // The connect timeout has to be present for this to have teeth: with "Command Timeout" alone the
-        // pre-fix code found no keyword it recognised and left CommandTimeout at zero anyway.
         using UmbracoDatabase database = CreateSqlServerDatabase("Server=.;Database=x;Connect Timeout=15;Command Timeout=300");
 
         Assert.Multiple(() =>
@@ -49,14 +47,14 @@ public class UmbracoDatabaseTests
     }
 
     [Test]
-    public void Can_Apply_Connect_Timeout_As_Command_Timeout_When_None_Configured()
+    public void Cannot_Apply_Connect_Timeout_As_Command_Timeout()
     {
         using UmbracoDatabase database = CreateSqlServerDatabase("Server=.;Database=x;Connect Timeout=60");
 
         Assert.Multiple(() =>
         {
-            Assert.AreEqual(60, database.CommandTimeout);
-            Assert.AreEqual(60, database.EffectiveCommandTimeout);
+            Assert.AreEqual(0, database.CommandTimeout);
+            Assert.AreEqual(30, database.EffectiveCommandTimeout);
         });
     }
 


### PR DESCRIPTION
## Description

Follows on from #23817, which fixed #23705 in 17 while keeping backward compatibility. This is the 19 half described there under "What needs to happen in 19, once this is merged up".

PR #23817 made `Command Timeout` in the connection string work, but **kept deriving the command timeout from the *connect* timeout as a deprecated fallback**, so that no existing connection string changed behaviour. This removes that fallback: **`Connect Timeout`, `Connection Timeout` and `Timeout` no longer influence the command timeout at all**. The two concepts are now fully independent.

### Breaking change

**A site relying on the connect timeout to lengthen its command timeout drops to the provider default of 30 seconds.** To keep a longer one, set `Command Timeout` in the connection string, or `Umbraco:CMS:Global:DatabaseCommandTimeout`.

Both were introduced in 17.8 and 18.3, and affected sites have logged a deprecation warning naming them on every boot since.

**To consider for Umbraco Cloud** — if its connection-string templates emit `Connect Timeout` without `Command Timeout`, those sites need one of the alternatives in place before reaching 19.

## Testing

The fallback tests are replaced rather than just deleted, so the new behaviour stays pinned: `Cannot_Apply_Connect_Timeout_As_Command_Timeout` asserts that a lone `Connect Timeout=60` now leaves `CommandTimeout` at zero and falls through to the provider default.
