### PR TITLE
Pipeline: Use AzureFileCopy@6 so the API docs upload works with the WIF service connection

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -952,7 +952,7 @@ stages:
               archiveFilePatterns: $(Build.SourcesDirectory)/csharp-docs.zip
               destinationFolder: $(Build.ArtifactStagingDirectory)/csharp-docs
               overwriteExistingFiles: true
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: "Copy C# Docs to blob storage"
             inputs:
               SourcePath: "$(Build.ArtifactStagingDirectory)/csharp-docs/*"
@@ -976,7 +976,7 @@ stages:
               archiveFilePatterns: $(Build.SourcesDirectory)/ui-docs.zip
               destinationFolder: $(Build.ArtifactStagingDirectory)/ui-docs
               overwriteExistingFiles: true
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: "Copy Storybook to blob storage"
             inputs:
               SourcePath: "$(Build.ArtifactStagingDirectory)/ui-docs/*"
@@ -1000,7 +1000,7 @@ stages:
               archiveFilePatterns: $(Build.SourcesDirectory)/ui-api-docs.zip
               destinationFolder: $(Build.ArtifactStagingDirectory)/ui-api-docs
               overwriteExistingFiles: true
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: "Copy UI API Docs to blob storage"
             inputs:
               SourcePath: "$(Build.ArtifactStagingDirectory)/ui-api-docs/*"


### PR DESCRIPTION
## Summary

#23592 switched the three API docs upload jobs to the `umbraco-storage-wif` service connection, but left them on `AzureFileCopy@4`, which does not support workload identity federation. The 17.7.0 release build ([282881](https://dev.azure.com/umbraco/Umbraco%20Cms/_build/results?buildId=282881&view=results)) failed all three jobs with:

> Unsupported authentication scheme 'WorkloadIdentityFederation' for endpoint.

Per Microsoft's [WIF task support table](https://learn.microsoft.com/azure/devops/pipelines/release/troubleshoot-workload-identity?view=azure-devops), `AzureFileCopy@1`–`@5` all require moving to `AzureFileCopy@6`, which is the first version to support WIF. `@6` authenticates via Azure RBAC (`Storage Blob Data Contributor`, already assigned to the connection's identity on `umbracoapidocs`) instead of SAS tokens. All task inputs used here are unchanged between `@4` and `@6`, and the stage already runs on `windows-latest` as `@6` requires.

This targets `v17/dev` and is expected to forward-merge cleanly into `main` and `v19/dev`. `v13/dev` is handled separately.

## Testing

Verified with a smoke test ([build 284106](https://dev.azure.com/umbraco/Umbraco%20Cms/_build/results?buildId=284106&view=results)) that ran `AzureFileCopy@6` with `umbraco-storage-wif` against `umbracoapidocs/$web` on the same agent image and Az module versions as the failed release build: `Login with Powershell context succeeded`, 1 file transferred, publicly reachable afterwards. The only difference from the failing run was the task version.

- [ ] Confirm `Upload API Documentation` stage succeeds on the next release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)