### PR TITLE
Pipeline: Use AzureFileCopy@6 so the API docs upload works with the WIF service connection

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -898,7 +898,7 @@ stages:
             inputs:
               archiveFilePatterns: $(Build.SourcesDirectory)/csharp-docs.zip
               destinationFolder: $(Build.ArtifactStagingDirectory)/csharp-docs
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: 'Copy C# Docs to blob storage'
             inputs:
               SourcePath: '$(Build.ArtifactStagingDirectory)/csharp-docs/*'
@@ -920,7 +920,7 @@ stages:
             inputs:
               archiveFilePatterns: $(Build.SourcesDirectory)/ui-docs.zip
               destinationFolder: $(Build.ArtifactStagingDirectory)/ui-docs
-          - task: AzureFileCopy@4
+          - task: AzureFileCopy@6
             displayName: 'Copy UI Docs to blob storage'
             inputs:
               SourcePath: '$(Build.ArtifactStagingDirectory)/ui-docs/*'


### PR DESCRIPTION
## Summary

v13 counterpart of #23836.

#23591 switched the API docs upload jobs to the `umbraco-storage-wif` service connection, but left them on `AzureFileCopy@4`, which does not support workload identity federation and fails with:

> Unsupported authentication scheme 'WorkloadIdentityFederation' for endpoint.

Per Microsoft's [WIF task support table](https://learn.microsoft.com/azure/devops/pipelines/release/troubleshoot-workload-identity?view=azure-devops), `AzureFileCopy@1`–`@5` all require moving to `AzureFileCopy@6`, the first version to support WIF. `@6` authenticates via Azure RBAC (`Storage Blob Data Contributor`, already assigned) instead of SAS tokens. All task inputs used here are unchanged, and the stage already runs on `windows-latest` as `@6` requires.

## Testing

Verified with a smoke test ([build 284106](https://dev.azure.com/umbraco/Umbraco%20Cms/_build/results?buildId=284106&view=results)) running `AzureFileCopy@6` with `umbraco-storage-wif` against `umbracoapidocs/$web`: login succeeded, 1 file transferred, publicly reachable afterwards. See #23836 for details.

- [ ] Confirm `Upload API Documentation` stage succeeds on the next v13 release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)