### PR TITLE
Distributed Locking: Bound the SQL Server lock command by its own lock timeout

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
@@ -169,7 +169,8 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
 
                 // This path can pass the timeout straight to the command, so it needs no save and restore.
                 var number = await dbContext.Database.ExecuteScalarAsync<int?>(
-                    $"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};SELECT value FROM dbo.umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id={LockId}",
+                    $"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};SELECT value FROM dbo.umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id=@id",
+                    [new SqlParameter("@id", LockId)],
                     commandTimeOut: TimeSpan.FromSeconds(CommandTimeoutSeconds));
 
                 if (number == null)
@@ -210,11 +211,14 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
                 int rowsAffected;
                 try
                 {
-#pragma warning disable EF1002
+                    // S2077: SET LOCK_TIMEOUT only accepts a literal, so the timeout cannot be a
+                    // parameter. It is an int, and the lock id is parameterized, so no part of the
+                    // statement comes from a string.
+#pragma warning disable EF1002, S2077
                     rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(
                         @$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={{0}}",
                         LockId);
-#pragma warning restore EF1002
+#pragma warning restore EF1002, S2077
                 }
                 finally
                 {

--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
@@ -69,8 +69,16 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
     /// </summary>
     private sealed class SqlServerDistributedLock : IDistributedLock
     {
+        /// <summary>
+        ///     The SQL Server error number reported when the server gives up waiting for a lock, having
+        ///     waited for the period set by <c>SET LOCK_TIMEOUT</c>.
+        /// </summary>
         private const int LockRequestTimeoutError = 1222;
 
+        /// <summary>
+        ///     The SQL Server error number reported when the client gives up waiting for the command,
+        ///     having waited for its command timeout.
+        /// </summary>
         /// <remarks>
         ///     The lock statement runs under a command timeout derived from the lock timeout, so a command
         ///     that times out obtaining the lock is reported as a lock timeout too, rather than escaping
@@ -233,6 +241,10 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
             }).GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        ///     Gets the command timeout, in whole seconds, that the statement obtaining this lock runs
+        ///     under, derived from the lock's own timeout.
+        /// </summary>
         /// <remarks>
         ///     Without this the ambient command timeout can abort the statement while the server is still
         ///     waiting for the row lock, surfacing a raw timeout instead of a lock timeout exception.

--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
@@ -157,7 +157,10 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
                         "A transaction with minimum ReadCommitted isolation level is required.");
                 }
 
-                var number = await dbContext.Database.ExecuteScalarAsync<int?>($"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};SELECT value FROM dbo.umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id={LockId}");
+                // This path can pass the timeout straight to the command, so it needs no save and restore.
+                var number = await dbContext.Database.ExecuteScalarAsync<int?>(
+                    $"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};SELECT value FROM dbo.umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id={LockId}",
+                    commandTimeOut: CommandTimeoutForLockTimeout);
 
                 if (number == null)
                 {
@@ -189,9 +192,22 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
                         "A transaction with minimum ReadCommitted isolation level is required.");
                 }
 
+                // Unlike the read lock, this path has no per-command timeout hook, so the context-wide
+                // one has to be set and put back.
+                var originalCommandTimeout = dbContext.Database.GetCommandTimeout();
+                dbContext.Database.SetCommandTimeout(CommandTimeoutForLockTimeout);
+
+                int rowsAffected;
+                try
+                {
 #pragma warning disable EF1002
-                var rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(@$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={LockId}");
+                    rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(@$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={LockId}");
 #pragma warning restore EF1002
+                }
+                finally
+                {
+                    dbContext.Database.SetCommandTimeout(originalCommandTimeout);
+                }
 
                 if (rowsAffected == 0)
                 {
@@ -199,6 +215,20 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
                     throw new ArgumentException($"LockObject with id={LockId} does not exist.");
                 }
             }).GetAwaiter().GetResult();
+        }
+
+        /// <remarks>
+        ///     Without this the ambient command timeout can abort the statement while the server is still
+        ///     waiting for the row lock, surfacing a raw timeout instead of a lock timeout exception.
+        /// </remarks>
+        private TimeSpan CommandTimeoutForLockTimeout
+        {
+            get
+            {
+                const int MarginInSeconds = 5;
+
+                return TimeSpan.FromSeconds(Math.Ceiling(_timeout.TotalSeconds) + MarginInSeconds);
+            }
         }
     }
 }

--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DistributedLocking;
 using Umbraco.Cms.Core.DistributedLocking.Exceptions;
 using Umbraco.Cms.Core.Exceptions;
+using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Persistence.EFCore.Scoping;
 using Umbraco.Extensions;
 
@@ -68,6 +69,15 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
     /// </summary>
     private sealed class SqlServerDistributedLock : IDistributedLock
     {
+        private const int LockRequestTimeoutError = 1222;
+
+        /// <remarks>
+        ///     The lock statement runs under a command timeout derived from the lock timeout, so a command
+        ///     that times out obtaining the lock is reported as a lock timeout too, rather than escaping
+        ///     the mechanism untranslated.
+        /// </remarks>
+        private const int CommandTimeoutError = -2;
+
         private readonly SqlServerEFCoreDistributedLockingMechanism<T> _parent;
         private readonly TimeSpan _timeout;
 
@@ -105,7 +115,7 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
                         throw new ArgumentOutOfRangeException(nameof(lockType), lockType, @"Unsupported lockType");
                 }
             }
-            catch (SqlException ex) when (ex.Number == 1222)
+            catch (SqlException ex) when (ex.Number is LockRequestTimeoutError or CommandTimeoutError)
             {
                 if (LockType == DistributedLockType.ReadLock)
                 {
@@ -160,7 +170,7 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
                 // This path can pass the timeout straight to the command, so it needs no save and restore.
                 var number = await dbContext.Database.ExecuteScalarAsync<int?>(
                     $"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};SELECT value FROM dbo.umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id={LockId}",
-                    commandTimeOut: CommandTimeoutForLockTimeout);
+                    commandTimeOut: TimeSpan.FromSeconds(CommandTimeoutSeconds));
 
                 if (number == null)
                 {
@@ -194,14 +204,16 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
 
                 // Unlike the read lock, this path has no per-command timeout hook, so the context-wide
                 // one has to be set and put back.
-                var originalCommandTimeout = dbContext.Database.GetCommandTimeout();
-                dbContext.Database.SetCommandTimeout(CommandTimeoutForLockTimeout);
+                int? originalCommandTimeout = dbContext.Database.GetCommandTimeout();
+                dbContext.Database.SetCommandTimeout(CommandTimeoutSeconds);
 
                 int rowsAffected;
                 try
                 {
 #pragma warning disable EF1002
-                    rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(@$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={LockId}");
+                    rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(
+                        @$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={{0}}",
+                        LockId);
 #pragma warning restore EF1002
                 }
                 finally
@@ -221,14 +233,6 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
         ///     Without this the ambient command timeout can abort the statement while the server is still
         ///     waiting for the row lock, surfacing a raw timeout instead of a lock timeout exception.
         /// </remarks>
-        private TimeSpan CommandTimeoutForLockTimeout
-        {
-            get
-            {
-                const int MarginInSeconds = 5;
-
-                return TimeSpan.FromSeconds(Math.Ceiling(_timeout.TotalSeconds) + MarginInSeconds);
-            }
-        }
+        private int CommandTimeoutSeconds => _timeout.ToLockCommandTimeoutSeconds();
     }
 }

--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqliteEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqliteEFCoreDistributedLockingMechanism.cs
@@ -170,6 +170,7 @@ internal sealed class SqliteEFCoreDistributedLockingMechanism<T> : IDistributedL
 
                 var query = @$"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id = {LockId.ToString(CultureInfo.InvariantCulture)}";
 
+                // The timeout is set on the context, which outlives the lock, so it has to be put back.
                 int? originalCommandTimeout = database.Database.GetCommandTimeout();
 
                 try
@@ -177,6 +178,8 @@ internal sealed class SqliteEFCoreDistributedLockingMechanism<T> : IDistributedL
                     // imagine there is an existing writer, whilst elapsed time is < command timeout sqlite will busy loop
                     // Important to note that if this value == 0 then Command.DefaultTimeout (30s) is used.
                     // Math.Ceiling such that (0 < totalseconds < 1) is rounded up to 1.
+                    // Here the command timeout *is* the wait for the lock, so - unlike the SQL Server
+                    // mechanisms - it is the lock timeout exactly, with no margin added on top.
                     database.Database.SetCommandTimeout((int)Math.Ceiling(_timeout.TotalSeconds));
                     var i = await database.Database.ExecuteScalarAsync<int>(query);
 

--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqliteEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqliteEFCoreDistributedLockingMechanism.cs
@@ -170,7 +170,7 @@ internal sealed class SqliteEFCoreDistributedLockingMechanism<T> : IDistributedL
 
                 var query = @$"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id = {LockId.ToString(CultureInfo.InvariantCulture)}";
 
-                var originalCommandTimeout = database.Database.GetCommandTimeout();
+                int? originalCommandTimeout = database.Database.GetCommandTimeout();
 
                 try
                 {

--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqliteEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqliteEFCoreDistributedLockingMechanism.cs
@@ -170,6 +170,8 @@ internal sealed class SqliteEFCoreDistributedLockingMechanism<T> : IDistributedL
 
                 var query = @$"UPDATE umbracoLock SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id = {LockId.ToString(CultureInfo.InvariantCulture)}";
 
+                var originalCommandTimeout = database.Database.GetCommandTimeout();
+
                 try
                 {
                     // imagine there is an existing writer, whilst elapsed time is < command timeout sqlite will busy loop
@@ -187,6 +189,10 @@ internal sealed class SqliteEFCoreDistributedLockingMechanism<T> : IDistributedL
                 catch (SqliteException ex) when (ex.IsBusyOrLocked())
                 {
                     throw new DistributedWriteLockTimeoutException(LockId);
+                }
+                finally
+                {
+                    database.Database.SetCommandTimeout(originalCommandTimeout);
                 }
             });
         }

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
@@ -60,6 +60,15 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
 
     private sealed class SqlServerDistributedLock : IDistributedLock
     {
+        private const int LockRequestTimeoutError = 1222;
+
+        /// <remarks>
+        ///     The lock statement runs under a command timeout derived from the lock timeout, so a command
+        ///     that times out obtaining the lock is reported as a lock timeout too, rather than escaping
+        ///     the mechanism untranslated.
+        /// </remarks>
+        private const int CommandTimeoutError = -2;
+
         private readonly SqlServerDistributedLockingMechanism _parent;
         private readonly TimeSpan _timeout;
 
@@ -92,7 +101,7 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
                         throw new ArgumentOutOfRangeException(nameof(lockType), lockType, @"Unsupported lockType");
                 }
             }
-            catch (SqlException ex) when (ex.Number == 1222)
+            catch (SqlException ex) when (ex.Number is LockRequestTimeoutError or CommandTimeoutError)
             {
                 if (LockType == DistributedLockType.ReadLock)
                 {
@@ -205,10 +214,6 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
         ///     cannot leak into the rest of the scope.
         /// </remarks>
         private void BoundNextCommandByLockTimeout(IUmbracoDatabase db)
-        {
-            const int MarginInSeconds = 5;
-
-            db.OneTimeCommandTimeout = (int)Math.Ceiling(_timeout.TotalSeconds) + MarginInSeconds;
-        }
+            => db.OneTimeCommandTimeout = _timeout.ToLockCommandTimeoutSeconds();
     }
 }

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
@@ -60,8 +60,16 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
 
     private sealed class SqlServerDistributedLock : IDistributedLock
     {
+        /// <summary>
+        ///     The SQL Server error number reported when the server gives up waiting for a lock, having
+        ///     waited for the period set by <c>SET LOCK_TIMEOUT</c>.
+        /// </summary>
         private const int LockRequestTimeoutError = 1222;
 
+        /// <summary>
+        ///     The SQL Server error number reported when the client gives up waiting for the command,
+        ///     having waited for its command timeout.
+        /// </summary>
         /// <remarks>
         ///     The lock statement runs under a command timeout derived from the lock timeout, so a command
         ///     that times out obtaining the lock is reported as a lock timeout too, rather than escaping
@@ -211,11 +219,16 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
             }
         }
 
+        /// <summary>
+        ///     Bounds the next statement executed on the database by a command timeout derived from this
+        ///     lock's own timeout.
+        /// </summary>
+        /// <param name="db">The database that will execute the lock statement.</param>
         /// <remarks>
         ///     Without this the ambient command timeout can abort the statement while the server is still
         ///     waiting for the row lock, surfacing a raw timeout instead of a lock timeout exception.
-        ///     <see cref="NPoco.IDatabase.OneTimeCommandTimeout" /> is reset once the command executes, so it
-        ///     cannot leak into the rest of the scope.
+        ///     <c>OneTimeCommandTimeout</c> is reset once the command executes, so it cannot leak into the
+        ///     rest of the scope.
         /// </remarks>
         private void BoundNextCommandByLockTimeout(IUmbracoDatabase db)
             => db.OneTimeCommandTimeout = _timeout.ToLockCommandTimeoutSeconds();

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
@@ -148,6 +148,8 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
 
             var lockTimeoutQuery = $"SET LOCK_TIMEOUT {_timeout.TotalMilliseconds}";
 
+            BoundNextCommandByLockTimeout(db);
+
             // execute the lock timeout query and the actual query in a single server roundtrip
             var i = db.ExecuteScalar<int?>($"{lockTimeoutQuery};{query}", new { id = LockId });
 
@@ -184,6 +186,8 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
 
             var lockTimeoutQuery = $"SET LOCK_TIMEOUT {_timeout.TotalMilliseconds}";
 
+            BoundNextCommandByLockTimeout(db);
+
             // execute the lock timeout query and the actual query in a single server roundtrip
             var i = db.Execute($"{lockTimeoutQuery};{query}", new { id = LockId });
 
@@ -192,6 +196,19 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
                 // ensure we are actually locking!
                 throw new ArgumentException($"LockObject with id={LockId} does not exist.");
             }
+        }
+
+        /// <remarks>
+        ///     Without this the ambient command timeout can abort the statement while the server is still
+        ///     waiting for the row lock, surfacing a raw timeout instead of a lock timeout exception.
+        ///     <see cref="NPoco.IDatabase.OneTimeCommandTimeout" /> is reset once the command executes, so it
+        ///     cannot leak into the rest of the scope.
+        /// </remarks>
+        private void BoundNextCommandByLockTimeout(IUmbracoDatabase db)
+        {
+            const int MarginInSeconds = 5;
+
+            db.OneTimeCommandTimeout = (int)Math.Ceiling(_timeout.TotalSeconds) + MarginInSeconds;
         }
     }
 }

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
@@ -155,7 +155,7 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
 
             const string query = "SELECT value FROM umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id=@id";
 
-            var lockTimeoutQuery = $"SET LOCK_TIMEOUT {_timeout.TotalMilliseconds}";
+            var lockTimeoutQuery = $"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds}";
 
             BoundNextCommandByLockTimeout(db);
 
@@ -193,7 +193,7 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
             const string query =
                 @"UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id";
 
-            var lockTimeoutQuery = $"SET LOCK_TIMEOUT {_timeout.TotalMilliseconds}";
+            var lockTimeoutQuery = $"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds}";
 
             BoundNextCommandByLockTimeout(db);
 

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
@@ -155,6 +155,8 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
 
             const string query = "SELECT value FROM umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id=@id";
 
+            // Cast to int, so that a fractional millisecond cannot put a culture-specific decimal mark
+            // into the statement - which would not be valid T-SQL.
             var lockTimeoutQuery = $"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds}";
 
             BoundNextCommandByLockTimeout(db);
@@ -193,6 +195,8 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
             const string query =
                 @"UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id";
 
+            // Cast to int, so that a fractional millisecond cannot put a culture-specific decimal mark
+            // into the statement - which would not be valid T-SQL.
             var lockTimeoutQuery = $"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds}";
 
             BoundNextCommandByLockTimeout(db);

--- a/src/Umbraco.Infrastructure/Persistence/DistributedLockTimeoutExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DistributedLockTimeoutExtensions.cs
@@ -1,0 +1,24 @@
+namespace Umbraco.Cms.Infrastructure.Persistence;
+
+/// <summary>
+///     Extension methods for expressing the timeout a distributed lock waits for as a database
+///     command timeout.
+/// </summary>
+public static class DistributedLockTimeoutExtensions
+{
+    private const int MarginInSeconds = 5;
+
+    /// <summary>
+    ///     Converts the timeout a distributed lock waits for to the whole number of seconds that the
+    ///     statement obtaining it should run under.
+    /// </summary>
+    /// <param name="lockTimeout">The timeout the lock waits for.</param>
+    /// <returns>The command timeout in whole seconds.</returns>
+    /// <remarks>
+    ///     Allows a margin on top of the lock timeout, so that a mechanism able to report a lock timeout
+    ///     of its own gets to do so before the client abandons the command. Rounds up, so that a
+    ///     sub-second timeout cannot become zero seconds - which providers read as no limit at all.
+    /// </remarks>
+    public static int ToLockCommandTimeoutSeconds(this TimeSpan lockTimeout)
+        => (int)Math.Ceiling(lockTimeout.TotalSeconds) + MarginInSeconds;
+}

--- a/src/Umbraco.Infrastructure/Persistence/DistributedLockTimeoutExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DistributedLockTimeoutExtensions.cs
@@ -18,6 +18,11 @@ public static class DistributedLockTimeoutExtensions
     ///     Allows a margin on top of the lock timeout, so that a mechanism able to report a lock timeout
     ///     of its own gets to do so before the client abandons the command. Rounds up, so that a
     ///     sub-second timeout cannot become zero seconds - which providers read as no limit at all.
+    ///     <para>
+    ///         The result is a function of the lock's own wait alone, deliberately independent of any
+    ///         ambient command timeout: a lock statement reads or writes a single row, so a longer
+    ///         configured timeout buys it nothing, and a shorter one would stop it waiting as asked.
+    ///     </para>
     /// </remarks>
     public static int ToLockCommandTimeoutSeconds(this TimeSpan lockTimeout)
         => (int)Math.Ceiling(lockTimeout.TotalSeconds) + MarginInSeconds;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
@@ -674,13 +674,13 @@ internal sealed class LocksTests : UmbracoIntegrationTest
                 logger.LogInformation("t2 - Finished read lock attempt");
             });
 
-            while (counter < 2)
-            {
-                Thread.Sleep(10);
-            }
+            Assert.That(
+                () => counter,
+                Is.EqualTo(2).After(10000, 10),
+                "Both transactions should have begun.");
 
             gate.Set();
-            Task.WaitAll(t1, t2);
+            Assert.IsTrue(Task.WaitAll([t1, t2], TimeSpan.FromSeconds(30)), "Both lock attempts should have finished.");
         }
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/LocksTests.cs
@@ -621,18 +621,66 @@ internal sealed class LocksTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public void Lock_Exceeds_Command_Timeout()
+    [LongRunning]
+    public void Throws_Lock_Timeout_When_Command_Timeout_Is_Shorter_Than_Lock_Timeout()
     {
-        using (var scope = ScopeProvider.CreateScope())
+        if (BaseTestDatabase.IsSqlite())
         {
-            var realDb = (Database)ScopeAccessor.AmbientScope.Database;
-            realDb.CommandTimeout = 1000;
+            // For SQLite the command timeout is the lock wait, so the two cannot disagree.
+            Assert.Ignore("Doesn't apply to SQLite");
+        }
 
-            Console.WriteLine("Write lock A");
-            // TODO: In theory this would throw
-            scope.EagerWriteLock(TimeSpan.FromMilliseconds(3000), Constants.Locks.ContentTree);
-            scope.Complete();
-            Console.WriteLine("Finished Write lock A");
+        var counter = 0;
+        var gate = new ManualResetEventSlim(false);
+        var logger = GetRequiredService<ILogger<LocksTests>>();
+
+        using (ExecutionContext.SuppressFlow())
+        {
+            var t1 = Task.Run(() =>
+            {
+                using var scope = ScopeProvider.CreateScope();
+
+                _ = scope.Database; // Begin transaction
+                Interlocked.Increment(ref counter);
+                gate.Wait();
+
+                logger.LogInformation("t1 - Attempting to acquire write lock");
+                scope.EagerWriteLock(TimeSpan.FromMilliseconds(2000), Constants.Locks.ContentTree);
+
+                logger.LogInformation("t1 - Acquired write lock, sleeping");
+                Thread.Sleep(6000); // Hold it for longer than t2 is prepared to wait.
+
+                scope.Complete();
+                logger.LogInformation("t1 - Complete transaction");
+            });
+
+            var t2 = Task.Run(() =>
+            {
+                using var scope = ScopeProvider.CreateScope();
+
+                scope.Database.CommandTimeout = 1; // Shorter than the lock timeout requested below.
+                Interlocked.Increment(ref counter);
+                gate.Wait();
+                Thread.Sleep(100); // Let the other transaction obtain the write lock first.
+
+                logger.LogInformation("t2 - Attempting to acquire read lock");
+
+                // The lock wait outlives the command timeout, so the lock timeout has to be what
+                // surfaces - not the underlying command timeout.
+                Assert.Throws<DistributedReadLockTimeoutException>(() =>
+                    scope.EagerReadLock(TimeSpan.FromMilliseconds(3000), Constants.Locks.ContentTree));
+
+                scope.Complete();
+                logger.LogInformation("t2 - Finished read lock attempt");
+            });
+
+            while (counter < 2)
+            {
+                Thread.Sleep(10);
+            }
+
+            gate.Set();
+            Task.WaitAll(t1, t2);
         }
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/DistributedLockTimeoutExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/DistributedLockTimeoutExtensionsTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Persistence;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence;
+
+[TestFixture]
+public class DistributedLockTimeoutExtensionsTests
+{
+    [Test]
+    [TestCase(1000, ExpectedResult = 6)]
+    [TestCase(5000, ExpectedResult = 10)]
+    [TestCase(60000, ExpectedResult = 65)]
+    public int Can_Allow_A_Margin_Over_The_Lock_Timeout(int milliseconds)
+        => TimeSpan.FromMilliseconds(milliseconds).ToLockCommandTimeoutSeconds();
+
+    [Test]
+    [TestCase(1, ExpectedResult = 6)]
+    [TestCase(500, ExpectedResult = 6)]
+    [TestCase(1001, ExpectedResult = 7)]
+    [TestCase(1500, ExpectedResult = 7)]
+    public int Can_Round_Partial_Second_Up(int milliseconds)
+        => TimeSpan.FromMilliseconds(milliseconds).ToLockCommandTimeoutSeconds();
+
+    [Test]
+    public void Cannot_Derive_A_Command_Timeout_Shorter_Than_The_Lock_Timeout()
+    {
+        // The point of the margin is that the mechanism gets to report its own lock timeout before the
+        // client abandons the command, so the derived value must always outlast the wait.
+        TimeSpan lockTimeout = TimeSpan.FromMilliseconds(2500);
+
+        Assert.Greater(lockTimeout.ToLockCommandTimeoutSeconds(), lockTimeout.TotalSeconds);
+    }
+
+    [Test]
+    public void Cannot_Derive_No_Limit_At_All()
+    {
+        // Zero seconds means no limit to supported providers, which would leave the command unbounded.
+        Assert.AreNotEqual(0, TimeSpan.Zero.ToLockCommandTimeoutSeconds());
+    }
+}


### PR DESCRIPTION
## Description

Both SQL Server distributed locking mechanisms issue `SET LOCK_TIMEOUT` to bound how long **the server** waits for the row lock, but neither bounded the **client's** command timeout. Whichever command timeout happened to apply could therefore abort the statement before the lock wait elapsed, and the caller saw a raw `SqlException: Execution Timeout Expired` (error `-2`) instead of `DistributedReadLockTimeoutException` / `DistributedWriteLockTimeoutException`. The `catch (SqlException ex) when (ex.Number == 1222)` filter in both mechanisms only matches the server's own lock-timeout error, so `-2` escaped untranslated.

The defaults are already mismatched, so this needs no unusual configuration to hit: `DistributedLockingReadLockDefaultTimeout` is 60s while both providers default the command timeout to 30s. A site that has configured nothing is exposed on every contended read lock.

Both SQLite mechanisms already bound their command — for SQLite the command timeout *is* the busy-wait — so this was an asymmetry between the two SQL Server mechanisms and their SQLite siblings rather than a new concept.

Surfaced while removing the connect-timeout fallback for #23705 (#23834), which widens who hits it. The bug is pre-existing in 17 and 18, so it is fixed here on `v17/dev` and merged up rather than buried in that breaking change.

## The rule

**A lock's command timeout is `ceil(lockTimeout) + 5s`, set unconditionally.**

That calculation lives in one place, as `TimeSpan.ToLockCommandTimeoutSeconds()` beside the existing `ToConnectionStringTimeoutSeconds()` in `Umbraco.Infrastructure.Persistence`, since the two mechanisms are in different assemblies and would otherwise each carry their own copy of the margin.

## Testing

### Automated

The behaviour is verified in `LocksTests.Throws_Lock_Timeout_When_Command_Timeout_Is_Shorter_Than_Lock_Timeout`.

The shared helper's arithmetic is covered by `DistributedLockTimeoutExtensionsTests`.

