### PR TITLE
Tiptap RTE: Document the toolbar menu item argument on execute/isActive (closes #23660)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/CLAUDE.md
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/CLAUDE.md
@@ -104,6 +104,11 @@ Four built-in kinds for toolbar extensions:
 - `menu` - Dropdown menu
 - `styleMenu` - Style selector dropdown
 
+For `menu` and `styleMenu`, each item's active/highlighted state comes from the extension's own API, not
+from the item itself — `isActive(editor, item)` and `execute(editor, item)` are called once per
+`MetaTiptapToolbarMenuItem`, so an override switches on `item.data` (see `font-family.tiptap-toolbar-api.ts`
+and `style-menu.tiptap-toolbar-api.ts`).
+
 ---
 
 ## File Naming Conventions

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/menu/tiptap-toolbar-menu.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/menu/tiptap-toolbar-menu.test.ts
@@ -115,37 +115,39 @@ describe('UmbTiptapToolbarMenuElement — disabled state (#23823)', () => {
 describe('UmbTiptapToolbarMenuElement — per-item active state (#23660)', () => {
 	let element: UmbTiptapToolbarMenuElement;
 
-	afterEach(() => {
-		element.remove();
-	});
+	const editorStub = {} as unknown as Editor;
 
-	it('calls isActive(editor, item) per item, so an extension can highlight the item matching its data', async () => {
-		const editorStub = {} as unknown as Editor;
+	const dataAwareApi: UmbTiptapToolbarElementApi = {
+		isActive: (_editor?: Editor, item?: MetaTiptapToolbarMenuItem) => item?.data === 'serif',
+		isDisabled: () => false,
+		execute: () => {},
+	} as unknown as UmbTiptapToolbarElementApi;
 
-		const dataAwareApi: UmbTiptapToolbarElementApi = {
-			isActive: (_editor?: Editor, item?: MetaTiptapToolbarMenuItem) => item?.data === 'serif',
-			isDisabled: () => false,
-			execute: () => {},
-		} as unknown as UmbTiptapToolbarElementApi;
+	const menuManifest = {
+		type: 'tiptapToolbarExtension',
+		kind: 'menu',
+		alias: 'Umb.Tiptap.Toolbar.Test',
+		name: 'Test Menu',
+		meta: { alias: 'testMenu', label: 'Test', icon: 'icon-text' },
+		items: [
+			{ label: 'Sans serif', data: 'sans-serif' },
+			{ label: 'Serif', data: 'serif' },
+		],
+	} as any;
 
-		const menuManifest = {
-			type: 'tiptapToolbarExtension',
-			kind: 'menu',
-			alias: 'Umb.Tiptap.Toolbar.Test',
-			name: 'Test Menu',
-			meta: { alias: 'testMenu', label: 'Test', icon: 'icon-text' },
-			items: [
-				{ label: 'Sans serif', data: 'sans-serif' },
-				{ label: 'Serif', data: 'serif' },
-			],
-		} as any;
-
+	beforeEach(() => {
 		element = document.createElement('umb-tiptap-toolbar-menu') as UmbTiptapToolbarMenuElement;
 		element.editor = editorStub;
 		element.api = dataAwareApi;
 		element.manifest = menuManifest;
 		document.body.appendChild(element);
+	});
 
+	afterEach(() => {
+		element.remove();
+	});
+
+	it('calls isActive(editor, item) per item, so an extension can highlight the item matching its data', async () => {
 		// `manifest`'s setter resolves the cascading menu items asynchronously (#setMenu); flush
 		// the microtask queue so they're populated, then force the render that picks them up.
 		for (let i = 0; i < 10; i++) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/menu/tiptap-toolbar-menu.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/menu/tiptap-toolbar-menu.test.ts
@@ -1,5 +1,6 @@
 import { UmbTiptapToolbarMenuElement } from './tiptap-toolbar-menu.element.js';
-import type { UmbTiptapToolbarElementApi } from '../../../extensions/types.js';
+import type { UmbCascadingMenuPopoverElement } from '../../cascading-menu-popover/cascading-menu-popover.element.js';
+import type { MetaTiptapToolbarMenuItem, UmbTiptapToolbarElementApi } from '../../../extensions/types.js';
 import type { Editor } from '../../../externals.js';
 import { expect } from '@open-wc/testing';
 
@@ -108,5 +109,57 @@ describe('UmbTiptapToolbarMenuElement — disabled state (#23823)', () => {
 		expect(seededElement.shadowRoot?.querySelector('uui-button')?.hasAttribute('disabled')).to.equal(true);
 
 		seededElement.remove();
+	});
+});
+
+describe('UmbTiptapToolbarMenuElement — per-item active state (#23660)', () => {
+	let element: UmbTiptapToolbarMenuElement;
+
+	afterEach(() => {
+		element.remove();
+	});
+
+	it('calls isActive(editor, item) per item, so an extension can highlight the item matching its data', async () => {
+		const editorStub = {} as unknown as Editor;
+
+		const dataAwareApi: UmbTiptapToolbarElementApi = {
+			isActive: (_editor?: Editor, item?: MetaTiptapToolbarMenuItem) => item?.data === 'serif',
+			isDisabled: () => false,
+			execute: () => {},
+		} as unknown as UmbTiptapToolbarElementApi;
+
+		const menuManifest = {
+			type: 'tiptapToolbarExtension',
+			kind: 'menu',
+			alias: 'Umb.Tiptap.Toolbar.Test',
+			name: 'Test Menu',
+			meta: { alias: 'testMenu', label: 'Test', icon: 'icon-text' },
+			items: [
+				{ label: 'Sans serif', data: 'sans-serif' },
+				{ label: 'Serif', data: 'serif' },
+			],
+		} as any;
+
+		element = document.createElement('umb-tiptap-toolbar-menu') as UmbTiptapToolbarMenuElement;
+		element.editor = editorStub;
+		element.api = dataAwareApi;
+		element.manifest = menuManifest;
+		document.body.appendChild(element);
+
+		// `manifest`'s setter resolves the cascading menu items asynchronously (#setMenu); flush
+		// the microtask queue so they're populated, then force the render that picks them up.
+		for (let i = 0; i < 10; i++) {
+			await Promise.resolve();
+		}
+		(element as unknown as { requestUpdate(): void }).requestUpdate();
+		await element.updateComplete;
+
+		const popover = element.shadowRoot?.querySelector('umb-cascading-menu-popover') as
+			| UmbCascadingMenuPopoverElement
+			| null
+			| undefined;
+		const items = popover?.items ?? [];
+
+		expect(items.map((item) => item.isActive?.())).to.deep.equal([false, true]);
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/tiptap-toolbar-element-api-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/tiptap-toolbar-element-api-base.ts
@@ -20,7 +20,7 @@ export abstract class UmbTiptapToolbarElementApiBase extends UmbControllerBase i
 	 * A method to execute the toolbar element action.
 	 * @see {ManifestTiptapToolbarExtension}
 	 * @param {Editor} editor The editor instance.
-	 * @param {unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
+	 * @param {...unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
 	 * kinds pass the invoked `MetaTiptapToolbarMenuItem` as the first argument.
 	 */
 	public abstract execute(editor?: Editor, ...args: Array<unknown>): void;
@@ -29,7 +29,7 @@ export abstract class UmbTiptapToolbarElementApiBase extends UmbControllerBase i
 	 * Informs the toolbar element if it is active or not. It uses the manifest meta alias to check if the toolbar element is active.
 	 * @see {ManifestTiptapToolbarExtension}
 	 * @param {Editor} editor The editor instance.
-	 * @param {unknown} _args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
+	 * @param {...unknown} _args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
 	 * kinds pass the `MetaTiptapToolbarMenuItem` to check as the first argument.
 	 * @returns {boolean} Returns true if the toolbar element is active.
 	 */

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/tiptap-toolbar-element-api-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/tiptap-toolbar-element-api-base.ts
@@ -20,16 +20,20 @@ export abstract class UmbTiptapToolbarElementApiBase extends UmbControllerBase i
 	 * A method to execute the toolbar element action.
 	 * @see {ManifestTiptapToolbarExtension}
 	 * @param {Editor} editor The editor instance.
+	 * @param {unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
+	 * kinds pass the invoked `MetaTiptapToolbarMenuItem` as the first argument.
 	 */
-	public abstract execute(editor?: Editor): void;
+	public abstract execute(editor?: Editor, ...args: Array<unknown>): void;
 
 	/**
 	 * Informs the toolbar element if it is active or not. It uses the manifest meta alias to check if the toolbar element is active.
 	 * @see {ManifestTiptapToolbarExtension}
 	 * @param {Editor} editor The editor instance.
+	 * @param {unknown} _args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
+	 * kinds pass the `MetaTiptapToolbarMenuItem` to check as the first argument.
 	 * @returns {boolean} Returns true if the toolbar element is active.
 	 */
-	public isActive(editor?: Editor): boolean {
+	public isActive(editor?: Editor, ..._args: Array<unknown>): boolean {
 		return editor && this.manifest?.meta.alias ? editor?.isActive(this.manifest.meta.alias) === true : false;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/types.ts
@@ -48,11 +48,18 @@ export interface UmbTiptapToolbarElementApi extends UmbApi, UmbTiptapExtensionAr
 
 	/**
 	 * Executes the toolbar element action.
+	 * @param {Editor} editor The editor instance.
+	 * @param {unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
+	 * kinds pass the invoked `MetaTiptapToolbarMenuItem` as the first argument.
 	 */
 	execute(editor?: Editor, ...args: Array<unknown>): void;
 
 	/**
 	 * Checks if the toolbar element is active.
+	 * @param {Editor} editor The editor instance.
+	 * @param {unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
+	 * kinds pass the `MetaTiptapToolbarMenuItem` to check as the first argument.
+	 * @returns {boolean} Returns true if the toolbar element is active.
 	 */
 	isActive(editor?: Editor, ...args: Array<unknown>): boolean;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/types.ts
@@ -49,7 +49,7 @@ export interface UmbTiptapToolbarElementApi extends UmbApi, UmbTiptapExtensionAr
 	/**
 	 * Executes the toolbar element action.
 	 * @param {Editor} editor The editor instance.
-	 * @param {unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
+	 * @param {...unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
 	 * kinds pass the invoked `MetaTiptapToolbarMenuItem` as the first argument.
 	 */
 	execute(editor?: Editor, ...args: Array<unknown>): void;
@@ -57,7 +57,7 @@ export interface UmbTiptapToolbarElementApi extends UmbApi, UmbTiptapExtensionAr
 	/**
 	 * Checks if the toolbar element is active.
 	 * @param {Editor} editor The editor instance.
-	 * @param {unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
+	 * @param {...unknown} args Extra arguments, whose shape depends on the toolbar kind — e.g. the `menu` and `styleMenu`
 	 * kinds pass the `MetaTiptapToolbarMenuItem` to check as the first argument.
 	 * @returns {boolean} Returns true if the toolbar element is active.
 	 */


### PR DESCRIPTION
## Description

Partly resolves #23660.

The reporter assumed a `menu`/`styleMenu` toolbar item needed its own `api` to know when it's the active item, since `MetaTiptapToolbarMenuItem` has no `api` field. It doesn't need one: the menu's own `api.isActive`/`api.execute` already receive the invoked item as a second argument, which is exactly how Font Family highlights the current font. That second argument was only reachable through an untyped `...args` rest parameter though, with no JSDoc mention on either `UmbTiptapToolbarElementApi` or its base class, so it wasn't discoverable from tooling alone.

This documents the parameter on both, adds a short pointer to the pattern in the tiptap package's CLAUDE.md, and adds a regression test asserting the menu element still calls `isActive(editor, item)` per item.

### How to test?

1. Open `UmbTiptapToolbarElementApiBase.execute`/`isActive` (or the `UmbTiptapToolbarElementApi` interface) in an editor and hover over them, the JSDoc should mention the per-item argument.
2. From `src/Umbraco.Web.UI.Client`, run `npm test -- --files "src/packages/tiptap/components/toolbar/menu/tiptap-toolbar-menu.test.ts"` and confirm the new "per-item active state (#23660)" test passes.
3. As a functional sanity check, add a Rich Text Editor data type with the Font Family toolbar button enabled, place the caret in a paragraph styled with `font-family: serif;`, and confirm "Serif" is highlighted in the dropdown.
