### PR TITLE
Scoping: Explicitly complete scopes that write, take write locks or publish notifications

### DIFF
--- a/src/Umbraco.Core/Services/FileServiceBase.cs
+++ b/src/Umbraco.Core/Services/FileServiceBase.cs
@@ -106,8 +106,9 @@ public abstract class FileServiceBase<TRepository, TEntity> : RepositoryService,
     /// <inheritdoc />
     public Task SetContentStreamAsync(string path, Stream content)
     {
-        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+        using ICoreScope scope = ScopeProvider.CreateCoreScope();
         Repository.SetFileContent(path, content);
+        scope.Complete();
         return Task.CompletedTask;
     }
 

--- a/src/Umbraco.Core/Services/LogViewerServiceBase.cs
+++ b/src/Umbraco.Core/Services/LogViewerServiceBase.cs
@@ -75,8 +75,9 @@ public abstract class LogViewerServiceBase : ILogViewerService
 
         logViewerQuery = new LogViewerQuery(name, query);
 
-        using ICoreScope scope = _provider.CreateCoreScope(autoComplete: true);
+        using ICoreScope scope = _provider.CreateCoreScope();
         _logViewerQueryRepository.Save(logViewerQuery);
+        scope.Complete();
 
         return Attempt.SucceedWithStatus<ILogViewerQuery?, LogViewerOperationStatus>(
             LogViewerOperationStatus.Success,
@@ -94,8 +95,9 @@ public abstract class LogViewerServiceBase : ILogViewerService
                 LogViewerOperationStatus.NotFoundLogSearch, null);
         }
 
-        using ICoreScope scope = _provider.CreateCoreScope(autoComplete: true);
+        using ICoreScope scope = _provider.CreateCoreScope();
         _logViewerQueryRepository.Delete(logViewerQuery);
+        scope.Complete();
 
         return Attempt.SucceedWithStatus<ILogViewerQuery?, LogViewerOperationStatus>(
             LogViewerOperationStatus.Success,

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -1231,8 +1231,8 @@ namespace Umbraco.Cms.Core.Services
                 Properties = new List<MemberExportProperty>(GetPropertyExportItems(member))
             };
 
-            scope.Complete();
             scope.Notifications.Publish(new ExportedMemberNotification(member, model));
+            scope.Complete();
 
             return model;
         }

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -1207,12 +1207,13 @@ namespace Umbraco.Cms.Core.Services
         /// </remarks>
         public MemberExportModel? ExportMember(Guid key)
         {
-            using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+            using ICoreScope scope = ScopeProvider.CreateCoreScope();
             IQuery<IMember>? query = Query<IMember>().Where(x => x.Key == key);
             IMember? member = _memberRepository.Get(query)?.FirstOrDefault();
 
             if (member == null)
             {
+                scope.Complete();
                 return null;
             }
 
@@ -1230,6 +1231,7 @@ namespace Umbraco.Cms.Core.Services
                 Properties = new List<MemberExportProperty>(GetPropertyExportItems(member))
             };
 
+            scope.Complete();
             scope.Notifications.Publish(new ExportedMemberNotification(member, model));
 
             return model;

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2363,21 +2363,24 @@ internal partial class UserService : RepositoryService, IUserService
             return UserClientCredentialsOperationStatus.InvalidClientId;
         }
 
-        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+        using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
         IEnumerable<string> currentClientIds = _userRepository.GetAllClientIds();
         if (currentClientIds.InvariantContains(clientId))
         {
+            scope.Complete();
             return UserClientCredentialsOperationStatus.DuplicateClientId;
         }
 
         IUser? user = await GetAsync(userKey);
         if (user is null || user.Kind != UserKind.Api)
         {
+            scope.Complete();
             return UserClientCredentialsOperationStatus.InvalidUser;
         }
 
         _userRepository.AddClientId(user.Id, clientId);
+        scope.Complete();
 
         return UserClientCredentialsOperationStatus.Success;
     }
@@ -2385,10 +2388,13 @@ internal partial class UserService : RepositoryService, IUserService
     /// <inheritdoc/>
     public async Task<bool> RemoveClientIdAsync(Guid userKey, string clientId)
     {
-        using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
+        using ICoreScope scope = ScopeProvider.CreateCoreScope();
 
         var userId = await _userIdKeyResolver.GetAsync(userKey);
-        return _userRepository.RemoveClientId(userId, clientId);
+        var removed = _userRepository.RemoveClientId(userId, clientId);
+        scope.Complete();
+
+        return removed;
     }
 
     /// <inheritdoc/>

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/DistributedJobs/HealthCheckNotifierJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/DistributedJobs/HealthCheckNotifierJob.cs
@@ -75,7 +75,7 @@ internal class HealthCheckNotifierJob : IDistributedBackgroundJob
         // Ensure we use an explicit scope since we are running on a background thread and plugin health
         // checks can be making service/database calls so we want to ensure the CallContext/Ambient scope
         // isn't used since that can be problematic.
-        using (ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true))
+        using (ICoreScope scope = _scopeProvider.CreateCoreScope())
         using (_profilingLogger.DebugDuration<HealthCheckNotifierJob>("Health checks executing", "Health checks complete"))
         {
             // Don't notify for any checks that are disabled, nor for any disabled just for notifications.
@@ -99,6 +99,8 @@ internal class HealthCheckNotifierJob : IDistributedBackgroundJob
             {
                 await notificationMethod.SendAsync(results);
             }
+
+            scope.Complete();
         }
     }
 }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/DistributedJobs/ScheduledPublishingJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/DistributedJobs/ScheduledPublishingJob.cs
@@ -82,7 +82,7 @@ internal class ScheduledPublishingJob : IDistributedBackgroundJob
             //    but then what should be its "scope"? could we attach it to scopes?
             // - and we should definitively *not* have to flush it here (should be auto)
             using UmbracoContextReference contextReference = _umbracoContextFactory.EnsureUmbracoContext();
-            using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
+            using ICoreScope scope = _scopeProvider.CreateCoreScope();
 
             /* We used to assume that there will never be two instances running concurrently where (IsMainDom && ServerRole == SchedulingPublisher)
              * However this is possible during an azure deployment slot swap for the SchedulingPublisher instance when trying to achieve zero downtime deployments.
@@ -96,6 +96,8 @@ internal class ScheduledPublishingJob : IDistributedBackgroundJob
 
                 PerformScheduledPublish(_contentService, Constants.UdiEntityType.Document, date);
                 PerformScheduledPublish(_elementService, Constants.UdiEntityType.Element, date);
+
+                scope.Complete();
             }
             finally
             {

--- a/src/Umbraco.Infrastructure/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Infrastructure/Mapping/UmbracoMapper.cs
@@ -224,9 +224,10 @@ public class UmbracoMapper : IUmbracoMapper
         if (ctor != null && map != null)
         {
             var target = ctor(source, context);
-            using (ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true))
+            using (ICoreScope scope = _scopeProvider.CreateCoreScope())
             {
                 map(source, target, context);
+                scope.Complete();
             }
 
             return (TTarget)target;
@@ -287,7 +288,7 @@ public class UmbracoMapper : IUmbracoMapper
     {
         var targetList = (IList?)Activator.CreateInstance(typeof(List<>).MakeGenericType(targetGenericArg));
 
-        using (ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true))
+        using (ICoreScope scope = _scopeProvider.CreateCoreScope())
         {
             foreach (var sourceItem in source)
             {
@@ -295,6 +296,8 @@ public class UmbracoMapper : IUmbracoMapper
                 map(sourceItem, targetItem, context);
                 targetList?.Add(targetItem);
             }
+
+            scope.Complete();
         }
 
         object? target = targetList;
@@ -361,9 +364,10 @@ public class UmbracoMapper : IUmbracoMapper
         // if there is a direct map, map
         if (map != null)
         {
-            using (ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true))
+            using (ICoreScope scope = _scopeProvider.CreateCoreScope())
             {
                 map(source!, target!, context);
+                scope.Complete();
             }
 
             return target;

--- a/src/Umbraco.Infrastructure/Mapping/UmbracoMapper.cs
+++ b/src/Umbraco.Infrastructure/Mapping/UmbracoMapper.cs
@@ -223,14 +223,14 @@ public class UmbracoMapper : IUmbracoMapper
         // if there is a direct constructor, map
         if (ctor != null && map != null)
         {
-            var target = ctor(source, context);
             using (ICoreScope scope = _scopeProvider.CreateCoreScope())
             {
+                var target = ctor(source, context);
                 map(source, target, context);
                 scope.Complete();
-            }
 
-            return (TTarget)target;
+                return (TTarget)target;
+            }
         }
 
         // otherwise, see if we can deal with enumerable

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJobTests.cs
@@ -60,6 +60,19 @@ public class HealthCheckNotifierJobTests
     }
 
     [Test]
+    public void Completes_Scope_When_Notification_Method_Throws()
+    {
+        var sut = CreateHealthCheckNotifier();
+        _mockNotificationMethod
+            .Setup(x => x.SendAsync(It.IsAny<HealthCheckResults>()))
+            .ThrowsAsync(new InvalidOperationException());
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => sut.ExecuteAsync());
+
+        _mockScope.Verify(x => x.Complete(), Times.Once);
+    }
+
+    [Test]
     public async Task Executes_Only_Enabled_Checks()
     {
         var sut = CreateHealthCheckNotifier();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJobTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Data;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -10,8 +11,8 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
 using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs.DistributedJobs;
-using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Tests.Common;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.BackgroundJobs.Jobs;
@@ -20,6 +21,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.BackgroundJobs.Jobs
 public class HealthCheckNotifierJobTests
 {
     private Mock<IHealthCheckNotificationMethod> _mockNotificationMethod;
+    private Mock<ICoreScope> _mockScope;
 
     private const string Check1Id = "00000000-0000-0000-0000-000000000001";
     private const string Check2Id = "00000000-0000-0000-0000-000000000002";
@@ -47,6 +49,14 @@ public class HealthCheckNotifierJobTests
         var sut = CreateHealthCheckNotifier();
         await sut.ExecuteAsync();
         VerifyNotificationsSent();
+    }
+
+    [Test]
+    public async Task Completes_Scope_After_Executing_Checks()
+    {
+        var sut = CreateHealthCheckNotifier();
+        await sut.ExecuteAsync();
+        _mockScope.Verify(x => x.Complete(), Times.Once);
     }
 
     [Test]
@@ -87,7 +97,18 @@ public class HealthCheckNotifierJobTests
             new List<IHealthCheckNotificationMethod> { _mockNotificationMethod.Object });
 
 
-        var mockScopeProvider = new Mock<IScopeProvider>();
+        _mockScope = new Mock<ICoreScope>();
+        var mockScopeProvider = new Mock<ICoreScopeProvider>();
+        mockScopeProvider
+            .Setup(x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher>(),
+                It.IsAny<IScopedNotificationPublisher>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(_mockScope.Object);
         var mockProfilingLogger = new Mock<IProfilingLogger>();
 
         return new HealthCheckNotifierJob(

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/HealthCheckNotifierJobTests.cs
@@ -60,7 +60,7 @@ public class HealthCheckNotifierJobTests
     }
 
     [Test]
-    public void Completes_Scope_When_Notification_Method_Throws()
+    public void Does_Not_Complete_Scope_When_Notification_Method_Throws()
     {
         var sut = CreateHealthCheckNotifier();
         _mockNotificationMethod
@@ -69,7 +69,7 @@ public class HealthCheckNotifierJobTests
 
         Assert.ThrowsAsync<InvalidOperationException>(() => sut.ExecuteAsync());
 
-        _mockScope.Verify(x => x.Complete(), Times.Once);
+        _mockScope.Verify(x => x.Complete(), Times.Never);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ScheduledPublishingJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ScheduledPublishingJobTests.cs
@@ -24,6 +24,7 @@ public class ScheduledPublishingJobTests
     private Mock<IContentService> _mockContentService;
     private Mock<IElementService> _mockElementService;
     private Mock<ILogger<ScheduledPublishingJob>> _mockLogger;
+    private Mock<ICoreScope> _mockScope;
 
     [Test]
     public async Task Does_Not_Execute_When_Not_Enabled()
@@ -41,6 +42,27 @@ public class ScheduledPublishingJobTests
         await sut.ExecuteAsync();
         VerifyScheduledPublishingPerformed();
         VerifyElementScheduledPublishingPerformed();
+    }
+
+    [Test]
+    public async Task Completes_Scope_After_Performing_Scheduled_Publishing()
+    {
+        var sut = CreateScheduledPublishing();
+        await sut.ExecuteAsync();
+        _mockScope.Verify(x => x.Complete(), Times.Once);
+    }
+
+    [Test]
+    public async Task Does_Not_Complete_Scope_When_Scheduled_Publishing_Throws()
+    {
+        var sut = CreateScheduledPublishing();
+        _mockContentService
+            .Setup(x => x.PerformScheduledPublish(It.IsAny<DateTime>()))
+            .Throws<InvalidOperationException>();
+
+        await sut.ExecuteAsync();
+
+        _mockScope.Verify(x => x.Complete(), Times.Never);
     }
 
     [Test]
@@ -83,6 +105,7 @@ public class ScheduledPublishingJobTests
 
         var mockServerMessenger = new Mock<IServerMessenger>();
 
+        _mockScope = new Mock<ICoreScope>();
         var mockScopeProvider = new Mock<ICoreScopeProvider>();
         mockScopeProvider
             .Setup(x => x.CreateCoreScope(
@@ -93,7 +116,7 @@ public class ScheduledPublishingJobTests
                 It.IsAny<bool?>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>()))
-            .Returns(Mock.Of<IScope>());
+            .Returns(_mockScope.Object);
 
         var scheduledPublishingSettings =
             Mock.Of<IOptionsMonitor<ScheduledPublishingSettings>>(x => x.CurrentValue == (settings ?? new ScheduledPublishingSettings()));

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Mapping/MappingTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Mapping/MappingTests.cs
@@ -13,7 +13,6 @@ using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Scoping;
-using IScopeProvider = Umbraco.Cms.Infrastructure.Scoping.IScopeProvider;
 using PropertyCollection = Umbraco.Cms.Core.Models.PropertyCollection;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Mapping;
@@ -24,8 +23,10 @@ public class MappingTests
     [SetUp]
     public void MockScopeProvider()
     {
-        var scopeMock = new Mock<IScopeProvider>();
-        scopeMock.Setup(x => x.CreateScope(
+        _scopeMock = new Mock<ICoreScope>();
+
+        var scopeMock = new Mock<ICoreScopeProvider>();
+        scopeMock.Setup(x => x.CreateCoreScope(
                 It.IsAny<IsolationLevel>(),
                 It.IsAny<RepositoryCacheMode>(),
                 It.IsAny<IEventDispatcher>(),
@@ -33,12 +34,46 @@ public class MappingTests
                 It.IsAny<bool?>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>()))
-            .Returns(Mock.Of<IScope>);
+            .Returns(_scopeMock.Object);
 
         _scopeProvider = scopeMock.Object;
     }
 
-    private IScopeProvider _scopeProvider;
+    private ICoreScopeProvider _scopeProvider;
+    private Mock<ICoreScope> _scopeMock;
+
+    [Test]
+    public void Map_Completes_Scope()
+    {
+        var definitions = new MapDefinitionCollection(() => new IMapDefinition[] { new MapperDefinition1() });
+        var mapper = new UmbracoMapper(definitions, _scopeProvider, NullLogger<UmbracoMapper>.Instance);
+
+        mapper.Map<Thing2>(new Thing1 { Value = "value" });
+
+        _scopeMock.Verify(x => x.Complete(), Times.Once);
+    }
+
+    [Test]
+    public void Map_To_Existing_Target_Completes_Scope()
+    {
+        var definitions = new MapDefinitionCollection(() => new IMapDefinition[] { new MapperDefinition1() });
+        var mapper = new UmbracoMapper(definitions, _scopeProvider, NullLogger<UmbracoMapper>.Instance);
+
+        mapper.Map(new Thing1 { Value = "value" }, new Thing2());
+
+        _scopeMock.Verify(x => x.Complete(), Times.Once);
+    }
+
+    [Test]
+    public void Map_Enumerable_Completes_Scope()
+    {
+        var definitions = new MapDefinitionCollection(() => new IMapDefinition[] { new MapperDefinition1() });
+        var mapper = new UmbracoMapper(definitions, _scopeProvider, NullLogger<UmbracoMapper>.Instance);
+
+        mapper.Map<IEnumerable<Thing1>, IEnumerable<Thing2>>(new[] { new Thing1 { Value = "value" } }).ToList();
+
+        _scopeMock.Verify(x => x.Complete(), Times.Once);
+    }
 
     [Test]
     public void SimpleMap()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Related to #12553. That PR was closed in 2025 because it had drifted too far from the current codebase to be safely rebased, with the intention of re-implementing it on the latest version using the original as a reference. This PR is a scoped re-implementation of the part that is still relevant: it converts every remaining call site that mutates state, takes a write lock or publishes a scoped notification inside an auto-completing scope to an explicitly completed scope. Pure-read sites are intentionally left as they are, because `autoComplete: true` is documented as being for read-only operations.

### Description

When a scope is created with `autoComplete: true`, `Scope.Dispose` marks it as completed whenever `Complete()` was not called, without knowing whether an exception is currently propagating. As a result, an exception thrown inside such a scope still commits the transaction, and the original exception can be masked by anything that throws during disposal (scoped notifications, scoped file systems, the transaction itself). `ICoreScopeProvider.CreateCoreScope` documents that auto-completed scopes are for read-only operations only, but the following call sites did not follow that rule (the last three were part of the original PR; the others were introduced later):

| Site | What ran inside the auto-completing scope |
|---|---|
| `LogViewerServiceBase.AddSavedLogQueryAsync` | Repository save |
| `LogViewerServiceBase.DeleteSavedLogQueryAsync` | Repository delete |
| `UserService.AddClientIdAsync` | Repository insert |
| `UserService.RemoveClientIdAsync` | Repository delete |
| `FileServiceBase.SetContentStreamAsync` | File system write via the repository |
| `MemberService.ExportMember` | Scoped notification (`ExportedMemberNotification`) |
| `ScheduledPublishingJob.ExecuteAsync` | Eager write lock plus content publishing |
| `HealthCheckNotifierJob.ExecuteAsync` | User-implemented health checks and notification methods |
| `UmbracoMapper` (three sites) | User-implemented map definitions |

Each site now creates a regular scope and calls `Complete()` on every non-exception path, including early returns, so a nested call does not cause an outer scope to roll back. `Complete()` is only a signal; the transaction is committed or rolled back when the scope is disposed. Scoped notifications are published before `Complete()`, as everywhere else in the codebase.

Behavioural notes:

* `ScheduledPublishingJob`: if publishing throws part-way through a run, the whole run now rolls back instead of committing the items processed so far. The job already catches and logs every exception, so the next run retries; nothing is lost, and partial results are no longer committed.
* `HealthCheckNotifierJob`: a throwing health check or notification method now rolls back the scope instead of completing it. Nothing in this path is expected to write, so the only visible change is that the original exception is no longer at risk of being masked by the disposal.
* `UmbracoMapper`: a throwing map definition now rolls back the scope instead of completing it. Nothing in this path is expected to write, so the only visible change is that the original exception is no longer at risk of being masked by the disposal.

Two unit tests mocked a scope provider that returned a `null` scope. That was harmless with `using (null)` but throws once `Complete()` is called, so `MappingTests` and `HealthCheckNotifierJobTests` now return a mocked scope. The shared `TestHelper.ScopeProvider` already returns a real provider, so `MemberManagerTests` and `MemberUserStoreTests` needed no change.

Unit tests were added that verify `Complete()` is called on the scope for the mapper (all three map paths), the health check notifier and the scheduled publishing job, and that the scheduled publishing and health check scopes are left uncompleted when publishing or a notification method throws. Reverting the production changes makes the completion tests fail, so they guard against the pattern being reintroduced in these classes.

### How to test

1. Run the unit tests: `dotnet test tests/Umbraco.Tests.UnitTests`.
2. Run the affected integration tests: `dotnet test tests/Umbraco.Tests.Integration --filter "FullyQualifiedName~LogViewerServiceTests|FullyQualifiedName~UserServiceTests|FullyQualifiedName~MemberServiceTests|FullyQualifiedName~ScheduledPublishing"`.
3. In the backoffice, save and delete a saved log search (Settings > Log Viewer), add and remove a client id on an API user, export a member, and confirm scheduled publishing still publishes content with a release date in the past.
4. Verify no writing sites remain auto-completing: `git grep -n "autoComplete: true" -- src` and check that none of the hits call `WriteLock`, `Notifications.Publish` or a repository write inside the scope.
