### PR TITLE
Tiptap RTE: Fix the toolbar menu test stub so it satisfies the editor event contract

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/menu/tiptap-toolbar-menu.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/menu/tiptap-toolbar-menu.test.ts
@@ -115,7 +115,9 @@ describe('UmbTiptapToolbarMenuElement — disabled state (#23823)', () => {
 describe('UmbTiptapToolbarMenuElement — per-item active state (#23660)', () => {
 	let element: UmbTiptapToolbarMenuElement;
 
-	const editorStub = {} as unknown as Editor;
+	// The element subscribes to `transaction` on connect and unsubscribes on disconnect, so a stub has to be an event
+	// emitter even for a test that never fires one.
+	const editorStub = { on: () => {}, off: () => {} } as unknown as Editor;
 
 	const dataAwareApi: UmbTiptapToolbarElementApi = {
 		isActive: (_editor?: Editor, item?: MetaTiptapToolbarMenuItem) => item?.data === 'serif',


### PR DESCRIPTION
`v17/dev` is currently red on `Test Backoffice`, and has been since `fc8f9a823fe`.

Two PRs collided, each green on its own:

- **#23823** made `UmbTiptapToolbarMenuElement` subscribe to editor events on connect (`this.editor.on('transaction', …)`, with a matching `off` on disconnect).
- **#23660** added a `describe` block to the same test file stubbing the editor as `{} as unknown as Editor` — no `on`, no `off`.

Together, `connectedCallback` throws `TypeError: this.editor.on is not a function`.

The element is right — a real `Editor` has `on`/`off` — so the fix is to the stub, not to production code. It was the only bare `{}` editor stub in the TipTap tests; the others already use the listener-backed factory in the same file.

## Testing

`npm test -- --files "src/packages/tiptap/components/toolbar/menu/tiptap-toolbar-menu.test.ts"` — 4 passed, verified failing (3 passed, 1 failed) before the change.
