### PR TITLE
Property Value Converters: Shadow default converters instead of removing or excluding them

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -177,12 +177,6 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<RichTextBlockPropertyValueConstructorCache>();
         builder.Services.AddSingleton<BlockEditorVarianceHandler>();
 
-        // both SimpleTinyMceValueConverter (in Core) and RteBlockRenderingValueConverter (in Infrastructure) will be
-        // discovered when CoreBootManager configures the converters. We will remove the basic one defined
-        // in core so that the more enhanced version is active.
-        builder.PropertyValueConverters()
-            .Remove<SimpleRichTextValueConverter>();
-
         // register *all* checks, except those marked [HideFromTypeFinder] of course
         builder.Services.AddSingleton<Core.HealthChecks.NotificationMethods.IMarkdownToHtmlConverter, MarkdownToHtmlConverter>();
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/JsonValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/JsonValueConverter.cs
@@ -14,15 +14,14 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 ///     The default converter for all property editors that expose a JSON value type
 /// </summary>
 /// <remarks>
-///     Since this is a default (umbraco) converter it will be ignored if another converter found conflicts with this one.
+///     Since this is a default converter, it is ignored when a non-default converter also applies. Other default converters
+///     for property editors with a JSON value type must declare that they shadow this one.
 /// </remarks>
 [DefaultPropertyValueConverter]
 public class JsonValueConverter : PropertyValueConverterBase, IDeliveryApiPropertyValueConverter
 {
     private readonly ILogger<JsonValueConverter> _logger;
     private readonly PropertyEditorCollection _propertyEditors;
-
-    private readonly string[] _excludedPropertyEditors = { Constants.PropertyEditors.Aliases.MediaPicker3 };
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="JsonValueConverter" /> class.
@@ -34,16 +33,13 @@ public class JsonValueConverter : PropertyValueConverterBase, IDeliveryApiProper
     }
 
     /// <summary>
-    ///     It is a converter for any value type that is "JSON"
-    ///     Unless it's in the Excluded Property Editors list
-    ///     The new MediaPicker 3 stores JSON but we want to use its own ValueConvertor
+    ///     Determines whether this converter applies to any property editor whose value type is <see cref="ValueTypes.Json" />.
     /// </summary>
     /// <param name="propertyType">The published property type to check.</param>
     /// <returns>True if this converter can convert the property type.</returns>
     public override bool IsConverter(IPublishedPropertyType propertyType) =>
         _propertyEditors.TryGet(propertyType.EditorAlias, out IDataEditor? editor)
-        && editor.GetValueEditor().ValueType.InvariantEquals(ValueTypes.Json)
-        && _excludedPropertyEditors.Contains(propertyType.EditorAlias) == false;
+        && editor.GetValueEditor().ValueType.InvariantEquals(ValueTypes.Json);
 
     /// <summary>
     /// Gets the type of the property value for the given published property type.

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/JsonValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/JsonValueConverter.cs
@@ -32,46 +32,25 @@ public class JsonValueConverter : PropertyValueConverterBase, IDeliveryApiProper
         _logger = logger;
     }
 
-    /// <summary>
-    ///     Determines whether this converter applies to any property editor whose value type is <see cref="ValueTypes.Json" />.
-    /// </summary>
-    /// <param name="propertyType">The published property type to check.</param>
-    /// <returns>True if this converter can convert the property type.</returns>
+    /// <inheritdoc/>
     public override bool IsConverter(IPublishedPropertyType propertyType) =>
         _propertyEditors.TryGet(propertyType.EditorAlias, out IDataEditor? editor)
         && editor.GetValueEditor().ValueType.InvariantEquals(ValueTypes.Json);
 
-    /// <summary>
-    /// Gets the type of the property value for the given published property type.
-    /// This implementation always returns <see cref="JsonDocument"/> as the property value type.
-    /// </summary>
-    /// <remarks>We return a JsonDocument here because it's readonly and faster than JsonNode.</remarks>
-    /// <param name="propertyType">The published property type.</param>
-    /// <returns>The <see cref="Type"/> representing <see cref="JsonDocument"/>.</returns>
+    /// <inheritdoc/>
+    /// <remarks>A <see cref="JsonDocument"/> is returned because it is read-only and faster than <see cref="JsonNode"/>.</remarks>
     public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
         => typeof(JsonDocument);
 
-    /// <summary>
-    /// Gets the property cache level for the specified property type.
-    /// </summary>
-    /// <param name="propertyType">The property type for which to determine the cache level.</param>
-    /// <returns>Always returns <see cref="PropertyCacheLevel.Element"/>.</returns>
-    /// <remarks>
-    /// This method overrides the base implementation and always returns <see cref="PropertyCacheLevel.Element"/> regardless of the property type.
-    /// </remarks>
+    /// <inheritdoc/>
     public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
         => PropertyCacheLevel.Element;
 
-    /// <summary>
-    /// Converts the source value to an intermediate representation suitable for further processing.
-    /// </summary>
-    /// <param name="owner">The published element that owns the property.</param>
-    /// <param name="propertyType">The type of the published property.</param>
-    /// <param name="source">The source value to convert.</param>
-    /// <param name="preview">Indicates whether the conversion is for preview mode.</param>
-    /// <returns>
-    /// If <paramref name="source"/> is a JSON string, returns a <see cref="JsonDocument"/>; if not, returns the original string; returns <c>null</c> if <paramref name="source"/> is <c>null</c>.
-    /// </returns>
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A source value that is not detected as JSON is passed through as a string rather than discarded, so the property
+    /// still yields its stored value when the editor holds non-JSON content.
+    /// </remarks>
     public override object? ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
     {
         if (source == null)
@@ -93,38 +72,18 @@ public class JsonValueConverter : PropertyValueConverterBase, IDeliveryApiProper
             }
         }
 
-        // it's not json, just return the string
         return sourceString;
     }
 
-    /// <summary>
-    /// Determines the appropriate cache level for a property when accessed via the delivery API.
-    /// </summary>
-    /// <param name="propertyType">The published property type for which to retrieve the cache level.</param>
-    /// <returns>The <see cref="PropertyCacheLevel"/> to be used for the specified property type.</returns>
+    /// <inheritdoc/>
     public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType)
         => GetPropertyCacheLevel(propertyType);
 
-    /// <summary>
-    /// Returns the .NET type used to represent the property value for the Delivery API, based on the specified published property type.
-    /// </summary>
-    /// <param name="propertyType">The published property type for which to determine the Delivery API value type.</param>
-    /// <returns>The <see cref="Type"/> representing the Delivery API property value, typically <see cref="JsonNode"/>.</returns>
+    /// <inheritdoc/>
     public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType)
         => typeof(JsonNode);
 
-    /// <summary>
-    /// Converts an intermediate JSON value, represented as a <see cref="JsonDocument"/>, to a <see cref="JsonNode"/> object suitable for use by the Delivery API.
-    /// </summary>
-    /// <param name="owner">The published element that owns the property.</param>
-    /// <param name="propertyType">Metadata describing the property type.</param>
-    /// <param name="referenceCacheLevel">The cache level for property references.</param>
-    /// <param name="inter">The intermediate value to convert; expected to be a <see cref="JsonDocument"/>.</param>
-    /// <param name="preview">True if the conversion is for preview mode; otherwise, false.</param>
-    /// <param name="expanding">True if nested properties are being expanded during conversion; otherwise, false.</param>
-    /// <returns>
-    /// A <see cref="JsonNode"/> representing the converted value for the Delivery API, or <c>null</c> if <paramref name="inter"/> is not a <see cref="JsonDocument"/>.
-    /// </returns>
+    /// <inheritdoc/>
     public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding)
         => inter is not JsonDocument jsonDocument
             ? null

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MediaPickerWithCropsValueConverter.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 /// Converts the value stored by the Media Picker with Crops property editor into a strongly-typed object
 /// representing the selected media item(s) and their associated crop data, making it accessible for use in code.
 /// </summary>
-[DefaultPropertyValueConverter]
+[DefaultPropertyValueConverter(typeof(JsonValueConverter))]
 public class MediaPickerWithCropsValueConverter : PropertyValueConverterBase, IDeliveryApiPropertyValueConverter
 {
     private static readonly ConcurrentDictionary<Type, ConstructorInvoker> _mediaWithCropsFactories = new();

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
@@ -29,7 +29,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 ///     A value converter for TinyMCE that will ensure any blocks content are rendered properly even when
 ///     used dynamically.
 /// </summary>
-[DefaultPropertyValueConverter]
+[DefaultPropertyValueConverter(typeof(SimpleRichTextValueConverter))]
 public class RteBlockRenderingValueConverter : SimpleRichTextValueConverter, IDeliveryApiPropertyValueConverter, IDisposable
 {
     private readonly HtmlImageSourceParser _imageSourceParser;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DefaultPropertyValueConverterShadowingTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DefaultPropertyValueConverterShadowingTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Blocks;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Media;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Templates;
+using Umbraco.Cms.Infrastructure.DeliveryApi;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
+
+/// <summary>
+/// Verifies that the default converters shipped for the same property editor resolve to the most specific one through
+/// shadowing, instead of relying on the less specific converter excluding the editor or being removed from the collection.
+/// </summary>
+[TestFixture]
+public class DefaultPropertyValueConverterShadowingTests
+{
+    [TestCase(Constants.PropertyEditors.Aliases.MediaPicker3)]
+    [TestCase("My.Custom.Json")]
+    public void JsonValueConverter_IsConverterForAnyPropertyEditorWithJsonValueType(string editorAlias)
+    {
+        var converter = new JsonValueConverter(PropertyEditors(editorAlias, ValueTypes.Json), Mock.Of<ILogger<JsonValueConverter>>());
+
+        Assert.IsTrue(converter.IsConverter(Mock.Of<IPublishedPropertyType>(x => x.EditorAlias == editorAlias)));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void MediaPicker3_ResolvesMediaPickerWithCropsValueConverterOverJsonValueConverter(bool jsonConverterFirst)
+    {
+        IPropertyValueConverter jsonConverter = new JsonValueConverter(
+            PropertyEditors(Constants.PropertyEditors.Aliases.MediaPicker3, ValueTypes.Json),
+            Mock.Of<ILogger<JsonValueConverter>>());
+        IPropertyValueConverter mediaPickerConverter = new MediaPickerWithCropsValueConverter(
+            Mock.Of<IPublishedMediaCache>(),
+            Mock.Of<IPublishedUrlProvider>(),
+            Mock.Of<IPublishedValueFallback>(),
+            Mock.Of<IJsonSerializer>(),
+            Mock.Of<IApiMediaWithCropsBuilder>());
+
+        IPublishedPropertyType propertyType = PublishedPropertyType(
+            Constants.PropertyEditors.Aliases.MediaPicker3,
+            jsonConverterFirst ? [jsonConverter, mediaPickerConverter] : [mediaPickerConverter, jsonConverter]);
+
+        Assert.AreEqual(typeof(MediaWithCrops), propertyType.ModelClrType);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void RichText_ResolvesRteBlockRenderingValueConverterOverSimpleRichTextValueConverter(bool simpleConverterFirst)
+    {
+        IPropertyValueConverter simpleConverter = new SimpleRichTextValueConverter();
+        IPropertyValueConverter blockRenderingConverter = CreateRteBlockRenderingValueConverter();
+
+        IPublishedPropertyType propertyType = PublishedPropertyType(
+            Constants.PropertyEditors.Aliases.RichText,
+            simpleConverterFirst ? [simpleConverter, blockRenderingConverter] : [blockRenderingConverter, simpleConverter]);
+
+        Assert.AreEqual(typeof(RichTextModel), propertyType.DeliveryApiModelClrType);
+    }
+
+    private static PropertyEditorCollection PropertyEditors(string editorAlias, string valueType)
+    {
+        var valueEditor = Mock.Of<IDataValueEditor>(x => x.ValueType == valueType);
+        var dataEditor = Mock.Of<IDataEditor>(x => x.Alias == editorAlias && x.GetValueEditor() == valueEditor);
+        return new PropertyEditorCollection(new DataEditorCollection(() => [dataEditor]));
+    }
+
+    private static IPublishedPropertyType PublishedPropertyType(string editorAlias, IPropertyValueConverter[] converters)
+    {
+        var dataType = new PublishedDataType(123, editorAlias, editorAlias, new Lazy<object?>(() => null));
+        var contentTypeFactory = Mock.Of<IPublishedContentTypeFactory>(x => x.GetDataType(dataType.Id) == dataType);
+
+        return new PublishedPropertyType(
+            "test",
+            dataType.Id,
+            true,
+            ContentVariation.Nothing,
+            new PropertyValueConverterCollection(() => converters),
+            Mock.Of<IPublishedModelFactory>(),
+            contentTypeFactory);
+    }
+
+    private static RteBlockRenderingValueConverter CreateRteBlockRenderingValueConverter()
+    {
+        var publishedUrlProvider = Mock.Of<IPublishedUrlProvider>();
+        var variationContextAccessor = Mock.Of<IVariationContextAccessor>();
+        var languageService = Mock.Of<ILanguageService>();
+        var blockEditorVarianceHandler = new BlockEditorVarianceHandler(languageService, Mock.Of<IContentTypeService>(), variationContextAccessor);
+
+        return new RteBlockRenderingValueConverter(
+            new HtmlLocalLinkParser(publishedUrlProvider),
+            new HtmlUrlParser(
+                Mock.Of<IOptionsMonitor<ContentSettings>>(x => x.CurrentValue == new ContentSettings()),
+                Mock.Of<ILogger<HtmlUrlParser>>(),
+                Mock.Of<IProfilingLogger>(),
+                Mock.Of<IIOHelper>()),
+            new HtmlImageSourceParser(publishedUrlProvider, Mock.Of<IImageUrlTokenGenerator>()),
+            Mock.Of<IApiRichTextElementParser>(),
+            Mock.Of<IApiRichTextMarkupParser>(),
+            Mock.Of<IPartialViewBlockEngine>(),
+            new BlockEditorConverter(
+                Mock.Of<IPublishedContentTypeCache>(),
+                Mock.Of<IPublishedModelFactory>(),
+                variationContextAccessor,
+                blockEditorVarianceHandler,
+                Mock.Of<IBlockElementService>()),
+            Mock.Of<IJsonSerializer>(),
+            Mock.Of<IApiElementBuilder>(),
+            new RichTextBlockPropertyValueConstructorCache(),
+            Mock.Of<ILogger<RteBlockRenderingValueConverter>>(),
+            variationContextAccessor,
+            blockEditorVarianceHandler,
+            Mock.Of<IOptionsMonitor<DeliveryApiSettings>>(x => x.CurrentValue == new DeliveryApiSettings()),
+            languageService,
+            Mock.Of<IPropertyRenderingContextAccessor>(),
+            Mock.Of<IElementCacheService>());
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Revives #8249 for the current codebase.

### Description

Two default property value converters shipped by Umbraco still work around the fact that another default converter exists for the same property editor, instead of using the shadowing support that `DefaultPropertyValueConverterAttribute` already provides:

- `RteBlockRenderingValueConverter` (Infrastructure) and `SimpleRichTextValueConverter` (Core) both apply to the rich text editor. To avoid the "only one converter can exist for a property" boot failure, `UmbracoBuilder.CoreServices` manually removed the Core one from the `PropertyValueConverterCollection`.
- `MediaPickerWithCropsValueConverter` and `JsonValueConverter` both apply to the Media Picker (MediaPicker3) editor, because that editor has a JSON value type. To avoid the same conflict, `JsonValueConverter` carried a hard-coded list of excluded editor aliases containing MediaPicker3.

This PR makes the more specific converter declare that it shadows the generic one, which is how every other default converter for a JSON-valued editor (block list, block grid, multi URL picker, image cropper, etc.) already does it:

- `RteBlockRenderingValueConverter` now has `[DefaultPropertyValueConverter(typeof(SimpleRichTextValueConverter))]`, and the manual `Remove<SimpleRichTextValueConverter>()` in `UmbracoBuilder.CoreServices` is gone.
- `MediaPickerWithCropsValueConverter` now has `[DefaultPropertyValueConverter(typeof(JsonValueConverter))]`, and the exclusion list in `JsonValueConverter` is gone, so it now applies to any property editor with a JSON value type as its documentation states.

Behaviour for a site is unchanged: the same converters are resolved for both editors. The resolution now happens through the documented contract rather than through a special case in the generic converter and a special case in DI registration. As a side effect, `SimpleRichTextValueConverter` stays in the collection, so removing `RteBlockRenderingValueConverter` now falls back to the simple converter instead of leaving the rich text editor without a converter.

### Testing

Unit tests are added in `DefaultPropertyValueConverterShadowingTests`, covering that `JsonValueConverter` applies to any JSON-valued editor (including MediaPicker3) and that both editor pairs resolve to the specific converter regardless of registration order. Without the source changes, 3 of the 6 cases fail (the MediaPicker3 match, and both rich text cases throw the duplicate converter exception); with them, all pass. The full unit test suite passes.

Manual check: boot a site and confirm it starts without a `BootFailedException`, then render a page with a rich text property (with blocks) and a Media Picker property and confirm the output is unchanged.
