### PR TITLE
Publishing: Make branch publishing property variance aware

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -219,5 +219,5 @@ public class DataEditor : IDataEditor
         HashSet<string> allowedCultures) => sourceValue;
 
     /// <inheritdoc />
-    public virtual IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue) => [];
+    public virtual IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue, string defaultCulture) => [];
 }

--- a/src/Umbraco.Core/PropertyEditors/DataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataEditor.cs
@@ -217,4 +217,7 @@ public class DataEditor : IDataEditor
         object? targetValue,
         bool canUpdateInvariantData,
         HashSet<string> allowedCultures) => sourceValue;
+
+    /// <inheritdoc />
+    public virtual IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue) => [];
 }

--- a/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
@@ -93,8 +93,13 @@ public interface IDataEditor : IDiscoverable
     /// </summary>
     /// <param name="sourceValue">The source (edited) property value.</param>
     /// <param name="targetValue">The target (published) property value.</param>
+    /// <param name="defaultCulture">
+    ///     The default culture to attribute a change to when it cannot be tied to one specific culture
+    ///     (e.g. a genuinely invariant nested value, or a purely structural change).
+    /// </param>
     /// <returns>
-    ///     The set of cultures containing an actual edit.
+    ///     The set of cultures containing an actual edit. Empty if the editor is unable to determine this,
+    ///     in which case the caller should fall back to flagging <paramref name="defaultCulture"/> as edited.
     /// </returns>
-    IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue) => [];
+    IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue, string defaultCulture) => [];
 }

--- a/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
@@ -85,4 +85,16 @@ public interface IDataEditor : IDiscoverable
         object? targetValue,
         bool canUpdateInvariantData,
         HashSet<string> allowedCultures) => sourceValue;
+
+    /// <summary>
+    ///     Determines the specific cultures that contain an actual content change within an otherwise
+    ///     culture-invariant property's value, for editors that support partial per-culture publishing
+    ///     (see <see cref="CanMergePartialPropertyValues"/>).
+    /// </summary>
+    /// <param name="sourceValue">The source (edited) property value.</param>
+    /// <param name="targetValue">The target (published) property value.</param>
+    /// <returns>
+    ///     The set of cultures containing an actual edit.
+    /// </returns>
+    IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue) => [];
 }

--- a/src/Umbraco.Infrastructure/Persistence/Factories/PropertyFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/PropertyFactory.cs
@@ -170,7 +170,8 @@ internal static class PropertyFactory
                                 changedCultures = dataEditor
                                     .GetChangedCulturesForPartialPropertyValues(
                                         propertyValue?.EditedValue,
-                                        propertyValue?.PublishedValue)
+                                        propertyValue?.PublishedValue,
+                                        defaultCulture)
                                     .ToArray();
                             }
 

--- a/src/Umbraco.Infrastructure/Persistence/Factories/PropertyFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/PropertyFactory.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Extensions;
 
@@ -66,6 +67,10 @@ internal static class PropertyFactory
     /// <param name="publishedVersionId"></param>
     /// <param name="properties">The properties to map</param>
     /// <param name="languageRepository"></param>
+    /// <param name="propertyEditors">
+    ///     The collection of registered property editors, used to determine which specific culture(s) an edit
+    ///     applies to when a property is culture-invariant but its data editor carries per-culture nested data.
+    /// </param>
     /// <param name="edited">out parameter indicating that one or more properties have been edited</param>
     /// <param name="editedCultures">
     ///     Out parameter containing a collection of edited cultures when the contentVariation varies by culture.
@@ -78,6 +83,7 @@ internal static class PropertyFactory
         int publishedVersionId,
         IEnumerable<IProperty> properties,
         ILanguageRepository languageRepository,
+        PropertyEditorCollection propertyEditors,
         out bool edited,
         out HashSet<string>? editedCultures)
     {
@@ -153,7 +159,29 @@ internal static class PropertyFactory
                                 defaultCulture = languageRepository.GetDefaultIsoCode();
                             }
 
-                            editedCultures?.Add(defaultCulture);
+                            // the property itself is invariant, but its data editor may carry per-culture
+                            // nested data (e.g. a Block List/Grid property whose element types vary by
+                            // culture) - ask it which specific culture(s) actually changed, instead of
+                            // blindly attributing the edit to the default culture.
+                            string[]? changedCultures = null;
+                            if (propertyEditors.TryGet(property.PropertyType.PropertyEditorAlias, out IDataEditor? dataEditor) &&
+                                dataEditor.CanMergePartialPropertyValues(property.PropertyType))
+                            {
+                                changedCultures = dataEditor
+                                    .GetChangedCulturesForPartialPropertyValues(
+                                        propertyValue?.EditedValue,
+                                        propertyValue?.PublishedValue)
+                                    .ToArray();
+                            }
+
+                            if (changedCultures is { Length: > 0 })
+                            {
+                                editedCultures?.UnionWith(changedCultures);
+                            }
+                            else
+                            {
+                                editedCultures?.Add(defaultCulture);
+                            }
                         }
                     }
                 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1390,6 +1390,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 publishedVersionId,
                 entity.Properties,
                 LanguageRepository,
+                PropertyEditors,
                 out edited,
                 out editedCultures).ToList();
 
@@ -1429,7 +1430,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 propertyTypeToPropertyData[(p.PropertyTypeId, p.VersionId, p.LanguageId, p.Segment)] = p;
             }
 
-            var propertyDataDtos = PropertyFactory.BuildDtos(entity.ContentType.Variations, entity.VersionId, publishedVersionId, entity.Properties, LanguageRepository, out edited, out editedCultures).ToList();
+            var propertyDataDtos = PropertyFactory.BuildDtos(entity.ContentType.Variations, entity.VersionId, publishedVersionId, entity.Properties, LanguageRepository, PropertyEditors, out edited, out editedCultures).ToList();
 
             // Set sortable values for property editors that support custom sorting.
             SetEntitySortableValues(entity, propertyDataDtos);

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditor.cs
@@ -63,6 +63,13 @@ public class BlockGridPropertyEditor : BlockGridPropertyEditorBase
         return valueEditor.MergeVariantInvariantPropertyValue(sourceValue, targetValue, canUpdateInvariantData,allowedCultures);
     }
 
+    /// <inheritdoc />
+    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    {
+        var valueEditor = (BlockGridEditorPropertyValueEditor)GetValueEditor();
+        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue);
+    }
+
     #region Pre Value Editor
 
     protected override IConfigurationEditor CreateConfigurationEditor() => new BlockGridConfigurationEditor(_ioHelper);

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditor.cs
@@ -64,10 +64,10 @@ public class BlockGridPropertyEditor : BlockGridPropertyEditorBase
     }
 
     /// <inheritdoc />
-    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue, string defaultCulture)
     {
         var valueEditor = (BlockGridEditorPropertyValueEditor)GetValueEditor();
-        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue);
+        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue, defaultCulture);
     }
 
     #region Pre Value Editor

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
@@ -55,10 +55,10 @@ public class BlockListPropertyEditor : BlockListPropertyEditorBase
     }
 
     /// <inheritdoc />
-    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue, string defaultCulture)
     {
         var valueEditor = (BlockListEditorPropertyValueEditor)GetValueEditor();
-        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue);
+        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue, defaultCulture);
     }
 
     /// <inheritdoc/>

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditor.cs
@@ -54,6 +54,13 @@ public class BlockListPropertyEditor : BlockListPropertyEditorBase
         return valueEditor.MergeVariantInvariantPropertyValue(sourceValue, targetValue, canUpdateInvariantData, allowedCultures);
     }
 
+    /// <inheritdoc />
+    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    {
+        var valueEditor = (BlockListEditorPropertyValueEditor)GetValueEditor();
+        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue);
+    }
+
     /// <inheritdoc/>
     protected override IConfigurationEditor CreateConfigurationEditor() =>
         new BlockListConfigurationEditor(_ioHelper);

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -648,12 +648,16 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
     /// </summary>
     /// <param name="sourceValue">The source (edited) property value.</param>
     /// <param name="targetValue">The target (published) property value.</param>
+    /// <param name="defaultCulture">
+    /// The default culture to attribute a change to when it cannot be tied to one specific culture (e.g. a
+    /// genuinely invariant nested value, or a purely structural change).
+    /// </param>
     /// <returns>
     /// The set of cultures containing an actual edit, or an empty collection if neither value can be
     /// resolved as block editor data - callers should treat an empty collection as "unable to narrow down the
-    /// affected culture(s)" and fall back to flagging the default culture as edited.
+    /// affected culture(s)" and fall back to flagging <paramref name="defaultCulture"/> as edited.
     /// </returns>
-    internal virtual IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    internal virtual IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue, string defaultCulture)
     {
         BlockEditorData<TValue, TLayout>? sourceBlockEditorData = sourceValue is not null ? BlockEditorValues.DeserializeAndClean(sourceValue) : null;
         BlockEditorData<TValue, TLayout>? targetBlockEditorData = targetValue is not null ? BlockEditorValues.DeserializeAndClean(targetValue) : null;
@@ -664,7 +668,7 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
             return [];
         }
 
-        return GetChangedCulturesForBlockValue(sourceBlockEditorData?.BlockValue, targetBlockEditorData?.BlockValue);
+        return GetChangedCulturesForBlockValue(sourceBlockEditorData?.BlockValue, targetBlockEditorData?.BlockValue, defaultCulture);
     }
 
     /// <summary>
@@ -675,15 +679,13 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
     /// </summary>
     /// <param name="sourceBlockValue">The source (edited) block value, or <c>null</c> if none exists.</param>
     /// <param name="targetBlockValue">The target (published) block value, or <c>null</c> if none has been published yet.</param>
+    /// <param name="defaultCulture">The culture to attribute a changed, genuinely invariant value or exposure entry to.</param>
     /// <returns>
     /// The set of cultures for which a content, settings, or exposure change was detected. A changed
-    /// value or exposure entry that is itself culture-invariant is attributed to the default culture.
+    /// value or exposure entry that is itself culture-invariant is attributed to <paramref name="defaultCulture"/>.
     /// </returns>
-    protected HashSet<string> GetChangedCulturesForBlockValue(TValue? sourceBlockValue, TValue? targetBlockValue)
+    protected HashSet<string> GetChangedCulturesForBlockValue(TValue? sourceBlockValue, TValue? targetBlockValue, string defaultCulture)
     {
-        // NOTE: the default culture is cached at repo level.
-        var defaultCulture = _languageService.GetDefaultIsoCodeAsync().GetAwaiter().GetResult();
-
         var changedCultures = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         CollectChangedCultures(sourceBlockValue?.ContentData ?? [], targetBlockValue?.ContentData ?? [], defaultCulture, changedCultures);

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -641,6 +641,18 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         return _jsonSerializer.Serialize(mergeResult);
     }
 
+    /// <summary>
+    /// Determines the specific cultures that contain an actual content, settings, or exposure change within an
+    /// otherwise culture-invariant block property value, by deserializing and comparing <paramref name="sourceValue"/>
+    /// (edited) against <paramref name="targetValue"/> (published).
+    /// </summary>
+    /// <param name="sourceValue">The source (edited) property value.</param>
+    /// <param name="targetValue">The target (published) property value.</param>
+    /// <returns>
+    /// The set of cultures containing an actual edit, or an empty collection if neither value can be
+    /// resolved as block editor data - callers should treat an empty collection as "unable to narrow down the
+    /// affected culture(s)" and fall back to flagging the default culture as edited.
+    /// </returns>
     internal virtual IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
     {
         BlockEditorData<TValue, TLayout>? sourceBlockEditorData = sourceValue is not null ? BlockEditorValues.DeserializeAndClean(sourceValue) : null;
@@ -656,13 +668,20 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
     }
 
     /// <summary>
-    /// Compares the content and settings data of two block values and returns the set of cultures for which a
-    /// nested, culture-variant block property value differs (added, removed, or changed) between
-    /// <paramref name="sourceBlockValue"/> (edited) and <paramref name="targetBlockValue"/> (published).
+    /// Compares two block values and returns the set of cultures for which a nested, culture-variant block
+    /// property value or block exposure differs (added, removed, or changed) between
+    /// <paramref name="sourceBlockValue"/> (edited) and <paramref name="targetBlockValue"/> (published). Block
+    /// layout is not compared, as it is invariant and shared between all cultures.
     /// </summary>
+    /// <param name="sourceBlockValue">The source (edited) block value, or <c>null</c> if none exists.</param>
+    /// <param name="targetBlockValue">The target (published) block value, or <c>null</c> if none has been published yet.</param>
+    /// <returns>
+    /// The set of cultures for which a content, settings, or exposure change was detected. A changed
+    /// value or exposure entry that is itself culture-invariant is attributed to the default culture.
+    /// </returns>
     protected HashSet<string> GetChangedCulturesForBlockValue(TValue? sourceBlockValue, TValue? targetBlockValue)
     {
-        // NOTE: default ISO code is cached at repo level.
+        // NOTE: the default culture is cached at repo level.
         var defaultCulture = _languageService.GetDefaultIsoCodeAsync().GetAwaiter().GetResult();
 
         var changedCultures = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -680,6 +699,10 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
     /// <paramref name="targetExpose"/> (published). Unlike layout, which is invariant/shared between all
     /// cultures, exposure is culture-specific - a block can be exposed for one culture and hidden for another.
     /// </summary>
+    /// <param name="sourceExpose">The source (edited) exposure entries.</param>
+    /// <param name="targetExpose">The target (published) exposure entries.</param>
+    /// <param name="defaultCulture">The culture to attribute a toggled, genuinely invariant exposure entry to.</param>
+    /// <param name="changedCultures">The set that any changed cultures are added to.</param>
     private static void CollectChangedExposureCultures(
         IList<BlockItemVariation> sourceExpose,
         IList<BlockItemVariation> targetExpose,

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -669,8 +669,35 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
 
         CollectChangedCultures(sourceBlockValue?.ContentData ?? [], targetBlockValue?.ContentData ?? [], defaultCulture, changedCultures);
         CollectChangedCultures(sourceBlockValue?.SettingsData ?? [], targetBlockValue?.SettingsData ?? [], defaultCulture, changedCultures);
+        CollectChangedExposureCultures(sourceBlockValue?.Expose ?? [], targetBlockValue?.Expose ?? [], defaultCulture, changedCultures);
 
         return changedCultures;
+    }
+
+    /// <summary>
+    /// Compares the exposure of two block values and returns the set of cultures for which a block's exposure
+    /// was toggled (added or removed) between <paramref name="sourceExpose"/> (edited) and
+    /// <paramref name="targetExpose"/> (published). Unlike layout, which is invariant/shared between all
+    /// cultures, exposure is culture-specific - a block can be exposed for one culture and hidden for another.
+    /// </summary>
+    private static void CollectChangedExposureCultures(
+        IList<BlockItemVariation> sourceExpose,
+        IList<BlockItemVariation> targetExpose,
+        string defaultCulture,
+        HashSet<string> changedCultures)
+    {
+        foreach (BlockItemVariation sourceVariation in sourceExpose.Where(sv => targetExpose.Any(tv => AreEqual(sv, tv)) is false))
+        {
+            changedCultures.Add(sourceVariation.Culture ?? defaultCulture);
+        }
+
+        foreach (BlockItemVariation targetVariation in targetExpose.Where(tv => sourceExpose.Any(sv => AreEqual(sv, tv)) is false))
+        {
+            changedCultures.Add(targetVariation.Culture ?? defaultCulture);
+        }
+
+        static bool AreEqual(BlockItemVariation a, BlockItemVariation b) =>
+            a.ContentKey == b.ContentKey && a.Culture == b.Culture && a.Segment == b.Segment;
     }
 
     private void CollectChangedCultures(

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -641,6 +641,141 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         return _jsonSerializer.Serialize(mergeResult);
     }
 
+    internal virtual IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    {
+        BlockEditorData<TValue, TLayout>? sourceBlockEditorData = sourceValue is not null ? BlockEditorValues.DeserializeAndClean(sourceValue) : null;
+        BlockEditorData<TValue, TLayout>? targetBlockEditorData = targetValue is not null ? BlockEditorValues.DeserializeAndClean(targetValue) : null;
+
+        if (sourceBlockEditorData is null && targetBlockEditorData is null)
+        {
+            // nothing resolvable on either side - let the caller fall back to the default culture.
+            return [];
+        }
+
+        return GetChangedCulturesForBlockValue(sourceBlockEditorData?.BlockValue, targetBlockEditorData?.BlockValue);
+    }
+
+    /// <summary>
+    /// Compares the content and settings data of two block values and returns the set of cultures for which a
+    /// nested, culture-variant block property value differs (added, removed, or changed) between
+    /// <paramref name="sourceBlockValue"/> (edited) and <paramref name="targetBlockValue"/> (published).
+    /// </summary>
+    protected HashSet<string> GetChangedCulturesForBlockValue(TValue? sourceBlockValue, TValue? targetBlockValue)
+    {
+        // NOTE: default ISO code is cached at repo level.
+        var defaultCulture = _languageService.GetDefaultIsoCodeAsync().GetAwaiter().GetResult();
+
+        var changedCultures = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        CollectChangedCultures(sourceBlockValue?.ContentData ?? [], targetBlockValue?.ContentData ?? [], defaultCulture, changedCultures);
+        CollectChangedCultures(sourceBlockValue?.SettingsData ?? [], targetBlockValue?.SettingsData ?? [], defaultCulture, changedCultures);
+
+        return changedCultures;
+    }
+
+    private void CollectChangedCultures(
+        List<BlockItemData> sourceBlockItems,
+        List<BlockItemData> targetBlockItems,
+        string defaultCulture,
+        HashSet<string> changedCultures)
+    {
+        // blocks removed entirely (present in published, gone from edited): every value they held is an edit
+        // for its own culture (its removal is the change).
+        foreach (BlockItemData targetBlockItem in targetBlockItems.Where(tb => sourceBlockItems.Any(sb => sb.Key == tb.Key) is false))
+        {
+            foreach (BlockPropertyValue targetBlockPropertyValue in targetBlockItem.Values)
+            {
+                changedCultures.Add(targetBlockPropertyValue.Culture ?? defaultCulture);
+            }
+        }
+
+        foreach (BlockItemData sourceBlockItem in sourceBlockItems)
+        {
+            BlockItemData? targetBlockItem = targetBlockItems.FirstOrDefault(tb => tb.Key == sourceBlockItem.Key);
+            if (targetBlockItem is null)
+            {
+                // block newly added in the edited value: every value it holds is an edit for its own culture.
+                foreach (BlockPropertyValue sourceBlockPropertyValue in sourceBlockItem.Values)
+                {
+                    changedCultures.Add(sourceBlockPropertyValue.Culture ?? defaultCulture);
+                }
+
+                continue;
+            }
+
+            // values removed from an existing block also count as edits for their own culture.
+            foreach (BlockPropertyValue targetBlockPropertyValue in targetBlockItem.Values.Where(tv =>
+                         sourceBlockItem.Values.Any(sv => sv.Alias == tv.Alias && sv.Culture == tv.Culture && sv.Segment == tv.Segment) is false))
+            {
+                changedCultures.Add(targetBlockPropertyValue.Culture ?? defaultCulture);
+            }
+
+            foreach (BlockPropertyValue sourceBlockPropertyValue in sourceBlockItem.Values)
+            {
+                BlockPropertyValue? targetBlockPropertyValue = targetBlockItem.Values.FirstOrDefault(tv =>
+                    tv.Alias == sourceBlockPropertyValue.Alias &&
+                    tv.Culture == sourceBlockPropertyValue.Culture &&
+                    tv.Segment == sourceBlockPropertyValue.Segment);
+
+                // is this another editor that supports partial merging? i.e. blocks within blocks - recurse,
+                // mirroring the recursion performed by MergePartialPropertyValueForCulture.
+                IDataEditor? nestedDataEditor = null;
+                var isNestedPartialMergeEditor = sourceBlockPropertyValue.PropertyType is not null
+                    && _propertyEditors.TryGet(sourceBlockPropertyValue.PropertyType.PropertyEditorAlias, out nestedDataEditor)
+                    && nestedDataEditor.CanMergePartialPropertyValues(sourceBlockPropertyValue.PropertyType);
+
+                if (isNestedPartialMergeEditor)
+                {
+                    var nestedChangedCultures = nestedDataEditor!.GetChangedCulturesForPartialPropertyValues(
+                        sourceBlockPropertyValue.Value,
+                        targetBlockPropertyValue?.Value)
+                        .ToArray();
+
+                    if (nestedChangedCultures.Length is 0)
+                    {
+                        // nested editor couldn't determine specifics - be conservative.
+                        changedCultures.Add(sourceBlockPropertyValue.Culture ?? defaultCulture);
+                    }
+                    else
+                    {
+                        changedCultures.UnionWith(nestedChangedCultures);
+                    }
+
+                    continue;
+                }
+
+                if (targetBlockPropertyValue is null)
+                {
+                    changedCultures.Add(sourceBlockPropertyValue.Culture ?? defaultCulture);
+                    continue;
+                }
+
+                if (!BlockPropertyValuesAreEqual(sourceBlockPropertyValue.Value, targetBlockPropertyValue.Value))
+                {
+                    changedCultures.Add(sourceBlockPropertyValue.Culture ?? defaultCulture);
+                }
+            }
+        }
+    }
+
+    private bool BlockPropertyValuesAreEqual(object? sourceValue, object? targetValue)
+    {
+        if (sourceValue is null && targetValue is null)
+        {
+            return true;
+        }
+
+        if (sourceValue is null || targetValue is null)
+        {
+            return false;
+        }
+
+        // Do NOT use object.Equals() here: block property values are populated by generic JSON
+        // deserialization, so for non-primitive values they are typically boxed JsonElements - a struct
+        // whose default equality is not a structural comparison. Round-trip through the serializer instead.
+        return _jsonSerializer.Serialize(sourceValue) == _jsonSerializer.Serialize(targetValue);
+    }
+
     protected TValue MergeBlockEditorDataForCulture(TValue sourceBlockValue, TValue targetBlockValue, string? culture)
     {
         // structure is global, layout and expose follows structure

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -711,18 +711,27 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         string defaultCulture,
         HashSet<string> changedCultures)
     {
-        foreach (BlockItemVariation sourceVariation in sourceExpose.Where(sv => targetExpose.Any(tv => AreEqual(sv, tv)) is false))
+        var sourceKeys = sourceExpose.Select(ToKey).ToHashSet();
+        var targetKeys = targetExpose.Select(ToKey).ToHashSet();
+
+        foreach (BlockItemVariation sourceVariation in sourceExpose)
         {
-            changedCultures.Add(sourceVariation.Culture ?? defaultCulture);
+            if (targetKeys.Contains(ToKey(sourceVariation)) is false)
+            {
+                changedCultures.Add(sourceVariation.Culture ?? defaultCulture);
+            }
         }
 
-        foreach (BlockItemVariation targetVariation in targetExpose.Where(tv => sourceExpose.Any(sv => AreEqual(sv, tv)) is false))
+        foreach (BlockItemVariation targetVariation in targetExpose)
         {
-            changedCultures.Add(targetVariation.Culture ?? defaultCulture);
+            if (sourceKeys.Contains(ToKey(targetVariation)) is false)
+            {
+                changedCultures.Add(targetVariation.Culture ?? defaultCulture);
+            }
         }
 
-        static bool AreEqual(BlockItemVariation a, BlockItemVariation b) =>
-            a.ContentKey == b.ContentKey && a.Culture == b.Culture && a.Segment == b.Segment;
+        static (Guid ContentKey, string? Culture, string? Segment) ToKey(BlockItemVariation variation) =>
+            (variation.ContentKey, variation.Culture, variation.Segment);
     }
 
     private void CollectChangedCultures(
@@ -731,10 +740,18 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         string defaultCulture,
         HashSet<string> changedCultures)
     {
+        Dictionary<Guid, BlockItemData> sourceBlockItemsByKey = ToBlockItemsByKey(sourceBlockItems);
+        Dictionary<Guid, BlockItemData> targetBlockItemsByKey = ToBlockItemsByKey(targetBlockItems);
+
         // blocks removed entirely (present in published, gone from edited): every value they held is an edit
         // for its own culture (its removal is the change).
-        foreach (BlockItemData targetBlockItem in targetBlockItems.Where(tb => sourceBlockItems.Any(sb => sb.Key == tb.Key) is false))
+        foreach (BlockItemData targetBlockItem in targetBlockItems)
         {
+            if (sourceBlockItemsByKey.ContainsKey(targetBlockItem.Key))
+            {
+                continue;
+            }
+
             foreach (BlockPropertyValue targetBlockPropertyValue in targetBlockItem.Values)
             {
                 changedCultures.Add(targetBlockPropertyValue.Culture ?? defaultCulture);
@@ -743,8 +760,7 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
 
         foreach (BlockItemData sourceBlockItem in sourceBlockItems)
         {
-            BlockItemData? targetBlockItem = targetBlockItems.FirstOrDefault(tb => tb.Key == sourceBlockItem.Key);
-            if (targetBlockItem is null)
+            if (targetBlockItemsByKey.TryGetValue(sourceBlockItem.Key, out BlockItemData? targetBlockItem) is false)
             {
                 // block newly added in the edited value: every value it holds is an edit for its own culture.
                 foreach (BlockPropertyValue sourceBlockPropertyValue in sourceBlockItem.Values)
@@ -755,19 +771,21 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
                 continue;
             }
 
+            Dictionary<(string Alias, string? Culture, string? Segment), BlockPropertyValue> sourceValuesByKey = ToBlockPropertyValuesByKey(sourceBlockItem.Values);
+            Dictionary<(string Alias, string? Culture, string? Segment), BlockPropertyValue> targetValuesByKey = ToBlockPropertyValuesByKey(targetBlockItem.Values);
+
             // values removed from an existing block also count as edits for their own culture.
-            foreach (BlockPropertyValue targetBlockPropertyValue in targetBlockItem.Values.Where(tv =>
-                         sourceBlockItem.Values.Any(sv => sv.Alias == tv.Alias && sv.Culture == tv.Culture && sv.Segment == tv.Segment) is false))
+            foreach (BlockPropertyValue targetBlockPropertyValue in targetBlockItem.Values)
             {
-                changedCultures.Add(targetBlockPropertyValue.Culture ?? defaultCulture);
+                if (sourceValuesByKey.ContainsKey(ToKey(targetBlockPropertyValue)) is false)
+                {
+                    changedCultures.Add(targetBlockPropertyValue.Culture ?? defaultCulture);
+                }
             }
 
             foreach (BlockPropertyValue sourceBlockPropertyValue in sourceBlockItem.Values)
             {
-                BlockPropertyValue? targetBlockPropertyValue = targetBlockItem.Values.FirstOrDefault(tv =>
-                    tv.Alias == sourceBlockPropertyValue.Alias &&
-                    tv.Culture == sourceBlockPropertyValue.Culture &&
-                    tv.Segment == sourceBlockPropertyValue.Segment);
+                targetValuesByKey.TryGetValue(ToKey(sourceBlockPropertyValue), out BlockPropertyValue? targetBlockPropertyValue);
 
                 // is this another editor that supports partial merging? i.e. blocks within blocks - recurse,
                 // mirroring the recursion performed by MergePartialPropertyValueForCulture.
@@ -780,7 +798,8 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
                 {
                     var nestedChangedCultures = nestedDataEditor!.GetChangedCulturesForPartialPropertyValues(
                         sourceBlockPropertyValue.Value,
-                        targetBlockPropertyValue?.Value)
+                        targetBlockPropertyValue?.Value,
+                        defaultCulture)
                         .ToArray();
 
                     if (nestedChangedCultures.Length is 0)
@@ -808,6 +827,31 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
                 }
             }
         }
+
+        static Dictionary<Guid, BlockItemData> ToBlockItemsByKey(List<BlockItemData> blockItems)
+        {
+            var result = new Dictionary<Guid, BlockItemData>(blockItems.Count);
+            foreach (BlockItemData blockItem in blockItems)
+            {
+                result.TryAdd(blockItem.Key, blockItem);
+            }
+
+            return result;
+        }
+
+        static Dictionary<(string Alias, string? Culture, string? Segment), BlockPropertyValue> ToBlockPropertyValuesByKey(IList<BlockPropertyValue> values)
+        {
+            var result = new Dictionary<(string Alias, string? Culture, string? Segment), BlockPropertyValue>(values.Count);
+            foreach (BlockPropertyValue value in values)
+            {
+                result.TryAdd(ToKey(value), value);
+            }
+
+            return result;
+        }
+
+        static (string Alias, string? Culture, string? Segment) ToKey(BlockPropertyValue value) =>
+            (value.Alias, value.Culture, value.Segment);
     }
 
     private bool BlockPropertyValuesAreEqual(object? sourceValue, object? targetValue)

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -787,6 +787,13 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
             {
                 targetValuesByKey.TryGetValue(ToKey(sourceBlockPropertyValue), out BlockPropertyValue? targetBlockPropertyValue);
 
+                // short-circuit for identical block values.
+                if (targetBlockPropertyValue is not null
+                    && BlockPropertyValuesAreEqual(sourceBlockPropertyValue.Value, targetBlockPropertyValue.Value))
+                {
+                    continue;
+                }
+
                 // is this another editor that supports partial merging? i.e. blocks within blocks - recurse,
                 // mirroring the recursion performed by MergePartialPropertyValueForCulture.
                 IDataEditor? nestedDataEditor = null;

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -164,6 +164,13 @@ public class RichTextPropertyEditor : DataEditor, IValueSchemaProvider
         return valueEditor.MergeVariantInvariantPropertyValue(sourceValue, targetValue, canUpdateInvariantData,allowedCultures);
     }
 
+    /// <inheritdoc />
+    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    {
+        var valueEditor = (RichTextPropertyValueEditor)GetValueEditor();
+        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue);
+    }
+
     /// <summary>
     ///     Create a custom value editor
     /// </summary>
@@ -527,6 +534,26 @@ public class RichTextPropertyEditor : DataEditor, IValueSchemaProvider
             // structure is global, and markup follows structure
             var mergedEditorValue = new RichTextEditorValue { Markup = sourceRichTextEditorValue.Markup, Blocks = blocksMergeResult };
             return RichTextPropertyEditorHelper.SerializeRichTextEditorValue(mergedEditorValue, _jsonSerializer);
+        }
+
+        internal override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+        {
+            TryParseEditorValue(sourceValue, out RichTextEditorValue? sourceRichTextEditorValue);
+            TryParseEditorValue(targetValue, out RichTextEditorValue? targetRichTextEditorValue);
+
+            if (sourceRichTextEditorValue?.Blocks is null && targetRichTextEditorValue?.Blocks is null)
+            {
+                // no blocks on either side - any difference is in the markup, which is invariant/structural
+                // for this property - let the caller fall back to the default culture.
+                return [];
+            }
+
+            BlockEditorData<RichTextBlockValue, RichTextBlockLayoutItem>? sourceBlockEditorData =
+                sourceRichTextEditorValue?.Blocks is not null ? ConvertAndClean(sourceRichTextEditorValue.Blocks) : null;
+            BlockEditorData<RichTextBlockValue, RichTextBlockLayoutItem>? targetBlockEditorData =
+                targetRichTextEditorValue?.Blocks is not null ? ConvertAndClean(targetRichTextEditorValue.Blocks) : null;
+
+            return GetChangedCulturesForBlockValue(sourceBlockEditorData?.BlockValue, targetBlockEditorData?.BlockValue);
         }
 
         private bool TryParseEditorValue(object? value, [NotNullWhen(true)] out RichTextEditorValue? richTextEditorValue)

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -544,7 +544,9 @@ public class RichTextPropertyEditor : DataEditor, IValueSchemaProvider
             if (sourceRichTextEditorValue?.Blocks is null && targetRichTextEditorValue?.Blocks is null)
             {
                 // no blocks on either side - any difference is in the markup, which is invariant/structural
-                // for this property - let the caller fall back to the default culture.
+                // for this property. Deliberately return empty rather than diffing the markup: this
+                // explicitly hands the change to the caller's default-culture fallback, it is not an
+                // "unable to determine" signal.
                 return [];
             }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -165,10 +165,10 @@ public class RichTextPropertyEditor : DataEditor, IValueSchemaProvider
     }
 
     /// <inheritdoc />
-    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue, string defaultCulture)
     {
         var valueEditor = (RichTextPropertyValueEditor)GetValueEditor();
-        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue);
+        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue, defaultCulture);
     }
 
     /// <summary>
@@ -536,7 +536,7 @@ public class RichTextPropertyEditor : DataEditor, IValueSchemaProvider
             return RichTextPropertyEditorHelper.SerializeRichTextEditorValue(mergedEditorValue, _jsonSerializer);
         }
 
-        internal override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+        internal override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue, string defaultCulture)
         {
             TryParseEditorValue(sourceValue, out RichTextEditorValue? sourceRichTextEditorValue);
             TryParseEditorValue(targetValue, out RichTextEditorValue? targetRichTextEditorValue);
@@ -553,7 +553,7 @@ public class RichTextPropertyEditor : DataEditor, IValueSchemaProvider
             BlockEditorData<RichTextBlockValue, RichTextBlockLayoutItem>? targetBlockEditorData =
                 targetRichTextEditorValue?.Blocks is not null ? ConvertAndClean(targetRichTextEditorValue.Blocks) : null;
 
-            return GetChangedCulturesForBlockValue(sourceBlockEditorData?.BlockValue, targetBlockEditorData?.BlockValue);
+            return GetChangedCulturesForBlockValue(sourceBlockEditorData?.BlockValue, targetBlockEditorData?.BlockValue, defaultCulture);
         }
 
         private bool TryParseEditorValue(object? value, [NotNullWhen(true)] out RichTextEditorValue? richTextEditorValue)

--- a/src/Umbraco.Infrastructure/PropertyEditors/SingleBlockPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SingleBlockPropertyEditor.cs
@@ -92,6 +92,13 @@ public class SingleBlockPropertyEditor : DataEditor
         return valueEditor.MergeVariantInvariantPropertyValue(sourceValue, targetValue, canUpdateInvariantData, allowedCultures);
     }
 
+    /// <inheritdoc />
+    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    {
+        var valueEditor = (SingleBlockEditorPropertyValueEditor)GetValueEditor();
+        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue);
+    }
+
     internal sealed class SingleBlockEditorPropertyValueEditor : BlockEditorPropertyValueEditor<SingleBlockValue, SingleBlockLayoutItem>
     {
         /// <summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/SingleBlockPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SingleBlockPropertyEditor.cs
@@ -93,10 +93,10 @@ public class SingleBlockPropertyEditor : DataEditor
     }
 
     /// <inheritdoc />
-    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue)
+    public override IEnumerable<string> GetChangedCulturesForPartialPropertyValues(object? sourceValue, object? targetValue, string defaultCulture)
     {
         var valueEditor = (SingleBlockEditorPropertyValueEditor)GetValueEditor();
-        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue);
+        return valueEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue, defaultCulture);
     }
 
     internal sealed class SingleBlockEditorPropertyValueEditor : BlockEditorPropertyValueEditor<SingleBlockValue, SingleBlockLayoutItem>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Integration.Attributes;
@@ -2522,5 +2523,213 @@ internal partial class BlockListElementLevelVariationTests
             Assert.IsFalse(content.IsCultureEdited("en-US"), "en-US culture should not be marked as edited");
             Assert.IsFalse(content.IsCultureEdited("da-DK"), "da-DK culture should not be marked as edited");
         });
+    }
+
+    /// <summary>
+    /// When an invariant Block List property holds culture-variant block values, editing only the
+    /// non-default culture's nested value must flag that specific culture as edited - not the default
+    /// culture - so that culture-aware publishing (e.g. branch publish) knows it needs republishing.
+    /// </summary>
+    [Test]
+    public async Task Editing_A_Non_Default_Culture_Block_Value_Flags_That_Culture_As_Edited()
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
+
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "invariantText", Value = "The first invariant content value" },
+                new() { Alias = "variantText", Value = "The first content value in English", Culture = "en-US" },
+                new() { Alias = "variantText", Value = "The first content value in Danish", Culture = "da-DK" },
+            },
+            new List<BlockPropertyValue>(),
+            publishContent: false);
+
+        // Route the initial value through ContentEditingService.UpdateAsync (as the backoffice does) so the
+        // block values are canonically sorted before the first publish - this avoids an unrelated, pre-existing
+        // false-positive "edited" state caused by JSON key-ordering differences between the edited and
+        // published value (see Publishing_All_Cultures_Should_Not_Mark_Content_As_Edited above).
+        var currentBlocksJson = (string)content.Properties["blocks"]!.GetValue()!;
+        var updateModel = new ContentUpdateModel
+        {
+            Properties = [new PropertyValueModel { Alias = "blocks", Value = currentBlocksJson }],
+            Variants =
+            [
+                new VariantModel { Name = content.GetCultureName("en-US")!, Culture = "en-US" },
+                new VariantModel { Name = content.GetCultureName("da-DK")!, Culture = "da-DK" },
+            ],
+        };
+        var updateResult = await ContentEditingService.UpdateAsync(content.Key, updateModel, Constants.Security.SuperUserKey);
+        Assert.IsTrue(updateResult.Success);
+
+        content = ContentService.GetById(content.Key)!;
+        PublishContent(content, contentType, ["en-US", "da-DK"]);
+
+        // reload to get the persisted Edited/EditedCultures state after the initial publish.
+        content = ContentService.GetById(content.Key)!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(content.Edited);
+            Assert.IsFalse(content.IsCultureEdited("en-US"));
+            Assert.IsFalse(content.IsCultureEdited("da-DK"));
+        });
+
+        var blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue()!);
+        blockListValue.ContentData[0].Values.Single(v => v.Alias == "variantText" && v.Culture == "da-DK").Value = "The second content value in Danish";
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+
+        // reload again to get the persisted Edited/EditedCultures state after this save.
+        content = ContentService.GetById(content.Key)!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(content.IsCultureEdited("en-US"), "English content did not change and must not be flagged as edited.");
+            Assert.IsTrue(content.IsCultureEdited("da-DK"), "Danish content changed inside the invariant Block List property and must be flagged as edited.");
+        });
+    }
+
+    /// <summary>
+    /// Branch publishing an already-published, culture-variant document must republish a culture whose
+    /// only pending change lives inside a nested, culture-variant block value of an otherwise
+    /// culture-invariant Block List property.
+    /// </summary>
+    [Test]
+    public async Task Can_Publish_Branch_Republishes_Non_Default_Culture_Changed_Only_Inside_Invariant_Block()
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
+
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "invariantText", Value = "Invariant value" },
+                new() { Alias = "variantText", Value = "English v1", Culture = "en-US" },
+                new() { Alias = "variantText", Value = "Danish v1", Culture = "da-DK" },
+            },
+            new List<BlockPropertyValue>(),
+            true);
+
+        var blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue()!);
+        blockListValue.ContentData[0].Values.Single(v => v.Alias == "variantText" && v.Culture == "da-DK").Value = "Danish v2";
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+
+        var results = ContentService.PublishBranch(content, PublishBranchFilter.Default, content.AvailableCultures.ToArray()).ToArray();
+
+        Assert.AreEqual(1, results.Length);
+        Assert.AreEqual(PublishResultType.SuccessPublishCulture, results[0].Result, "Branch publish must republish because Danish content changed.");
+
+        SetVariationContext("da-DK", null);
+        var publishedContent = GetPublishedContent(content.Key);
+        var blockListModel = publishedContent.Value<BlockListModel>("blocks");
+        Assert.AreEqual("Danish v2", blockListModel!.First().Content.Value<string>("variantText"));
+    }
+
+    /// <summary>
+    /// The same branch-republish behaviour must also hold when the changed culture-variant value sits
+    /// inside a nested block list (blocks within blocks), each wrapped by its own culture-invariant
+    /// Block List property.
+    /// </summary>
+    [Test]
+    public async Task Can_Publish_Branch_Republishes_Non_Default_Culture_Changed_Only_Inside_Nested_Invariant_Blocks()
+    {
+        var nestedElementType = CreateElementType(ContentVariation.Culture, "myNestedElementType");
+        var nestedBlockListDataType = await CreateBlockListDataType(nestedElementType);
+
+        var rootElementType = new ContentTypeBuilder()
+            .WithAlias("myRootElementType")
+            .WithName("My Root Element Type")
+            .WithIsElement(true)
+            .WithContentVariation(ContentVariation.Culture)
+            .AddPropertyType()
+            .WithAlias("variantText")
+            .WithName("Variant text")
+            .WithDataTypeId(Constants.DataTypes.Textbox)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+            .WithValueStorageType(ValueStorageType.Nvarchar)
+            .WithVariations(ContentVariation.Culture)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("nestedBlocks")
+            .WithName("Nested blocks")
+            .WithDataTypeId(nestedBlockListDataType.Id)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.BlockList)
+            .WithValueStorageType(ValueStorageType.Ntext)
+            .WithVariations(ContentVariation.Nothing)
+            .Done()
+            .Build();
+        await ContentTypeService.CreateAsync(rootElementType, Constants.Security.SuperUserKey);
+        var rootBlockListDataType = await CreateBlockListDataType(rootElementType);
+        var contentType = CreateContentType(ContentVariation.Culture, rootBlockListDataType);
+
+        var nestedElementContentKey = Guid.NewGuid();
+        var nestedElementSettingsKey = Guid.NewGuid();
+        var content = CreateContent(
+            contentType,
+            rootElementType,
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "variantText", Value = "Root content value in English", Culture = "en-US" },
+                new() { Alias = "variantText", Value = "Root content value in Danish", Culture = "da-DK" },
+                new()
+                {
+                    Alias = "nestedBlocks",
+                    Value = BlockListPropertyValue(
+                        nestedElementType,
+                        nestedElementContentKey,
+                        nestedElementSettingsKey,
+                        new BlockProperty(
+                            new List<BlockPropertyValue>
+                            {
+                                new() { Alias = "variantText", Value = "Nested English v1", Culture = "en-US" },
+                                new() { Alias = "variantText", Value = "Nested Danish v1", Culture = "da-DK" },
+                            },
+                            new List<BlockPropertyValue>(),
+                            null,
+                            null)),
+                },
+            },
+            [],
+            true);
+
+        var blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue()!);
+        blockListValue.ContentData[0].Values.Single(v => v.Alias == "nestedBlocks").Value = BlockListPropertyValue(
+            nestedElementType,
+            nestedElementContentKey,
+            nestedElementSettingsKey,
+            new BlockProperty(
+                new List<BlockPropertyValue>
+                {
+                    new() { Alias = "variantText", Value = "Nested English v1", Culture = "en-US" },
+                    new() { Alias = "variantText", Value = "Nested Danish v2", Culture = "da-DK" },
+                },
+                new List<BlockPropertyValue>(),
+                null,
+                null));
+
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+
+        Assert.IsTrue(content.IsCultureEdited("da-DK"), "Nested Danish content changed and must be flagged as edited.");
+
+        var results = ContentService.PublishBranch(content, PublishBranchFilter.Default, content.AvailableCultures.ToArray()).ToArray();
+
+        Assert.AreEqual(1, results.Length);
+        Assert.AreEqual(PublishResultType.SuccessPublishCulture, results[0].Result, "Branch publish must republish because nested Danish content changed.");
+
+        SetVariationContext("da-DK", null);
+        var publishedContent = GetPublishedContent(content.Key);
+        var rootBlock = publishedContent.Value<BlockListModel>("blocks")!.First();
+        var nestedBlock = rootBlock.Content.Value<BlockListModel>("nestedBlocks")!.First();
+        Assert.AreEqual("Nested Danish v2", nestedBlock.Content.Value<string>("variantText"));
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -2732,4 +2732,95 @@ internal partial class BlockListElementLevelVariationTests
         var nestedBlock = rootBlock.Content.Value<BlockListModel>("nestedBlocks")!.First();
         Assert.AreEqual("Nested Danish v2", nestedBlock.Content.Value<string>("variantText"));
     }
+
+    /// <summary>
+    /// Exposure (<see cref="BlockListValue.Expose"/>) is culture-specific, unlike layout: exposing a block for
+    /// an additional culture - with no change to any block value - must flag that specific culture as edited,
+    /// so branch publishing republishes it and picks up the newly-exposed block.
+    /// </summary>
+    [Test]
+    public async Task Can_Publish_Branch_Republishes_Non_Default_Culture_Changed_Only_Via_Exposure()
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType);
+
+        var content = CreateContent(contentType, elementType, [], false);
+        var contentElementKey = Guid.NewGuid();
+        var settingsElementKey = Guid.NewGuid();
+        var blockListValue = BlockListPropertyValue(
+            elementType,
+            contentElementKey,
+            settingsElementKey,
+            new BlockProperty(
+                new List<BlockPropertyValue>
+                {
+                    new() { Alias = "invariantText", Value = "Invariant content value" },
+                    new() { Alias = "variantText", Value = "English content value", Culture = "en-US" },
+                    new() { Alias = "variantText", Value = "Danish content value", Culture = "da-DK" },
+                },
+                new List<BlockPropertyValue>(),
+                null,
+                null));
+
+        // exposed for English only, initially.
+        blockListValue.Expose = [new() { ContentKey = contentElementKey, Culture = "en-US" }];
+        var propertyValueJson = JsonSerializer.Serialize(blockListValue);
+        content.Properties["blocks"]!.SetValue(propertyValueJson);
+
+        // route the initial value through ContentEditingService.UpdateAsync (as the backoffice does) so the
+        // block values are canonically sorted before the first publish - this avoids an unrelated, pre-existing
+        // false-positive "edited" state caused by JSON key-ordering differences between the edited and
+        // published value (see Publishing_All_Cultures_Should_Not_Mark_Content_As_Edited above).
+        var updateModel = new ContentUpdateModel
+        {
+            Properties = [new PropertyValueModel { Alias = "blocks", Value = propertyValueJson }],
+            Variants =
+            [
+                new VariantModel { Name = content.GetCultureName("en-US")!, Culture = "en-US" },
+                new VariantModel { Name = content.GetCultureName("da-DK")!, Culture = "da-DK" },
+            ],
+        };
+        var updateResult = await ContentEditingService.UpdateAsync(content.Key, updateModel, Constants.Security.SuperUserKey);
+        Assert.IsTrue(updateResult.Success);
+
+        content = ContentService.GetById(content.Key)!;
+        PublishContent(content, contentType, ["en-US", "da-DK"]);
+
+        content = ContentService.GetById(content.Key)!;
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(content.IsCultureEdited("en-US"));
+            Assert.IsFalse(content.IsCultureEdited("da-DK"));
+        });
+
+        SetVariationContext("da-DK", null);
+        Assert.AreEqual(0, GetPublishedContent(content.Key).Value<BlockListModel>("blocks")!.Count, "The block is not yet exposed for Danish.");
+
+        // now also expose the same block for Danish - no block value changes at all.
+        blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue()!);
+        blockListValue.Expose =
+        [
+            new() { ContentKey = contentElementKey, Culture = "en-US" },
+            new() { ContentKey = contentElementKey, Culture = "da-DK" },
+        ];
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(content.IsCultureEdited("en-US"), "English exposure did not change and must not be flagged as edited.");
+            Assert.IsTrue(content.IsCultureEdited("da-DK"), "Danish exposure changed and must be flagged as edited.");
+        });
+
+        var results = ContentService.PublishBranch(content, PublishBranchFilter.Default, content.AvailableCultures.ToArray()).ToArray();
+
+        Assert.AreEqual(1, results.Length);
+        Assert.AreEqual(PublishResultType.SuccessPublishCulture, results[0].Result, "Branch publish must republish because Danish exposure changed.");
+
+        SetVariationContext("da-DK", null);
+        var blockListModel = GetPublishedContent(content.Key).Value<BlockListModel>("blocks");
+        Assert.AreEqual(1, blockListModel!.Count);
+        Assert.AreEqual("Danish content value", blockListModel.First().Content.Value<string>("variantText"));
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -2823,4 +2823,116 @@ internal partial class BlockListElementLevelVariationTests
         Assert.AreEqual(1, blockListModel!.Count);
         Assert.AreEqual("Danish content value", blockListModel.First().Content.Value<string>("variantText"));
     }
+
+    /// <summary>
+    /// A block containing an unchanged, culture-invariant nested Block List property must not cause the
+    /// default culture to be flagged as edited: only the culture whose value actually changed is an edit.
+    /// </summary>
+    [Test]
+    public async Task Editing_A_Non_Default_Culture_Block_Value_Alongside_An_Unchanged_Nested_Block_Flags_Only_That_Culture()
+    {
+        var nestedElementType = CreateElementType(ContentVariation.Culture, "myNestedElementType");
+        var nestedBlockListDataType = await CreateBlockListDataType(nestedElementType);
+
+        var rootElementType = new ContentTypeBuilder()
+            .WithAlias("myRootElementType")
+            .WithName("My Root Element Type")
+            .WithIsElement(true)
+            .WithContentVariation(ContentVariation.Culture)
+            .AddPropertyType()
+                .WithAlias("variantText")
+                .WithName("Variant text")
+                .WithDataTypeId(Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+                .WithValueStorageType(ValueStorageType.Nvarchar)
+                .WithVariations(ContentVariation.Culture)
+                .Done()
+            .AddPropertyType()
+                .WithAlias("nestedBlocks")
+                .WithName("Nested blocks")
+                .WithDataTypeId(nestedBlockListDataType.Id)
+                .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.BlockList)
+                .WithValueStorageType(ValueStorageType.Ntext)
+                .WithVariations(ContentVariation.Nothing)
+                .Done()
+            .Build();
+        await ContentTypeService.CreateAsync(rootElementType, Constants.Security.SuperUserKey);
+        var rootBlockListDataType = await CreateBlockListDataType(rootElementType);
+        var contentType = CreateContentType(ContentVariation.Culture, rootBlockListDataType);
+
+        var nestedElementContentKey = Guid.NewGuid();
+        var nestedElementSettingsKey = Guid.NewGuid();
+        var content = CreateContent(
+            contentType,
+            rootElementType,
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "variantText", Value = "Root content value in English", Culture = "en-US" },
+                new() { Alias = "variantText", Value = "Root content value in Danish", Culture = "da-DK" },
+                new()
+                {
+                    Alias = "nestedBlocks",
+                    Value = BlockListPropertyValue(
+                        nestedElementType,
+                        nestedElementContentKey,
+                        nestedElementSettingsKey,
+                        new BlockProperty(
+                            new List<BlockPropertyValue>
+                            {
+                                new() { Alias = "variantText", Value = "Nested English v1", Culture = "en-US" },
+                                new() { Alias = "variantText", Value = "Nested Danish v1", Culture = "da-DK" },
+                            },
+                            new List<BlockPropertyValue>(),
+                            null,
+                            null)),
+                },
+            },
+            [],
+            publishContent: false);
+
+        // Route the initial value through ContentEditingService.UpdateAsync (as the backoffice does) so the
+        // block values are canonically sorted and serialized before the first publish - this avoids an
+        // unrelated, pre-existing false-positive "edited" state caused by JSON differences between the edited
+        // and published value (see Publishing_All_Cultures_Should_Not_Mark_Content_As_Edited above).
+        var updateModel = new ContentUpdateModel
+        {
+            Properties = [new PropertyValueModel { Alias = "blocks", Value = (string)content.Properties["blocks"]!.GetValue()! }],
+            Variants =
+            [
+                new VariantModel { Name = content.GetCultureName("en-US")!, Culture = "en-US" },
+                new VariantModel { Name = content.GetCultureName("da-DK")!, Culture = "da-DK" },
+            ],
+        };
+        var updateResult = await ContentEditingService.UpdateAsync(content.Key, updateModel, Constants.Security.SuperUserKey);
+        Assert.IsTrue(updateResult.Success);
+
+        content = ContentService.GetById(content.Key)!;
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(content.IsCultureEdited("en-US"));
+            Assert.IsTrue(content.IsCultureEdited("da-DK"));
+        });
+        PublishContent(content, contentType, ["en-US", "da-DK"]);
+
+        content = ContentService.GetById(content.Key)!;
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(content.IsCultureEdited("en-US"));
+            Assert.IsFalse(content.IsCultureEdited("da-DK"));
+        });
+
+        // Change the Danish root value only - the invariant nested Block List property is left untouched.
+        var blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue()!);
+        blockListValue.ContentData[0].Values.Single(v => v.Alias == "variantText" && v.Culture == "da-DK").Value = "Root content value in Danish, v2";
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+
+        content = ContentService.GetById(content.Key)!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(content.IsCultureEdited("da-DK"), "Danish content changed and must be flagged as edited.");
+            Assert.IsFalse(content.IsCultureEdited("en-US"), "English content did not change and must not be flagged as edited.");
+        });
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/RichTextElementLevelVariationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/RichTextElementLevelVariationTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
@@ -737,6 +738,41 @@ internal sealed class RichTextElementLevelVariationTests : BlockEditorElementVar
             Assert.AreEqual("The invariant value", blocks[0].Content.Properties["invariantText"]);
             Assert.AreEqual(expectedVariantValue, blocks[0].Content.Properties["variantText"]);
         });
+    }
+
+    /// <summary>
+    /// When an invariant Rich Text property holds culture-variant block values, a change to only the
+    /// non-default culture's nested block value must be attributed to that specific culture - not the default
+    /// culture - so that culture-aware publishing (e.g. branch publish) knows it needs republishing. This
+    /// mirrors BlockListElementLevelVariationTests.Publishing.Editing_A_Non_Default_Culture_Block_Value_Flags_That_Culture_As_Edited,
+    /// proving the same behaviour for Rich Text's shared block-value implementation.
+    /// </summary>
+    /// <remarks>
+    /// This exercises <see cref="IDataEditor.GetChangedCulturesForPartialPropertyValues"/> directly rather than
+    /// through a full ContentService save/publish round-trip: unlike Block List/Grid, Rich Text's
+    /// <c>FromEditor</c> does not canonically sort nested block values by culture, so a full round-trip is not
+    /// order-stable and would make this assertion flaky for reasons unrelated to the behaviour under test.
+    /// </remarks>
+    [Test]
+    public async Task GetChangedCulturesForPartialPropertyValues_Flags_Only_The_Culture_With_An_Actual_Change()
+    {
+        var elementType = CreateElementType(ContentVariation.Culture);
+        var rteDataType = await CreateRichTextDataType(elementType);
+        var richTextValue = CreateRichTextValue(elementType);
+        var publishedJson = JsonSerializer.Serialize(richTextValue);
+
+        var editedValue = JsonSerializer.Deserialize<RichTextEditorValue>(publishedJson)!;
+        editedValue.Blocks!.ContentData[0].Values.Single(v => v.Alias == "variantText" && v.Culture == "da-DK").Value = "#1: The second content value in Danish";
+        var editedJson = JsonSerializer.Serialize(editedValue);
+
+        var dataEditor = rteDataType.Editor!;
+        var changedCultures = dataEditor.GetChangedCulturesForPartialPropertyValues(editedJson, publishedJson, "en-US").ToArray();
+
+        CollectionAssert.AreEquivalent(new[] { "da-DK" }, changedCultures);
+
+        // an unchanged value must not report any changed cultures at all.
+        var unchangedCultures = dataEditor.GetChangedCulturesForPartialPropertyValues(publishedJson, publishedJson, "en-US").ToArray();
+        Assert.IsEmpty(unchangedCultures);
     }
 
     private async Task<IDataType> CreateRichTextDataType(IContentType elementType)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/23549

### Description

On a culture-variant document with a culture-**invariant** Block List/Grid (or Rich Text with blocks, or Single Block) property whose element type is culture-**variant**, editing a non-default culture's block value (or exposure) and then publishing the document using **Publish with descendants** (branch publishing), the edited culture is silently skipped - even when explicitly selected. The document keeps reporting as `Published`/no pending changes, and the edited value never reaches the published property. A plain single-node publish of the same content works correctly, which is what makes this specific to branch publishing.

The root cause can be found in `PropertyFactory.BuildDtos`. It computes which culture(s) to flag as "edited" when a property's stored value changes. For an invariant property it always attributes the change to the site's default culture, with no awareness that the property's JSON blob might carry per-culture data nested inside blocks (property level variance). Branch publish (`ContentService.PublishBranch`) only ever republishes an already-published culture when it's flagged as edited, so a non-default-culture-only change is never picked up. Single-node `Publish` has no such gate (it republishes whatever cultures are explicitly requested), which is why it isn't affected.

To solve this, the data editors need to be able to signal any property level variance changes to the publishing chain. To this end, a new method has been added: `IDataEditor.GetChangedCulturesForPartialPropertyValues(sourceValue, targetValue)`. It's strictly opt-in  and default returns `[]` (non-breaking).

All concrete handling of this for block enabled editors happens in `BlockValuePropertyValueEditorBase`, by comparing content data, settings data, and block **exposure** per culture (including recursion into nested blocks-within-blocks). Block **layout** (ordering/grid placement) is intentionally left out of the diff and stays attributed to the default culture, since layout is invariant and shared across all cultures - but exposure is culture-specific, so toggling which cultures a block is exposed for is now correctly attributed.

`PropertyFactory.BuildDtos` now consults this method for invariant properties whose editor opts in, and performs fallback to the previous default-culture behaviour whenever the editor can't narrow it down (or doesn't opt in at all). In short; no behaviour change for any other property type.

### Testing this PR

_See also the [original issue](https://github.com/umbraco/Umbraco-CMS/issues/23549)._

1. Create a culture-variant document type with a culture-**invariant** Block List (or Grid/RichText-with-blocks/SingleBlock) property, using a culture-**variant** element type.
2. Publish a document of that type for two languages.
3. Edit only the non-default language's value inside a block and save.
4. Use **Publish with descendants**, selecting both languages.
5. Confirm the non-default language's published content now reflects the change.