### PR TITLE
Database: Specify the log file when creating a LocalDB database (closes #23852)

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/LocalDb.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/LocalDb.cs
@@ -1,6 +1,7 @@
-using System.Data;
+﻿using System.Data;
 using System.Diagnostics;
 using Microsoft.Data.SqlClient;
+using static Umbraco.Cms.Persistence.SqlServer.TSqlQuoting;
 
 namespace Umbraco.Cms.Persistence.SqlServer;
 
@@ -1065,33 +1066,6 @@ public class LocalDb
             p.WaitForExit();
 
             return p.ExitCode;
-        }
-    }
-
-    /// <summary>
-    ///     Returns a Unicode string with the delimiters added to make the input string a valid SQL Server delimited
-    ///     identifier.
-    /// </summary>
-    /// <param name="name">The name to quote.</param>
-    /// <param name="quote">A quote character.</param>
-    /// <returns></returns>
-    /// <remarks>
-    ///     This is a C# implementation of T-SQL QUOTEDNAME.
-    ///     <paramref name="quote" /> is optional, it can be '[' (default), ']', '\'' or '"'.
-    /// </remarks>
-    internal static string QuotedName(string name, char quote = '[')
-    {
-        switch (quote)
-        {
-            case '[':
-            case ']':
-                return "[" + name.Replace("]", "]]") + "]";
-            case '\'':
-                return "'" + name.Replace("'", "''") + "'";
-            case '"':
-                return "\"" + name.Replace("\"", "\"\"") + "\"";
-            default:
-                throw new NotSupportedException("Not a valid quote character.");
         }
     }
 

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseCreator.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseCreator.cs
@@ -1,29 +1,48 @@
-﻿using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Umbraco.Cms.Infrastructure.Persistence;
 using static Umbraco.Cms.Persistence.SqlServer.TSqlQuoting;
 
 namespace Umbraco.Cms.Persistence.SqlServer.Services;
 
+/// <summary>
+///     Implements <see cref="IDatabaseCreator" /> for SQL Server.
+/// </summary>
 public class SqlServerDatabaseCreator : IDatabaseCreator
 {
+    /// <inheritdoc />
     public string ProviderName => Constants.ProviderName;
 
+    /// <summary>
+    ///     Creates a SQL Server database, either from a data file or by name.
+    /// </summary>
+    /// <param name="connectionString">The connection string to use for creating the database.</param>
+    /// <remarks>
+    ///     <para>
+    ///         When the connection string carries an <c>AttachDbFilename</c> that does not yet exist, the database is
+    ///         created at that path and then detached, leaving the data and log files in place for the runtime to
+    ///         attach on demand. Otherwise a database is created by name, if one does not already exist.
+    ///     </para>
+    ///     <para>
+    ///         Neither statement can be parameterised, so every value is quoted with
+    ///         <see cref="TSqlQuoting.QuotedName" />.
+    ///     </para>
+    /// </remarks>
     public void Create(string connectionString)
     {
         var builder = new SqlConnectionStringBuilder(connectionString);
 
-        // Get connection string without database specific information
+        // Get connection string without database specific information.
         var masterBuilder = new SqlConnectionStringBuilder(builder.ConnectionString)
         {
             AttachDBFilename = string.Empty,
-            InitialCatalog = string.Empty
+            InitialCatalog = string.Empty,
         };
         var masterConnectionString = masterBuilder.ConnectionString;
 
         string fileName = builder.AttachDBFilename,
             database = builder.InitialCatalog;
 
-        // Create database
+        // Create database.
         if (!string.IsNullOrEmpty(fileName) && !File.Exists(fileName))
         {
             if (string.IsNullOrWhiteSpace(database))
@@ -32,12 +51,14 @@ public class SqlServerDatabaseCreator : IDatabaseCreator
                 database = "Umbraco-" + Guid.NewGuid();
             }
 
-            // Specify the log file explicitly rather than letting SQL Server derive it from the
-            // data file path. That derivation drops the directory separator in front of a directory
-            // whose name starts with a dot, so a data file in "C:\repo\.tools\Umbraco.mdf" yields
-            // the log file "C:\repo.tools\Umbraco_log.ldf", which fails with operating system error
-            // 3 because the directory does not exist. The name and location used here are the ones
-            // SQL Server derives itself for any path without such a directory.
+            // Specify the log file explicitly rather than letting SQL Server derive it from the data
+            // file path. That derivation mishandles dot segments: one starting with a single dot is
+            // merged into the segment before it, so "C:\repo\.tools" becomes "C:\repo.tools", and
+            // ".." consumes one segment too many. Where the resulting directory does not exist,
+            // creation fails with operating system error 3; where it happens to exist, creation
+            // succeeds and the log is written outside the data file's directory, leaving a database
+            // whose files are no longer together. Affected engines are 2017 and later, so a
+            // correctly derived path on an earlier one is not evidence that this is unnecessary.
             var logName = GetLogName(fileName);
             var logFileName = GetLogFileName(fileName);
 
@@ -84,11 +105,15 @@ public class SqlServerDatabaseCreator : IDatabaseCreator
         => Path.GetFileNameWithoutExtension(dataFileName) + "_log";
 
     /// <summary>
-    ///     Gets the log (LDF) file path SQL Server assigns to a database created from the specified
-    ///     data file, which sits next to the data file.
+    ///     Gets the log (LDF) file path for the specified data file, beside the data file.
     /// </summary>
     /// <param name="dataFileName">The data (MDF) file name.</param>
     /// <returns>The log file path, for example "C:\Data\Umbraco_log.ldf" for "C:\Data\Umbraco.mdf".</returns>
+    /// <remarks>
+    ///     This is where SQL Server places the log itself for the paths it derives correctly. Stating
+    ///     it explicitly avoids the derivation described in <see cref="Create" />, so this deliberately
+    ///     does not reproduce what SQL Server derives for the paths it gets wrong.
+    /// </remarks>
     internal static string GetLogFileName(string dataFileName)
     {
         var logFileName = GetLogName(dataFileName) + ".ldf";

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseCreator.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseCreator.cs
@@ -1,5 +1,6 @@
-using Microsoft.Data.SqlClient;
+﻿using Microsoft.Data.SqlClient;
 using Umbraco.Cms.Infrastructure.Persistence;
+using static Umbraco.Cms.Persistence.SqlServer.TSqlQuoting;
 
 namespace Umbraco.Cms.Persistence.SqlServer.Services;
 
@@ -44,10 +45,11 @@ public class SqlServerDatabaseCreator : IDatabaseCreator
             connection.Open();
 
             using var command = new SqlCommand(
-                $"CREATE DATABASE [{database}] ON (NAME='{database}', FILENAME='{fileName}') " +
-                $"LOG ON (NAME='{logName}', FILENAME='{logFileName}');" +
-                $"ALTER DATABASE [{database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;" +
-                $"EXEC sp_detach_db @dbname='{database}';",
+                $"CREATE DATABASE {QuotedName(database)} " +
+                $"ON (NAME=N{QuotedName(database, '\'')}, FILENAME=N{QuotedName(fileName, '\'')}) " +
+                $"LOG ON (NAME=N{QuotedName(logName, '\'')}, FILENAME=N{QuotedName(logFileName, '\'')});" +
+                $"ALTER DATABASE {QuotedName(database)} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;" +
+                $"EXEC sp_detach_db @dbname=N{QuotedName(database, '\'')};",
                 connection);
             command.ExecuteNonQuery();
 
@@ -59,8 +61,8 @@ public class SqlServerDatabaseCreator : IDatabaseCreator
             connection.Open();
 
             using var command = new SqlCommand(
-                $"IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = '{database}') " +
-                $"CREATE DATABASE [{database}];",
+                $"IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N{QuotedName(database, '\'')}) " +
+                $"CREATE DATABASE {QuotedName(database)};",
                 connection);
             command.ExecuteNonQuery();
 

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseCreator.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseCreator.cs
@@ -31,11 +31,21 @@ public class SqlServerDatabaseCreator : IDatabaseCreator
                 database = "Umbraco-" + Guid.NewGuid();
             }
 
+            // Specify the log file explicitly rather than letting SQL Server derive it from the
+            // data file path. That derivation drops the directory separator in front of a directory
+            // whose name starts with a dot, so a data file in "C:\repo\.tools\Umbraco.mdf" yields
+            // the log file "C:\repo.tools\Umbraco_log.ldf", which fails with operating system error
+            // 3 because the directory does not exist. The name and location used here are the ones
+            // SQL Server derives itself for any path without such a directory.
+            var logName = GetLogName(fileName);
+            var logFileName = GetLogFileName(fileName);
+
             using var connection = new SqlConnection(masterConnectionString);
             connection.Open();
 
             using var command = new SqlCommand(
-                $"CREATE DATABASE [{database}] ON (NAME='{database}', FILENAME='{fileName}');" +
+                $"CREATE DATABASE [{database}] ON (NAME='{database}', FILENAME='{fileName}') " +
+                $"LOG ON (NAME='{logName}', FILENAME='{logFileName}');" +
                 $"ALTER DATABASE [{database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;" +
                 $"EXEC sp_detach_db @dbname='{database}';",
                 connection);
@@ -56,5 +66,32 @@ public class SqlServerDatabaseCreator : IDatabaseCreator
 
             connection.Close();
         }
+    }
+
+    /// <summary>
+    ///     Gets the logical name SQL Server assigns to the log file of a database created from the
+    ///     specified data file.
+    /// </summary>
+    /// <param name="dataFileName">The data (MDF) file name.</param>
+    /// <returns>The logical log file name, for example "Umbraco_log" for "Umbraco.mdf".</returns>
+    /// <remarks>
+    ///     SQL Server derives this from the data file name rather than from the database name, and
+    ///     strips only the last extension, so "My.Site.mdf" becomes "My.Site_log".
+    /// </remarks>
+    internal static string GetLogName(string dataFileName)
+        => Path.GetFileNameWithoutExtension(dataFileName) + "_log";
+
+    /// <summary>
+    ///     Gets the log (LDF) file path SQL Server assigns to a database created from the specified
+    ///     data file, which sits next to the data file.
+    /// </summary>
+    /// <param name="dataFileName">The data (MDF) file name.</param>
+    /// <returns>The log file path, for example "C:\Data\Umbraco_log.ldf" for "C:\Data\Umbraco.mdf".</returns>
+    internal static string GetLogFileName(string dataFileName)
+    {
+        var logFileName = GetLogName(dataFileName) + ".ldf";
+        var directory = Path.GetDirectoryName(dataFileName);
+
+        return string.IsNullOrEmpty(directory) ? logFileName : Path.Combine(directory, logFileName);
     }
 }

--- a/src/Umbraco.Cms.Persistence.SqlServer/TSqlQuoting.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/TSqlQuoting.cs
@@ -1,0 +1,35 @@
+namespace Umbraco.Cms.Persistence.SqlServer;
+
+/// <summary>
+///     Quoting helpers for composing T-SQL statements that cannot be parameterised, such as
+///     <c>CREATE DATABASE</c>.
+/// </summary>
+internal static class TSqlQuoting
+{
+    /// <summary>
+    ///     Returns a Unicode string with the delimiters added to make the input string a valid SQL Server delimited
+    ///     identifier.
+    /// </summary>
+    /// <param name="name">The name to quote.</param>
+    /// <param name="quote">A quote character.</param>
+    /// <returns>The quoted name, with any embedded delimiter doubled.</returns>
+    /// <remarks>
+    ///     This is a C# implementation of T-SQL QUOTENAME.
+    ///     <paramref name="quote" /> is optional, it can be '[' (default), ']', '\'' or '"'.
+    /// </remarks>
+    internal static string QuotedName(string name, char quote = '[')
+    {
+        switch (quote)
+        {
+            case '[':
+            case ']':
+                return "[" + name.Replace("]", "]]") + "]";
+            case '\'':
+                return "'" + name.Replace("'", "''") + "'";
+            case '"':
+                return "\"" + name.Replace("\"", "\"\"") + "\"";
+            default:
+                throw new NotSupportedException("Not a valid quote character.");
+        }
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Testing/SqlServerTestDatabase.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/SqlServerTestDatabase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Umbraco.
+﻿// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using System.Collections.Concurrent;
@@ -11,6 +11,8 @@ using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Persistence.SqlServer;
 
 // ReSharper disable ConvertToUsingDeclaration
+using static Umbraco.Cms.Persistence.SqlServer.TSqlQuoting;
+
 namespace Umbraco.Cms.Tests.Integration.Testing;
 
 /// <remarks>
@@ -67,7 +69,7 @@ public class SqlServerTestDatabase : SqlServerBaseTestDatabase, ITestDatabase
             connection.Open();
             using (var command = connection.CreateCommand())
             {
-                SetCommand(command, $@"CREATE DATABASE {LocalDb.QuotedName(meta.Name)}");
+                SetCommand(command, $@"CREATE DATABASE {QuotedName(meta.Name)}");
                 command.ExecuteNonQuery();
             }
         }
@@ -88,13 +90,13 @@ public class SqlServerTestDatabase : SqlServerBaseTestDatabase, ITestDatabase
                 }
 
                 var sql = $@"
-                        ALTER DATABASE {LocalDb.QuotedName(meta.Name)}
+                        ALTER DATABASE {QuotedName(meta.Name)}
                         SET SINGLE_USER
                         WITH ROLLBACK IMMEDIATE";
                 SetCommand(command, sql);
                 command.ExecuteNonQuery();
 
-                SetCommand(command, $@"DROP DATABASE {LocalDb.QuotedName(meta.Name)}");
+                SetCommand(command, $@"DROP DATABASE {QuotedName(meta.Name)}");
                 command.ExecuteNonQuery();
             }
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerDatabaseCreatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerDatabaseCreatorTests.cs
@@ -45,6 +45,22 @@ public class SqlServerDatabaseCreatorTests
     }
 
     [Test]
+    public void Can_Derive_The_Log_File_Beside_The_Data_File_When_The_Path_Contains_A_Parent_Segment()
+    {
+        // SQL Server's own derivation consumes one segment too many here, resolving the log of
+        // "repo\a\..\b\Umbraco.mdf" to "repo\Umbraco_log.ldf" rather than "repo\b\Umbraco_log.ldf".
+        // The rule the derivation has to uphold is that the log sits in the same directory as the
+        // data file, whatever dot segments the path happens to contain.
+        var dataFileName = Path.Combine("repo", "a", "..", "b", "Umbraco.mdf");
+
+        var logFileName = SqlServerDatabaseCreator.GetLogFileName(dataFileName);
+
+        Assert.AreEqual(
+            Path.GetDirectoryName(Path.GetFullPath(dataFileName)),
+            Path.GetDirectoryName(Path.GetFullPath(logFileName)));
+    }
+
+    [Test]
     public void Can_Derive_The_Log_File_When_The_Data_File_Has_No_Directory()
         => Assert.AreEqual("Umbraco_log.ldf", SqlServerDatabaseCreator.GetLogFileName("Umbraco.mdf"));
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerDatabaseCreatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerDatabaseCreatorTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
+
+[TestFixture]
+public class SqlServerDatabaseCreatorTests
+{
+    // The expected values below are the names SQL Server itself derives when CREATE DATABASE
+    // specifies only a data file, verified against SQL Server 2019 and 2025 LocalDB. The log file
+    // is named after the data file rather than the database, and only the last extension is
+    // stripped, whatever that extension is.
+    [Test]
+    [TestCase("Umbraco.mdf", ExpectedResult = "Umbraco_log")]
+    [TestCase("Umbraco.MDF", ExpectedResult = "Umbraco_log")]
+    [TestCase("Umbraco.data", ExpectedResult = "Umbraco_log")]
+    [TestCase("Umbraco", ExpectedResult = "Umbraco_log")]
+    [TestCase("My.Site.mdf", ExpectedResult = "My.Site_log")]
+    [TestCase(".mdf", ExpectedResult = "_log")]
+    public string Can_Derive_The_Log_Name_Sql_Server_Would_Derive(string dataFileName)
+        => SqlServerDatabaseCreator.GetLogName(dataFileName);
+
+    [Test]
+    public void Can_Derive_The_Log_File_Next_To_The_Data_File()
+    {
+        var dataFileName = Path.Combine("umbraco", "Data", "Umbraco.mdf");
+
+        Assert.AreEqual(
+            Path.Combine("umbraco", "Data", "Umbraco_log.ldf"),
+            SqlServerDatabaseCreator.GetLogFileName(dataFileName));
+    }
+
+    [Test]
+    public void Can_Derive_The_Log_File_In_A_Directory_Whose_Name_Starts_With_A_Dot()
+    {
+        // SQL Server's own derivation drops the separator in front of ".tools" here, which is why
+        // the log file is specified explicitly: it would otherwise resolve to a "repo.tools"
+        // directory that does not exist, and CREATE DATABASE would fail with operating system
+        // error 3.
+        var dataFileName = Path.Combine("repo", ".tools", "wt", "umbraco", "Data", "Umbraco.mdf");
+
+        Assert.AreEqual(
+            Path.Combine("repo", ".tools", "wt", "umbraco", "Data", "Umbraco_log.ldf"),
+            SqlServerDatabaseCreator.GetLogFileName(dataFileName));
+    }
+
+    [Test]
+    public void Can_Derive_The_Log_File_When_The_Data_File_Has_No_Directory()
+        => Assert.AreEqual("Umbraco_log.ldf", SqlServerDatabaseCreator.GetLogFileName("Umbraco.mdf"));
+
+    [Test]
+    public void Can_Derive_A_Log_File_Whose_Name_Matches_The_Log_Name()
+    {
+        // The two are used together in a single CREATE DATABASE statement, so they must agree.
+        var dataFileName = Path.Combine("umbraco", "Data", "My.Site.mdf");
+
+        Assert.AreEqual(
+            SqlServerDatabaseCreator.GetLogName(dataFileName) + ".ldf",
+            Path.GetFileName(SqlServerDatabaseCreator.GetLogFileName(dataFileName)));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/TSqlQuotingTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/TSqlQuotingTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using Umbraco.Cms.Persistence.SqlServer;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
+
+[TestFixture]
+public class TSqlQuotingTests
+{
+    [Test]
+    [TestCase("Umbraco", ExpectedResult = "[Umbraco]")]
+    [TestCase("Umbraco-7b1e4f0c", ExpectedResult = "[Umbraco-7b1e4f0c]")]
+    [TestCase("", ExpectedResult = "[]")]
+    [TestCase("a b", ExpectedResult = "[a b]")]
+    public string Can_Quote_An_Identifier_By_Default(string name)
+        => TSqlQuoting.QuotedName(name);
+
+    [Test]
+    [TestCase('[')]
+    [TestCase(']')]
+    public void Can_Quote_An_Identifier_With_Either_Bracket(char quote)
+        => Assert.AreEqual("[Umbraco]", TSqlQuoting.QuotedName("Umbraco", quote));
+
+    [Test]
+    [TestCase("a]b", ExpectedResult = "[a]]b]")]
+    [TestCase("a]]b", ExpectedResult = "[a]]]]b]")]
+    [TestCase("]", ExpectedResult = "[]]]")]
+    public string Can_Escape_A_Closing_Bracket_In_An_Identifier(string name)
+        => TSqlQuoting.QuotedName(name);
+
+    [Test]
+    [TestCase(@"C:\Data\Umbraco.mdf", ExpectedResult = @"'C:\Data\Umbraco.mdf'")]
+    [TestCase("", ExpectedResult = "''")]
+    public string Can_Quote_A_String_Literal(string name)
+        => TSqlQuoting.QuotedName(name, '\'');
+
+    [Test]
+    [TestCase(@"C:\Bob's Site\Umbraco.mdf", ExpectedResult = @"'C:\Bob''s Site\Umbraco.mdf'")]
+    [TestCase("''", ExpectedResult = "''''''")]
+    [TestCase("'", ExpectedResult = "''''")]
+    public string Can_Escape_An_Apostrophe_In_A_String_Literal(string name)
+        => TSqlQuoting.QuotedName(name, '\'');
+
+    [Test]
+    [TestCase("Umbraco", ExpectedResult = "\"Umbraco\"")]
+    [TestCase("a\"b", ExpectedResult = "\"a\"\"b\"")]
+    public string Can_Quote_And_Escape_A_Double_Quoted_Name(string name)
+        => TSqlQuoting.QuotedName(name, '"');
+
+    // Each quote style escapes only its own delimiter, so a name carrying the others passes through
+    // untouched. Escaping the wrong one would corrupt file paths, which legitimately contain both.
+    [Test]
+    [TestCase("a'b", ExpectedResult = "[a'b]")]
+    [TestCase("a\"b", ExpectedResult = "[a\"b]")]
+    public string Can_Leave_Other_Delimiters_Alone_When_Quoting_An_Identifier(string name)
+        => TSqlQuoting.QuotedName(name);
+
+    [Test]
+    [TestCase("a]b", ExpectedResult = "'a]b'")]
+    [TestCase("a\"b", ExpectedResult = "'a\"b'")]
+    public string Can_Leave_Other_Delimiters_Alone_When_Quoting_A_String_Literal(string name)
+        => TSqlQuoting.QuotedName(name, '\'');
+
+    [Test]
+    [TestCase('`')]
+    [TestCase('(')]
+    [TestCase(' ')]
+    public void Cannot_Quote_With_An_Unsupported_Character(char quote)
+        => Assert.Throws<NotSupportedException>(() => TSqlQuoting.QuotedName("Umbraco", quote));
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23852

### Description

`SqlServerDatabaseCreator.Create` builds its `CREATE DATABASE` with a data file only, leaving SQL Server to derive the log file path from it. That derivation drops the directory separator in front of a directory whose name starts with a dot, so a data file at:

```
C:\repo\.tools\src\Site\umbraco\Data\Umbraco.mdf
```

gets its log file resolved to:

```
C:\repo.tools\src\Site\umbraco\Data\Umbraco_log.ldf
```

That directory does not exist, so creation fails and unattended install terminates:

```
Microsoft.Data.SqlClient.SqlException (0x80131904): CREATE FILE encountered operating system
error 3(The system cannot find the path specified.) while attempting to open or create the
physical file 'C:\repo.tools\src\Site\umbraco\Data\Umbraco_log.ldf'.
CREATE DATABASE failed. Some file names listed could not be created. Check related errors.
   at Umbraco.Cms.Persistence.SqlServer.Services.SqlServerDatabaseCreator.Create(String connectionString)
   at Umbraco.Cms.Infrastructure.Persistence.DbProviderFactoryCreator.CreateDatabase(String providerName, String connectionString)
   at Umbraco.Cms.Infrastructure.Install.UnattendedInstaller.HandleAsync(RuntimeUnattendedInstallNotification notification, CancellationToken cancellationToken)
```

The site can then only be installed by copying an existing `.mdf` into place. That works because with the file present `Create` matches neither branch (`fileName` is non-empty but exists, `InitialCatalog` is empty), so no `CREATE DATABASE` runs and no log path is derived. Attach uses the data file path verbatim and is unaffected, which is why only creation is broken.

Anyone whose project sits under a dot-prefixed directory hits this. It is increasingly common: Claude Code places its git worktrees at `<repo>/.claude/worktrees/<name>/`, and conventions like `.worktrees/`, `.tools/` and `.src/` do the same. Nothing about the path length or the `.mdf` itself is involved, only the dot-prefixed directory.

#### The fix

The statement now carries an explicit `LOG ON` clause, so nothing depends on SQL Server's derivation:

```csharp
$"CREATE DATABASE [{database}] ON (NAME='{database}', FILENAME='{fileName}') " +
$"LOG ON (NAME='{logName}', FILENAME='{logFileName}');" +
```

The name and location are the ones SQL Server derives itself, established by measuring it rather than assuming. Two details drove the implementation:

1. The log's logical name comes from the **data file** name, not the database name. `Umbraco.mdf` yields `Umbraco_log` even though the database is `Umbraco-<guid>`. Using `{database}_log` would have silently changed it.
2. Only the last extension is stripped, whatever it is. So `Umbraco.MDF`, `Umbraco.data` and extensionless `Umbraco` all yield `Umbraco_log`, and `My.Site.mdf` yields `My.Site_log`. `Path.GetFileNameWithoutExtension` matches this exactly, which is why `LocalDb.GetLogFilename` is deliberately not reused: it throws unless the name ends in `.mdf` and strips exactly `.mdf`.

`LOG ON (FILENAME=...)` without `NAME` is not an option, as SQL Server rejects it with `File option NAME is required in this CREATE/ALTER DATABASE statement`.

This is not a new pattern in the codebase. `LocalDb`, in the same assembly, already specifies `LOG ON (NAME=..., FILENAME=...)` in both of its `CREATE DATABASE` statements, using the same `_log` and `_log.ldf` convention. This aligns `SqlServerDatabaseCreator` with its neighbour.

#### No behavioural change for any other path

The derivation was compared against SQL Server's implicit behaviour on logical name, physical name, size, growth, `is_percent_growth` and max size, for every case I could construct:

| Data file | Path without a dot-directory | Path with a dot-directory |
|---|---|---|
| `Umbraco.mdf`, `Umbraco.MDF`, `Umbraco.data`, `Umbraco`, `My.Site.mdf`, `.mdf` | identical | fixed |
| relative bare filename | identical, both rejected by SQL Server | n/a |
| forward-slash path | identical, both rejected | identical, both rejected |
| logical log name colliding with the data file's | identical, both fail with the same message | n/a |
| directory that does not exist | identical, same message naming the same file | n/a |

Specifying `LOG ON` without `SIZE` or `FILEGROWTH` does not change the log file's characteristics: 1024 pages, growth 8192, max 268435456 in every case, before and after.

Verified on both SQL Server 2019 LocalDB (15.0.4382.1) and SQL Server 2025 LocalDB (17.0.4025.3), which behave the same.

There is no public API change. The two helpers are `internal static`, testable through the `InternalsVisibleTo Umbraco.Tests.UnitTests` this project already declares. They could be inlined into `Create` if reviewers prefer a smaller class, at the cost of the unit tests.

### Testing

#### Automated

`SqlServerDatabaseCreatorTests` covers the derivation, 10 cases pinning the exact names SQL Server produces, including the awkward extensions and a data file with no directory. Paths are built with `Path.Combine` rather than literal separators, since the unit suite also runs on Linux and macOS.

- New tests: 10 passed
- Full unit suite after the change: 6794 passed, 0 failed, 6 skipped

No existing tests needed updating. Nothing referenced `SqlServerDatabaseCreator` outside its DI registration, and it had no tests before.

#### Manual

I also ran the compiled `Create` against a throwaway LocalDB instance for a `.claude` path and a plain path. Both created `Umbraco.mdf` plus `Umbraco_log.ldf` and then attached successfully, confirming the composed SQL is valid and that the runtime's `AttachDbFilename` connection still works afterwards.

To reproduce the original failure and confirm the fix on a clean install:

1. Create a directory whose name starts with a dot and scaffold a site inside it:

   ```
   mkdir C:\src\.wt
   cd C:\src\.wt
   dotnet new umbraco -n MySite
   ```

2. Point it at LocalDB in `MySite/appsettings.Development.json`:

   ```json
   {
     "ConnectionStrings": {
       "umbracoDbDSN": "Data Source=(localdb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\Umbraco.mdf;Integrated Security=True",
       "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
     },
     "Umbraco": {
       "CMS": {
         "Unattended": {
           "InstallUnattended": true,
           "UnattendedUserName": "Admin",
           "UnattendedUserEmail": "admin@example.test",
           "UnattendedUserPassword": "test123456!"
         }
       }
     }
   }
   ```

3. Make sure `MySite/umbraco/Data/Umbraco.mdf` does not exist, then `dotnet run --project MySite`.

Before this change the boot terminates with the error above. After it, the database is created and the install completes. Running the same steps in `C:\src\wt\MySite` rather than `C:\src\.wt\MySite` succeeds either way, which isolates the dot-prefixed directory as the trigger.