### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
     <PackageVersion Include="Examine" Version="3.10.0" />
     <PackageVersion Include="Examine.Core" Version="3.10.0" />
-    <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageVersion Include="HtmlAgilityPack" Version="1.13.0" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
@@ -58,8 +58,8 @@
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
     <PackageVersion Include="MiniProfiler.Shared" Version="4.5.4" />
     <PackageVersion Include="ncrontab" Version="3.4.0" />
-    <PackageVersion Include="NPoco" Version="6.2.0" />
-    <PackageVersion Include="NPoco.SqlServer" Version="6.2.0" />
+    <PackageVersion Include="NPoco" Version="6.3.0" />
+    <PackageVersion Include="NPoco.SqlServer" Version="6.3.0" />
     <PackageVersion Include="OpenIddict.Abstractions" Version="7.6.1" />
     <PackageVersion Include="OpenIddict.AspNetCore" Version="7.6.1" />
     <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.6.1" />

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -122,7 +122,7 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
             .ToArray();
 
         var tag = TagName(element);
-        var attributes = element.Attributes.ToDictionary(a => a.Name, a => a.Value as object);
+        var attributes = element.Attributes.ToDictionary(a => a.Name, a => (object)(a.Value ?? string.Empty));
 
         ReplaceLocalLinks(contentCache, mediaCache, attributes);
 

--- a/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
@@ -72,7 +72,7 @@ public sealed partial class HtmlStringUtilities
             foreach (HtmlNode target in CollectionsMarshal.AsSpan(targets))
             {
                 HtmlNode content = doc.CreateTextNode(target.InnerHtml + " ");
-                target.ParentNode.ReplaceChild(content, target);
+                target.ParentNode!.ReplaceChild(content, target);
             }
         }
         else


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Routine dependency maintenance for the **17.8** release line. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

#### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| HtmlAgilityPack | 1.12.4 | 1.13.0 |
| NPoco | 6.2.0 | 6.3.0 |
| NPoco.SqlServer | 6.2.0 | 6.3.0 |

#### Test packages (`tests/Directory.Packages.props`)

No changes needed — nothing outdated in the test-only package set.

#### Inline / template versions

- `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: no change needed.
- `templates/UmbracoExtension`: no change needed (none of the bumped packages are referenced there).

#### Deliberately left unchanged

- `Microsoft.OpenApi` (currently outdated to 2.12.2) is explicitly marked **HOLD at 2.9.0 - do not bump** in `Directory.Packages.props`: versions 2.10.0+ have a confirmed regression in OpenAPI 3.0 nullability serialization that corrupts the generated Delivery API 3.0 contract. Left untouched per that comment.
- Any package where only a **major** update is available (out of scope for this PR).

#### Required source fix

`HtmlAgilityPack` 1.13.0 adds nullable reference annotations that were not present in 1.12.4 (`HtmlAttribute.Value` and `HtmlNode.ParentNode` are now `string?` / `HtmlNode?`). This broke the build with `CS8620`/`CS8602` in two call sites, both fixed to match the new annotations without changing behaviour:
- `src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs`: coerce a possibly-null attribute value to `string.Empty` before boxing, preserving the existing non-null `Dictionary<string, object>` contract.
- `src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs`: null-forgiving on `ParentNode` for nodes matched by the `.//*` XPath query, which can never be the document root and therefore always have a parent.

## Testing

Solution builds in Release and the unit test suite passes; CI checks are the source of truth.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LuQeQTteq8QHNcRseisJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018LuQeQTteq8QHNcRseisJZ)_