### PR TITLE
Trees: Remove the debounce delaying tree active-state updates after navigation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts
@@ -1,7 +1,6 @@
 import { customElement, html, ifDefined, property, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { ensureSlash } from '@umbraco-cms/backoffice/router';
-import { debounce } from '@umbraco-cms/backoffice/utils';
 import { UmbEntityContext } from '@umbraco-cms/backoffice/entity';
 
 /**
@@ -67,10 +66,12 @@ export class UmbMenuItemLayoutElement extends UmbLitElement {
 
 	override connectedCallback() {
 		super.connectedCallback();
-		window.addEventListener('navigationend', this.#debouncedCheckIsActive);
+		window.addEventListener('navigationend', this.#onNavigationEnd);
 	}
 
-	#debouncedCheckIsActive = debounce(() => this.#checkIsActive(), 100);
+	// history.pushState runs synchronously before any router-slot dispatches this event, so the location
+	// is already final on the first firing — no need to coalesce repeat firings from nested router-slots.
+	#onNavigationEnd = () => this.#checkIsActive();
 
 	#checkIsActive() {
 		if (!this.href) {
@@ -107,7 +108,7 @@ export class UmbMenuItemLayoutElement extends UmbLitElement {
 
 	override disconnectedCallback() {
 		super.disconnectedCallback();
-		window.removeEventListener('navigationend', this.#debouncedCheckIsActive);
+		window.removeEventListener('navigationend', this.#onNavigationEnd);
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/active-manager/tree-active-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/active-manager/tree-active-manager.ts
@@ -6,7 +6,7 @@ import {
 	type Observable,
 } from '@umbraco-cms/backoffice/observable-api';
 import { ensureSlash } from '@umbraco-cms/backoffice/router';
-import { debounce, UmbDeprecation } from '@umbraco-cms/backoffice/utils';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 
 /**
@@ -41,7 +41,9 @@ export class UmbTreeItemActiveManager extends UmbControllerBase {
 
 	// One listener per tree rather than one per tree item: every item asks the same question of the
 	// same answer, and a tree scoped source is released together with the items observing it.
-	#onNavigationEnd = debounce(() => this.#currentLocation.setValue(window.location.pathname), 100);
+	// history.pushState runs synchronously before any router-slot dispatches this event, so the location
+	// is already final on the first firing — no need to coalesce repeat firings from nested router-slots.
+	#onNavigationEnd = () => this.#currentLocation.setValue(window.location.pathname);
 
 	override hostConnected(): void {
 		super.hostConnected();
@@ -52,7 +54,6 @@ export class UmbTreeItemActiveManager extends UmbControllerBase {
 	override hostDisconnected(): void {
 		super.hostDisconnected();
 		window.removeEventListener('navigationend', this.#onNavigationEnd);
-		this.#onNavigationEnd.cancel();
 	}
 
 	/**


### PR DESCRIPTION
### Description

The tree's active-state highlighting (which tree item shows as "active" as you navigate) lagged behind navigation by up to 100ms, because `UmbTreeItemActiveManager` debounced the `navigationend` listener that updates
the current location before any tree item re-evaluates its active state.

The debounce only added latency, with nothing to coalesce that wasn't already going to collapse to one update on its own. The listener now updates the current location directly on `navigationend`.

**How to test:**
1. Open the Content section with a few nodes in the tree.
2. Click between different tree items.
3. Confirm the active (highlighted) tree item updates immediately on navigation, with no perceptible delay.