### PR TITLE
Backoffice Section Menu: Do not expand the parent tree item when creating

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -65,6 +65,7 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 		};
 
 		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setIsNew(false);
 		workspaceContext.setUnique('test-unique');
 		await aTimeout(150);
 	});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -1,11 +1,13 @@
 import { UmbMenuTreeStructureWorkspaceContextBase } from './menu-tree-structure-workspace-context-base.js';
 import {
 	UmbTestMenuStructureControllerHostElement,
+	UmbTestSectionSidebarMenuContext,
 	UmbTestSubmittableTreeEntityWorkspaceContext,
 	UmbTestTreeRepository,
 	createTestAncestorItem,
 	createTestTreeRepositoryManifest,
 } from './menu-tree-structure-workspace-context.test-utils.js';
+import { UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT } from './section-sidebar-menu/index.js';
 import { UMB_ANCESTORS_ENTITY_CONTEXT, UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
 import { aTimeout, expect } from '@open-wc/testing';
 import { UmbActionEventContext } from '@umbraco-cms/backoffice/action';
@@ -39,6 +41,7 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 
 	beforeEach(async () => {
 		UmbTestTreeRepository.reset();
+		UmbTestSectionSidebarMenuContext.reset();
 
 		host = new UmbTestMenuStructureControllerHostElement();
 		document.body.appendChild(host);
@@ -46,8 +49,20 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 		actionEventContext = new UmbActionEventContext(host);
 		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
 		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
+		new UmbContextProviderController(
+			host,
+			UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT,
+			new UmbTestSectionSidebarMenuContext(host) as never,
+		);
 
 		context = new TestMenuTreeStructureWorkspaceContext(host);
+		context.manifest = {
+			type: 'workspaceContext',
+			kind: 'menuStructure',
+			alias: 'Umb.Test.MenuStructureWorkspaceContext',
+			name: 'Test Menu Structure Workspace Context',
+			meta: { menuItemAlias: 'test-menu-item' },
+		};
 
 		workspaceContext.setEntityType('test-entity-type');
 		workspaceContext.setUnique('test-unique');
@@ -182,6 +197,12 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 		});
 	});
 
+	describe('expanding the sidebar menu', () => {
+		it('expands the resolved parent when opening an existing item', async () => {
+			expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
+		});
+	});
+
 	describe('destroy', () => {
 		it('stops reacting to reload-structure events once destroyed', async () => {
 			context.destroy();
@@ -194,5 +215,68 @@ describe('UmbMenuTreeStructureWorkspaceContextBase', () => {
 
 			expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
 		});
+	});
+});
+
+describe('UmbMenuTreeStructureWorkspaceContextBase (creating a new item)', () => {
+	let host: UmbTestMenuStructureControllerHostElement;
+	let workspaceContext: UmbTestSubmittableTreeEntityWorkspaceContext;
+	let context: TestMenuTreeStructureWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.register(createTestTreeRepositoryManifest(TEST_TREE_REPOSITORY_ALIAS));
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregister(TEST_TREE_REPOSITORY_ALIAS);
+	});
+
+	beforeEach(async () => {
+		UmbTestTreeRepository.reset();
+		UmbTestSectionSidebarMenuContext.reset();
+
+		host = new UmbTestMenuStructureControllerHostElement();
+		document.body.appendChild(host);
+
+		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
+		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
+		new UmbContextProviderController(
+			host,
+			UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT,
+			new UmbTestSectionSidebarMenuContext(host) as never,
+		);
+
+		context = new TestMenuTreeStructureWorkspaceContext(host);
+		context.manifest = {
+			type: 'workspaceContext',
+			kind: 'menuStructure',
+			alias: 'Umb.Test.MenuStructureWorkspaceContext.Create',
+			name: 'Test Menu Structure Workspace Context (create)',
+			meta: { menuItemAlias: 'test-menu-item' },
+		};
+
+		// Simulate opening a "Create X under Y" workspace before any save: isNew is already true,
+		// and the item already has a client-generated unique.
+		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setIsNew(true);
+		workspaceContext.setCreateUnderParent({ unique: 'parent-unique', entityType: 'test-entity-type' });
+		workspaceContext.setUnique('new-item-unique');
+		await aTimeout(150);
+	});
+
+	afterEach(() => {
+		context.destroy();
+		document.body.removeChild(host);
+	});
+
+	it('does not expand the parent while the workspace is still in create mode', async () => {
+		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(0);
+	});
+
+	it('expands the parent once the item has been saved', async () => {
+		workspaceContext.setIsNew(false);
+		await aTimeout(150);
+
+		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -281,3 +281,68 @@ describe('UmbMenuTreeStructureWorkspaceContextBase (creating a new item)', () =>
 		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
 	});
 });
+
+describe('UmbMenuTreeStructureWorkspaceContextBase (isNew resolves after the structure has already loaded)', () => {
+	let host: UmbTestMenuStructureControllerHostElement;
+	let workspaceContext: UmbTestSubmittableTreeEntityWorkspaceContext;
+	let context: TestMenuTreeStructureWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.register(createTestTreeRepositoryManifest(TEST_TREE_REPOSITORY_ALIAS));
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregister(TEST_TREE_REPOSITORY_ALIAS);
+	});
+
+	beforeEach(async () => {
+		UmbTestTreeRepository.reset();
+		UmbTestSectionSidebarMenuContext.reset();
+
+		host = new UmbTestMenuStructureControllerHostElement();
+		document.body.appendChild(host);
+
+		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
+		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
+		new UmbContextProviderController(
+			host,
+			UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT,
+			new UmbTestSectionSidebarMenuContext(host) as never,
+		);
+
+		context = new TestMenuTreeStructureWorkspaceContext(host);
+		context.manifest = {
+			type: 'workspaceContext',
+			kind: 'menuStructure',
+			alias: 'Umb.Test.MenuStructureWorkspaceContext.Race',
+			name: 'Test Menu Structure Workspace Context (isNew resolves late)',
+			meta: { menuItemAlias: 'test-menu-item' },
+		};
+
+		// A workspace context that publishes `unique` before `isNew` has resolved (e.g. a slow detail request) -
+		// the structure fetch runs and completes while `isNew` is still undefined.
+		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setUnique('test-unique');
+		await aTimeout(150);
+	});
+
+	afterEach(() => {
+		context.destroy();
+		document.body.removeChild(host);
+	});
+
+	it('fetches the structure but does not expand while isNew is still unresolved', async () => {
+		expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
+		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(0);
+	});
+
+	it('expands once isNew resolves to false, without re-fetching the structure', async () => {
+		const requestCountBeforeIsNewResolves = UmbTestTreeRepository.requestTreeItemAncestorsCalls.length;
+
+		workspaceContext.setIsNew(false);
+		await aTimeout(150);
+
+		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
+		expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(requestCountBeforeIsNewResolves);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -199,8 +199,9 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		this.#structure.setValue(structureItems);
 		this.#setParentData(structureItems);
 
+		// Don't expand the parent for an item that hasn't been created yet.
 		const menuItemAlias = this.manifest?.meta?.menuItemAlias;
-		if (menuItemAlias && !this.#isModalContext) {
+		if (menuItemAlias && !this.#isModalContext && !isNew) {
 			this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 		}
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -201,7 +201,7 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 
 		// Don't expand the parent for an item that hasn't been created yet.
 		const menuItemAlias = this.manifest?.meta?.menuItemAlias;
-		if (menuItemAlias && !this.#isModalContext && !isNew) {
+		if (menuItemAlias && !this.#isModalContext && isNew === false) {
 			this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 		}
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -37,7 +37,6 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 	#ancestorContext = new UmbAncestorsEntityContext(this);
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
 	#isModalContext: boolean = false;
-	#isNew: boolean | undefined = undefined;
 	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 	#structureRequestId = 0;
 
@@ -77,15 +76,15 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 				'observeUnique',
 			);
 
+			// isNew is observed on its own, separate from the structure fetch, so the expand decision never
+			// depends on which of the two happens to settle first: whichever settles last (isNew resolving to
+			// false, or the structure fetch resolving) is the one that actually triggers the expand.
 			this.observe(
 				this.#workspaceContext?.isNew,
-				(value) => {
-					// Workspace has changed from new to existing
-					if (value === false && this.#isNew === true) {
-						// TODO: We do not need to request here as we already know the structure and unique
-						this.#requestStructure();
+				(isNew) => {
+					if (isNew === false) {
+						this.#tryExpandSectionSidebarMenu();
 					}
-					this.#isNew = value;
 				},
 				'observeIsNew',
 			);
@@ -199,11 +198,25 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		this.#structure.setValue(structureItems);
 		this.#setParentData(structureItems);
 
-		// Don't expand the parent for an item that hasn't been created yet.
+		this.#tryExpandSectionSidebarMenu();
+	}
+
+	/**
+	 * Expands the parent in the section sidebar menu, but only once we know for certain the item isn't still being
+	 * created, and only once the structure has actually been fetched. Reads both conditions fresh, so it's safe to
+	 * call from either the structure-fetch completion or the isNew observer, whichever settles last.
+	 */
+	#tryExpandSectionSidebarMenu() {
 		const menuItemAlias = this.manifest?.meta?.menuItemAlias;
-		if (menuItemAlias && !this.#isModalContext && isNew === false) {
-			this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
-		}
+		if (!menuItemAlias || this.#isModalContext) return;
+
+		// Don't expand the parent for an item that hasn't been created yet.
+		if (this.#workspaceContext?.getIsNew() !== false) return;
+
+		const structureItems = this.#structure.getValue();
+		if (!structureItems.length) return;
+
+		this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 	}
 
 	#clearStructure() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context.test-utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context.test-utils.ts
@@ -127,3 +127,31 @@ export function createTestAncestorItem(entity: UmbEntityModel, name = entity.uni
 		parent: { unique: null, entityType: 'test-root-entity-type' },
 	} as unknown as UmbTreeItemModel;
 }
+
+/**
+ * A minimal `UmbSectionSidebarMenuSectionContext` stand-in. It only implements `expansion.expandItems`,
+ * recording each call so a test can check whether — and how often — the parent tree item was expanded.
+ */
+export class UmbTestSectionSidebarMenuContext {
+	static expandItemsCalls: Array<unknown> = [];
+
+	static reset() {
+		UmbTestSectionSidebarMenuContext.expandItemsCalls = [];
+	}
+
+	#host: UmbControllerHost;
+
+	readonly expansion = {
+		expandItems: (entries: unknown) => {
+			UmbTestSectionSidebarMenuContext.expandItemsCalls.push(entries);
+		},
+	};
+
+	constructor(host: UmbControllerHost) {
+		this.#host = host;
+	}
+
+	getHostElement() {
+		return this.#host.getHostElement();
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -281,3 +281,68 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase (creating a new item)'
 		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
 	});
 });
+
+describe('UmbMenuVariantTreeStructureWorkspaceContextBase (isNew resolves after the structure has already loaded)', () => {
+	let host: UmbTestMenuVariantStructureControllerHostElement;
+	let workspaceContext: UmbTestSubmittableTreeEntityWorkspaceContext;
+	let context: TestMenuVariantTreeStructureWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.register(createTestVariantTreeRepositoryManifest(TEST_TREE_REPOSITORY_ALIAS));
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregister(TEST_TREE_REPOSITORY_ALIAS);
+	});
+
+	beforeEach(async () => {
+		UmbTestVariantTreeRepository.reset();
+		UmbTestSectionSidebarMenuContext.reset();
+
+		host = new UmbTestMenuVariantStructureControllerHostElement();
+		document.body.appendChild(host);
+
+		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
+		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
+		new UmbContextProviderController(
+			host,
+			UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT,
+			new UmbTestSectionSidebarMenuContext(host) as never,
+		);
+
+		context = new TestMenuVariantTreeStructureWorkspaceContext(host);
+		context.manifest = {
+			type: 'workspaceContext',
+			kind: 'menuStructure',
+			alias: 'Umb.Test.MenuVariantStructureWorkspaceContext.Race',
+			name: 'Test Menu Variant Structure Workspace Context (isNew resolves late)',
+			meta: { menuItemAlias: 'test-menu-item' },
+		};
+
+		// A workspace context that publishes `unique` before `isNew` has resolved (e.g. a slow detail request) -
+		// the structure fetch runs and completes while `isNew` is still undefined.
+		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setUnique('test-unique');
+		await aTimeout(150);
+	});
+
+	afterEach(() => {
+		context.destroy();
+		document.body.removeChild(host);
+	});
+
+	it('fetches the structure but does not expand while isNew is still unresolved', async () => {
+		expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
+		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(0);
+	});
+
+	it('expands once isNew resolves to false, without re-fetching the structure', async () => {
+		const requestCountBeforeIsNewResolves = UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls.length;
+
+		workspaceContext.setIsNew(false);
+		await aTimeout(150);
+
+		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
+		expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(requestCountBeforeIsNewResolves);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -7,7 +7,7 @@ import {
 	createTestVariantAncestorItem,
 	createTestVariantTreeRepositoryManifest,
 } from './menu-variant-tree-structure-workspace-context.test-utils.js';
-import { UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT } from './section-sidebar-menu/section-context/section-sidebar-menu.section-context.token.js';
+import { UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT } from './section-sidebar-menu/index.js';
 import { UMB_ANCESTORS_ENTITY_CONTEXT, UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
 import { aTimeout, expect } from '@open-wc/testing';
 import { UmbActionEventContext } from '@umbraco-cms/backoffice/action';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -65,6 +65,7 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 		};
 
 		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setIsNew(false);
 		workspaceContext.setUnique('test-unique');
 		await aTimeout(150);
 	});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.test.ts
@@ -1,11 +1,13 @@
 import { UmbMenuVariantTreeStructureWorkspaceContextBase } from './menu-variant-tree-structure-workspace-context-base.js';
 import {
 	UmbTestMenuVariantStructureControllerHostElement,
+	UmbTestSectionSidebarMenuContext,
 	UmbTestSubmittableTreeEntityWorkspaceContext,
 	UmbTestVariantTreeRepository,
 	createTestVariantAncestorItem,
 	createTestVariantTreeRepositoryManifest,
 } from './menu-variant-tree-structure-workspace-context.test-utils.js';
+import { UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT } from './section-sidebar-menu/section-context/section-sidebar-menu.section-context.token.js';
 import { UMB_ANCESTORS_ENTITY_CONTEXT, UMB_PARENT_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
 import { aTimeout, expect } from '@open-wc/testing';
 import { UmbActionEventContext } from '@umbraco-cms/backoffice/action';
@@ -39,6 +41,7 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 
 	beforeEach(async () => {
 		UmbTestVariantTreeRepository.reset();
+		UmbTestSectionSidebarMenuContext.reset();
 
 		host = new UmbTestMenuVariantStructureControllerHostElement();
 		document.body.appendChild(host);
@@ -46,8 +49,20 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 		actionEventContext = new UmbActionEventContext(host);
 		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
 		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
+		new UmbContextProviderController(
+			host,
+			UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT,
+			new UmbTestSectionSidebarMenuContext(host) as never,
+		);
 
 		context = new TestMenuVariantTreeStructureWorkspaceContext(host);
+		context.manifest = {
+			type: 'workspaceContext',
+			kind: 'menuStructure',
+			alias: 'Umb.Test.MenuVariantStructureWorkspaceContext',
+			name: 'Test Menu Variant Structure Workspace Context',
+			meta: { menuItemAlias: 'test-menu-item' },
+		};
 
 		workspaceContext.setEntityType('test-entity-type');
 		workspaceContext.setUnique('test-unique');
@@ -182,6 +197,12 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 		});
 	});
 
+	describe('expanding the sidebar menu', () => {
+		it('expands the resolved parent when opening an existing item', async () => {
+			expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
+		});
+	});
+
 	describe('destroy', () => {
 		it('stops reacting to reload-structure events once destroyed', async () => {
 			context.destroy();
@@ -194,5 +215,68 @@ describe('UmbMenuVariantTreeStructureWorkspaceContextBase', () => {
 
 			expect(UmbTestVariantTreeRepository.requestTreeItemAncestorsCalls).to.have.lengthOf(1);
 		});
+	});
+});
+
+describe('UmbMenuVariantTreeStructureWorkspaceContextBase (creating a new item)', () => {
+	let host: UmbTestMenuVariantStructureControllerHostElement;
+	let workspaceContext: UmbTestSubmittableTreeEntityWorkspaceContext;
+	let context: TestMenuVariantTreeStructureWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.register(createTestVariantTreeRepositoryManifest(TEST_TREE_REPOSITORY_ALIAS));
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregister(TEST_TREE_REPOSITORY_ALIAS);
+	});
+
+	beforeEach(async () => {
+		UmbTestVariantTreeRepository.reset();
+		UmbTestSectionSidebarMenuContext.reset();
+
+		host = new UmbTestMenuVariantStructureControllerHostElement();
+		document.body.appendChild(host);
+
+		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
+		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
+		new UmbContextProviderController(
+			host,
+			UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT,
+			new UmbTestSectionSidebarMenuContext(host) as never,
+		);
+
+		context = new TestMenuVariantTreeStructureWorkspaceContext(host);
+		context.manifest = {
+			type: 'workspaceContext',
+			kind: 'menuStructure',
+			alias: 'Umb.Test.MenuVariantStructureWorkspaceContext.Create',
+			name: 'Test Menu Variant Structure Workspace Context (create)',
+			meta: { menuItemAlias: 'test-menu-item' },
+		};
+
+		// Simulate opening a "Create X under Y" workspace before any save: isNew is already true,
+		// and the item already has a client-generated unique.
+		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setIsNew(true);
+		workspaceContext.setCreateUnderParent({ unique: 'parent-unique', entityType: 'test-entity-type' });
+		workspaceContext.setUnique('new-item-unique');
+		await aTimeout(150);
+	});
+
+	afterEach(() => {
+		context.destroy();
+		document.body.removeChild(host);
+	});
+
+	it('does not expand the parent while the workspace is still in create mode', async () => {
+		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(0);
+	});
+
+	it('expands the parent once the item has been saved', async () => {
+		workspaceContext.setIsNew(false);
+		await aTimeout(150);
+
+		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -46,7 +46,6 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	#ancestorContext = new UmbAncestorsEntityContext(this);
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
 	#isModalContext: boolean = false;
-	#isNew: boolean | undefined = undefined;
 	#variantWorkspaceContext?: typeof UMB_VARIANT_WORKSPACE_CONTEXT.TYPE;
 	#workspaceActiveVariantId?: UmbVariantId;
 	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
@@ -100,14 +99,15 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 				'observeUnique',
 			);
 
+			// isNew is observed on its own, separate from the structure fetch, so the expand decision never
+			// depends on which of the two happens to settle first: whichever settles last (isNew resolving to
+			// false, or the structure fetch resolving) is the one that actually triggers the expand.
 			this.observe(
 				this.#workspaceContext?.isNew,
-				(value) => {
-					// Workspace has changed from new to existing
-					if (value === false && this.#isNew === true) {
-						this.#requestStructure();
+				(isNew) => {
+					if (isNew === false) {
+						this.#tryExpandSectionSidebarMenu();
 					}
-					this.#isNew = value;
 				},
 				'observeIsNew',
 			);
@@ -247,12 +247,26 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 			this.#setParentData(structureItems);
 			this.#setAncestorData(data);
 
-			// Don't expand the parent for an item that hasn't been created yet.
-			const menuItemAlias = this.manifest?.meta?.menuItemAlias;
-			if (menuItemAlias && !this.#isModalContext && isNew === false) {
-				this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
-			}
+			this.#tryExpandSectionSidebarMenu();
 		}
+	}
+
+	/**
+	 * Expands the parent in the section sidebar menu, but only once we know for certain the item isn't still being
+	 * created, and only once the structure has actually been fetched. Reads both conditions fresh, so it's safe to
+	 * call from either the structure-fetch completion or the isNew observer, whichever settles last.
+	 */
+	#tryExpandSectionSidebarMenu() {
+		const menuItemAlias = this.manifest?.meta?.menuItemAlias;
+		if (!menuItemAlias || this.#isModalContext) return;
+
+		// Don't expand the parent for an item that hasn't been created yet.
+		if (this.#workspaceContext?.getIsNew() !== false) return;
+
+		const structureItems = this.#structure.getValue();
+		if (!structureItems.length) return;
+
+		this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 	}
 
 	#clearStructure() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -247,8 +247,9 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 			this.#setParentData(structureItems);
 			this.#setAncestorData(data);
 
+			// Don't expand the parent for an item that hasn't been created yet.
 			const menuItemAlias = this.manifest?.meta?.menuItemAlias;
-			if (menuItemAlias && !this.#isModalContext) {
+			if (menuItemAlias && !this.#isModalContext && !isNew) {
 				this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 			}
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -249,7 +249,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 
 			// Don't expand the parent for an item that hasn't been created yet.
 			const menuItemAlias = this.manifest?.meta?.menuItemAlias;
-			if (menuItemAlias && !this.#isModalContext && !isNew) {
+			if (menuItemAlias && !this.#isModalContext && isNew === false) {
 				this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 			}
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context.test-utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context.test-utils.ts
@@ -1,11 +1,14 @@
-import { UmbTestSubmittableTreeEntityWorkspaceContext } from './menu-tree-structure-workspace-context.test-utils.js';
+import {
+	UmbTestSectionSidebarMenuContext,
+	UmbTestSubmittableTreeEntityWorkspaceContext,
+} from './menu-tree-structure-workspace-context.test-utils.js';
 import type { ManifestApi } from '@umbraco-cms/backoffice/extension-api';
 import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
 import { customElement } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import type { UmbTreeItemModel, UmbTreeRootModel } from '@umbraco-cms/backoffice/tree';
 
-export { UmbTestSubmittableTreeEntityWorkspaceContext };
+export { UmbTestSubmittableTreeEntityWorkspaceContext, UmbTestSectionSidebarMenuContext };
 
 @customElement('umb-test-menu-variant-structure-controller-host')
 export class UmbTestMenuVariantStructureControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}


### PR DESCRIPTION
### Description

Opening a "Create X under Y" workspace expanded the new item's parent's tree item in the sidebar, even before the new item was saved. This happened because the menu structure workspace context resolves and expands the parent's tree position on every structure request, including the one triggered while the workspace is still in create mode.

The fix gates the expansion on `isNew`. The parent is only expanded once the item is no longer new. Once the item is saved, the existing structure-refresh flow still expands the parent as before, so the newly created item becomes visible in the tree.

### How to test

1. In the Content tree, collapse an item that has children.
2. Create → pick a Document Type to create a new document under that item.
3. Confirm the parent stays collapsed while the create state is open (unsaved).
4. Save the Document.
5. Confirm the parent now expands and reveals the newly created Document.