### PR TITLE
Rich Text: Tolerate a new block layout `data-key` attribute in server-side markup parsing

### DIFF
--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -205,7 +205,15 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
 
     private static void CleanUpBlocks(string tag, Dictionary<string, object> attributes)
     {
-        if (tag.StartsWith("umb-rte-block") is false || attributes.TryGetValue(BlockContentKeyAttribute, out object? blockContentKeyAttribute) is false || blockContentKeyAttribute is not string dataKey)
+        if (tag.StartsWith("umb-rte-block") is false)
+        {
+            return;
+        }
+
+        // The layout key is editor-internal bookkeeping and must not leak into Delivery API output.
+        attributes.Remove(BlockLayoutKeyAttribute);
+
+        if (attributes.TryGetValue(BlockContentKeyAttribute, out object? blockContentKeyAttribute) is false || blockContentKeyAttribute is not string dataKey)
         {
             return;
         }

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
@@ -144,6 +144,9 @@ internal sealed class ApiRichTextMarkupParser : ApiRichTextParserBase, IApiRichT
         HtmlNode[] blocks = doc.DocumentNode.SelectNodes("//*[starts-with(local-name(),'umb-rte-block')]")?.ToArray() ?? Array.Empty<HtmlNode>();
         foreach (HtmlNode block in blocks)
         {
+            // The layout key is editor-internal bookkeeping and must not leak into Delivery API output.
+            block.Attributes.Remove(BlockLayoutKeyAttribute);
+
             var dataKey = block.GetAttributeValue(BlockContentKeyAttribute, string.Empty);
             if (Guid.TryParse(dataKey, out Guid key) is false)
             {

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
@@ -14,6 +14,7 @@ internal abstract partial class ApiRichTextParserBase
     private readonly IApiMediaUrlProvider _apiMediaUrlProvider;
 
     protected const string BlockContentKeyAttribute = "data-content-key";
+    protected const string BlockLayoutKeyAttribute = "data-key";
 
     protected ApiRichTextParserBase(IApiContentRouteBuilder apiContentRouteBuilder, IApiMediaUrlProvider apiMediaUrlProvider)
     {

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextParsingRegexes.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextParsingRegexes.cs
@@ -5,9 +5,9 @@ namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 internal static partial class RichTextParsingRegexes
 {
     /// <summary>
-    /// Returns a regular expression that matches Umbraco RTE block elements, including optional inline variants and class attributes.
+    /// Returns a regular expression that matches Umbraco RTE block elements, including optional inline variants and any other attributes (e.g. class, data-key) around data-content-key.
     /// </summary>
     /// <returns>A <see cref="Regex"/> for matching Umbraco RTE block elements.</returns>
-    [GeneratedRegex("<umb-rte-block(?:-inline)?(?: class=\"(.[^\"]*)\")? data-content-key=\"(?<key>.[^\"]*)\">(?:<!--Umbraco-Block-->)?<\\/umb-rte-block(?:-inline)?>")]
+    [GeneratedRegex("<umb-rte-block(?:-inline)?(?:\\s+[\\w-]+=\"[^\"]*\")*?\\s+data-content-key=\"(?<key>[^\"]+)\"(?:\\s+[\\w-]+=\"[^\"]*\")*\\s*>(?:<!--Umbraco-Block-->)?<\\/umb-rte-block(?:-inline)?>")]
     public static partial Regex BlockRegex();
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextParsingRegexes.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextParsingRegexes.cs
@@ -8,6 +8,6 @@ internal static partial class RichTextParsingRegexes
     /// Returns a regular expression that matches Umbraco RTE block elements, including optional inline variants and any other attributes (e.g. class, data-key) around data-content-key.
     /// </summary>
     /// <returns>A <see cref="Regex"/> for matching Umbraco RTE block elements.</returns>
-    [GeneratedRegex("<umb-rte-block(?:-inline)?(?:\\s+[\\w-]+=\"[^\"]*\")*?\\s+data-content-key=\"(?<key>[^\"]+)\"(?:\\s+[\\w-]+=\"[^\"]*\")*\\s*>(?:<!--Umbraco-Block-->)?<\\/umb-rte-block(?:-inline)?>")]
+    [GeneratedRegex("<umb-rte-block(?:-inline)?(?:.*=\"[^\"]*\")*?\\s+data-content-key=\"(?<key>[^\"]+)\"(?:.*=\"[^\"]*\")*\\s*>(?:<!--Umbraco-Block-->)?<\\/umb-rte-block(?:-inline)?>")]
     public static partial Regex BlockRegex();
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
@@ -359,6 +359,26 @@ public class RichTextParserTests : PropertyValueConverterTests
 
     [TestCase(true)]
     [TestCase(false)]
+    public void ParseElement_CleansUpBlocks_RemovesLayoutKey(bool inlineBlock)
+    {
+        var parser = CreateRichTextElementParser();
+        var id = Guid.NewGuid();
+        var layoutKey = Guid.NewGuid();
+
+        var tagName = $"umb-rte-block{(inlineBlock ? "-inline" : string.Empty)}";
+        var element = parser.Parse($"<p><{tagName} data-key=\"{layoutKey:N}\" data-content-key=\"{id:N}\"><!--Umbraco-Block--></{tagName}></p>", RichTextBlockModel.Empty) as RichTextRootElement;
+        Assert.IsNotNull(element);
+        var paragraph = element.Elements.Single() as RichTextGenericElement;
+        Assert.IsNotNull(paragraph);
+        var block = paragraph.Elements.Single() as RichTextGenericElement;
+        Assert.IsNotNull(block);
+        Assert.AreEqual(1, block.Attributes.Count);
+        Assert.IsTrue(block.Attributes.ContainsKey("content-id"));
+        Assert.AreEqual(id, block.Attributes["content-id"]);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
     public void ParseElement_AppendsBlocks(bool inlineBlock)
     {
         var parser = CreateRichTextElementParser();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ValueConverters/RichTextParsingRegexesTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ValueConverters/RichTextParsingRegexesTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors.ValueConverters;
+
+[TestFixture]
+public class RichTextParsingRegexesTests
+{
+    private const string ContentKey = "36cc710a-d8a6-45d0-a07f-7bbd8742cf02";
+    private const string LayoutKey = "d2eeef66-4111-42f4-a164-7a523eaffbc2";
+
+    [TestCase($"<umb-rte-block data-key=\"{LayoutKey}\" data-content-key=\"{ContentKey}\"></umb-rte-block>")]
+    [TestCase($"<umb-rte-block data-content-key=\"{ContentKey}\" data-key=\"{LayoutKey}\"></umb-rte-block>")]
+    [TestCase($"<umb-rte-block data-content-key=\"{ContentKey}\"></umb-rte-block>")]
+    [TestCase($"<umb-rte-block class=\"x\" data-content-key=\"{ContentKey}\"></umb-rte-block>")]
+    [TestCase($"<umb-rte-block-inline data-key=\"{LayoutKey}\" data-content-key=\"{ContentKey}\"></umb-rte-block-inline>")]
+    [TestCase($"<umb-rte-block data-key=\"{LayoutKey}\" data-content-key=\"{ContentKey}\"><!--Umbraco-Block--></umb-rte-block>")]
+    public void Matches_And_Captures_The_Content_Key(string markup)
+    {
+        var match = RichTextParsingRegexes.BlockRegex().Match(markup);
+
+        Assert.IsTrue(match.Success);
+        Assert.AreEqual(ContentKey, match.Groups["key"].Value);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ValueConverters/RichTextParsingRegexesTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ValueConverters/RichTextParsingRegexesTests.cs
@@ -15,11 +15,29 @@ public class RichTextParsingRegexesTests
     [TestCase($"<umb-rte-block class=\"x\" data-content-key=\"{ContentKey}\"></umb-rte-block>")]
     [TestCase($"<umb-rte-block-inline data-key=\"{LayoutKey}\" data-content-key=\"{ContentKey}\"></umb-rte-block-inline>")]
     [TestCase($"<umb-rte-block data-key=\"{LayoutKey}\" data-content-key=\"{ContentKey}\"><!--Umbraco-Block--></umb-rte-block>")]
-    public void Matches_And_Captures_The_Content_Key(string markup)
+    public void Can_Match_Block_With_Optional_Attributes(string markup)
     {
         var match = RichTextParsingRegexes.BlockRegex().Match(markup);
 
         Assert.IsTrue(match.Success);
         Assert.AreEqual(ContentKey, match.Groups["key"].Value);
+    }
+
+    [TestCase($"<umb-rte-block data-key=\"{LayoutKey}\"></umb-rte-block>")]
+    [TestCase($"<umb-rte-block></umb-rte-block>")]
+    public void Cannot_Match_Block_Without_Content_Key(string markup)
+    {
+        var match = RichTextParsingRegexes.BlockRegex().Match(markup);
+
+        Assert.IsFalse(match.Success);
+    }
+
+    [TestCase($"<umb-rte-block data-content-key=\"{ContentKey}\">some text</umb-rte-block>")]
+    [TestCase($"<umb-rte-block data-content-key=\"{ContentKey}\"><p>nested</p></umb-rte-block>")]
+    public void Cannot_Match_Block_With_Inner_Content(string markup)
+    {
+        var match = RichTextParsingRegexes.BlockRegex().Match(markup);
+
+        Assert.IsFalse(match.Success);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParserTests.cs
@@ -240,6 +240,23 @@ public class ApiRichTextMarkupParserTests
         StringAssert.Contains(@"src=""FRESH_URL""", parsedHtml);
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CleanUpBlocks_RemovesLayoutKeyAttribute(bool inlineBlock)
+    {
+        var parser = BuildDefaultSut(new Dictionary<Guid, MockData>());
+        var contentKey = Guid.Parse("36cc710a-d8a6-45d0-a07f-7bbd8742cf02");
+        var layoutKey = Guid.Parse("d2eeef66-4111-42f4-a164-7a523eaffbc2");
+
+        var tagName = $"umb-rte-block{(inlineBlock ? "-inline" : string.Empty)}";
+        var markup = $"<{tagName} data-key=\"{layoutKey:N}\" data-content-key=\"{contentKey:N}\"><!--Umbraco-Block--></{tagName}>";
+        var expectedOutput = $"<{tagName} data-content-id=\"{contentKey:D}\"></{tagName}>";
+
+        var parsedHtml = parser.Parse(markup);
+
+        Assert.AreEqual(expectedOutput, parsedHtml);
+    }
+
     private ApiRichTextMarkupParser BuildDefaultSut(Dictionary<Guid, MockData> mockData)
     {
         var contentCacheMock = new Mock<IPublishedContentCache>();


### PR DESCRIPTION
## Description

Prep work for an upcoming Tiptap RTE change that starts persisting a `data-key` attribute on block elements, alongside the existing `data-content-key`.

Two spots needed to tolerate that. `RichTextParsingRegexes.BlockRegex()` only matched `data-content-key` when it appeared right after the tag name or an optional `class` attribute, so a block carrying `data-key` first would render as an unreplaced `<umb-rte-block>` placeholder on the front end instead of its actual content. And the Delivery API's block markup cleanup swaps `data-content-key` for `content-id` but wasn't stripping `data-key`, so that editor-internal identifier would have leaked into API responses.

Both are fixed now: the regex matches `data-content-key` regardless of what other attributes surround it, and the Delivery API strips `data-key` unconditionally alongside the existing `data-content-key` handling.

### How to test?

There's nothing to click through yet, since nothing on `v19/dev` emits `data-key` on RTE blocks until the paired Tiptap RTE work lands. Run the unit tests instead:

1. `RichTextParsingRegexesTests` - confirms the regex matches with `data-key` in any position, and still rejects blocks missing `data-content-key` or carrying inner content.
2. `RichTextParserTests.ParseElement_CleansUpBlocks_RemovesLayoutKey`
3. `ApiRichTextMarkupParserTests.CleanUpBlocks_RemovesLayoutKeyAttribute`

All three confirm `data-key` never survives into parsed/Delivery API output.
