### PR TITLE
Block Editors: Derive exposed/published state on the shared block entry context

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -6,7 +6,6 @@ import { stringOrStringArrayContains, UmbDeprecation } from '@umbraco-cms/backof
 import { UmbDataPathBlockElementDataQuery } from '@umbraco-cms/backoffice/block';
 import { renderHiddenUfm } from '@umbraco-cms/backoffice/ufm';
 import { umbDestroyOnDisconnect, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UmbElementVariantState } from '@umbraco-cms/backoffice/element';
 import { UmbObserveValidationStateController } from '@umbraco-cms/backoffice/validation';
 import { UUIBlinkAnimationValue, UUIBlinkKeyframes } from '@umbraco-cms/backoffice/external/uui';
 import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
@@ -137,8 +136,6 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	@state()
 	private _exposed?: boolean;
 
-	private _localExpose?: boolean;
-
 	// Unsupported is triggered if the Block Type is not recognized, it can also be triggered by the Content Element Type not existing any longer. [NL]
 	@state()
 	private _unsupported?: boolean;
@@ -192,9 +189,6 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	private _isExternalContent = false;
 
 	@state()
-	private _externalContentVariantState: string | null | undefined;
-
-	@state()
 	private _isReadOnly = false;
 
 	constructor() {
@@ -246,10 +240,10 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 			null,
 		);
 		this.observe(
-			this.#context.hasExpose,
-			(exposed) => {
-				this._localExpose = exposed;
-				this.#updateExposedState();
+			this.#context.isExposed,
+			(isExposed) => {
+				this.#updateBlockViewProps({ unpublished: !isExposed });
+				this._exposed = isExposed;
 			},
 			null,
 		);
@@ -271,15 +265,6 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 			this.#context.isExternalContent,
 			(isExternalContent) => {
 				this._isExternalContent = isExternalContent;
-				this.#updateExposedState();
-			},
-			null,
-		);
-		this.observe(
-			this.#context.externalContentVariantState,
-			(state) => {
-				this._externalContentVariantState = state;
-				this.#updateExposedState();
 			},
 			null,
 		);
@@ -450,16 +435,6 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	#expose = () => {
 		this.#context.expose();
 	};
-
-	#updateExposedState() {
-		// External content blocks use the element's variant state; local blocks use the expose entry
-		const isExposed = this._isExternalContent
-			? this._externalContentVariantState === UmbElementVariantState.PUBLISHED ||
-				this._externalContentVariantState === UmbElementVariantState.PUBLISHED_PENDING_CHANGES
-			: this._localExpose;
-		this.#updateBlockViewProps({ unpublished: !isExposed });
-		this._exposed = isExposed;
-	}
 
 	#onUfmResolved = (event: UmbUfmResolvedEvent) => {
 		this.#context.setName(event.detail.text);

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
@@ -6,7 +6,6 @@ import { UmbLitElement, umbDestroyOnDisconnect } from '@umbraco-cms/backoffice/l
 import { stringOrStringArrayContains, UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 import { UmbDataPathBlockElementDataQuery } from '@umbraco-cms/backoffice/block';
 import { renderHiddenUfm } from '@umbraco-cms/backoffice/ufm';
-import { UmbElementVariantState } from '@umbraco-cms/backoffice/element';
 import { UmbObserveValidationStateController } from '@umbraco-cms/backoffice/validation';
 import { UUIBlinkAnimationValue, UUIBlinkKeyframes } from '@umbraco-cms/backoffice/external/uui';
 import type {
@@ -120,8 +119,6 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 	@state()
 	private _exposed?: boolean;
 
-	private _localExpose?: boolean;
-
 	@state()
 	private _unsupported?: boolean;
 
@@ -153,9 +150,6 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 
 	@property({ type: Boolean, attribute: 'is-reference', reflect: true })
 	private _isExternalContent = false;
-
-	@state()
-	private _externalContentVariantState: string | null | undefined;
 
 	@state()
 	private _isReadOnly = false;
@@ -206,10 +200,10 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 			null,
 		);
 		this.observe(
-			this.#context.hasExpose,
-			(exposed) => {
-				this._localExpose = exposed;
-				this.#updateExposedState();
+			this.#context.isExposed,
+			(isExposed) => {
+				this.#updateBlockViewProps({ unpublished: !isExposed });
+				this._exposed = isExposed;
 			},
 			null,
 		);
@@ -231,15 +225,6 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 			this.#context.isExternalContent,
 			(isExternalContent) => {
 				this._isExternalContent = isExternalContent;
-				this.#updateExposedState();
-			},
-			null,
-		);
-		this.observe(
-			this.#context.externalContentVariantState,
-			(state) => {
-				this._externalContentVariantState = state;
-				this.#updateExposedState();
 			},
 			null,
 		);
@@ -357,16 +342,6 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 	#onUfmResolved = (event: UmbUfmResolvedEvent) => {
 		this.#context.setName(event.detail.text);
 	};
-
-	#updateExposedState() {
-		// External content blocks use the element's variant state; local blocks use the expose entry
-		const isExposed = this._isExternalContent
-			? this._externalContentVariantState === UmbElementVariantState.PUBLISHED ||
-				this._externalContentVariantState === UmbElementVariantState.PUBLISHED_PENDING_CHANGES
-			: this._localExpose;
-		this.#updateBlockViewProps({ unpublished: !isExposed });
-		this._exposed = isExposed;
-	}
 
 	#extensionSlotFilterMethod = (manifest: ManifestBlockEditorCustomView) => {
 		if (this._unsupported) {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -233,10 +233,10 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 			null,
 		);
 		this.observe(
-			this.#context.hasExpose,
-			(exposed) => {
-				this.#updateBlockViewProps({ unpublished: !exposed });
-				this._exposed = exposed;
+			this.#context.isExposed,
+			(isExposed) => {
+				this.#updateBlockViewProps({ unpublished: !isExposed });
+				this._exposed = isExposed;
 			},
 			null,
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/block-single-entry/block-single-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/block-single-entry/block-single-entry.element.ts
@@ -6,7 +6,6 @@ import { stringOrStringArrayContains, UmbDeprecation } from '@umbraco-cms/backof
 import { UmbLitElement, umbDestroyOnDisconnect } from '@umbraco-cms/backoffice/lit-element';
 import { UmbDataPathBlockElementDataQuery } from '@umbraco-cms/backoffice/block';
 import { renderHiddenUfm } from '@umbraco-cms/backoffice/ufm';
-import { UmbElementVariantState } from '@umbraco-cms/backoffice/element';
 import { UmbObserveValidationStateController } from '@umbraco-cms/backoffice/validation';
 import { UUIBlinkAnimationValue, UUIBlinkKeyframes } from '@umbraco-cms/backoffice/external/uui';
 import type {
@@ -121,8 +120,6 @@ export class UmbBlockSingleEntryElement extends UmbLitElement implements UmbProp
 	@state()
 	private _exposed?: boolean;
 
-	private _localExpose?: boolean;
-
 	@state()
 	private _unsupported?: boolean;
 
@@ -151,9 +148,6 @@ export class UmbBlockSingleEntryElement extends UmbLitElement implements UmbProp
 
 	@property({ type: Boolean, attribute: 'is-reference', reflect: true })
 	private _isExternalContent = false;
-
-	@state()
-	private _externalContentVariantState: string | null | undefined;
 
 	@state()
 	private _isReadOnly = false;
@@ -204,10 +198,10 @@ export class UmbBlockSingleEntryElement extends UmbLitElement implements UmbProp
 			null,
 		);
 		this.observe(
-			this.#context.hasExpose,
-			(exposed) => {
-				this._localExpose = exposed;
-				this.#updateExposedState();
+			this.#context.isExposed,
+			(isExposed) => {
+				this.#updateBlockViewProps({ unpublished: !isExposed });
+				this._exposed = isExposed;
 			},
 			null,
 		);
@@ -215,15 +209,6 @@ export class UmbBlockSingleEntryElement extends UmbLitElement implements UmbProp
 			this.#context.isExternalContent,
 			(isExternalContent) => {
 				this._isExternalContent = isExternalContent;
-				this.#updateExposedState();
-			},
-			null,
-		);
-		this.observe(
-			this.#context.externalContentVariantState,
-			(state) => {
-				this._externalContentVariantState = state;
-				this.#updateExposedState();
 			},
 			null,
 		);
@@ -319,16 +304,6 @@ export class UmbBlockSingleEntryElement extends UmbLitElement implements UmbProp
 	#updateBlockViewProps(incoming: Partial<UmbBlockEditorCustomViewProperties<UmbBlockSingleLayoutModel>>) {
 		this._blockViewProps = { ...this._blockViewProps, ...incoming };
 		this.requestUpdate('_blockViewProps');
-	}
-
-	#updateExposedState() {
-		// External content blocks use the element's variant state; local blocks use the expose entry
-		const isExposed = this._isExternalContent
-			? this._externalContentVariantState === UmbElementVariantState.PUBLISHED ||
-				this._externalContentVariantState === UmbElementVariantState.PUBLISHED_PENDING_CHANGES
-			: this._localExpose;
-		this.#updateBlockViewProps({ unpublished: !isExposed });
-		this._exposed = isExposed;
 	}
 
 	override connectedCallback(): void {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -28,7 +28,11 @@ import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-
 import { UmbModalRouteRegistrationController, UmbRoutePathAddendumContext } from '@umbraco-cms/backoffice/router';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UmbUfmVirtualRenderController } from '@umbraco-cms/backoffice/ufm';
-import { UMB_EDIT_ELEMENT_WORKSPACE_PATH_PATTERN, UMB_ELEMENT_ENTITY_TYPE } from '@umbraco-cms/backoffice/element';
+import {
+	UMB_EDIT_ELEMENT_WORKSPACE_PATH_PATTERN,
+	UMB_ELEMENT_ENTITY_TYPE,
+	UmbElementVariantState,
+} from '@umbraco-cms/backoffice/element';
 import { UMB_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/workspace';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import type { UmbBlockTypeBaseModel } from '@umbraco-cms/backoffice/block-type';
@@ -84,6 +88,20 @@ export abstract class UmbBlockEntryContext<
 
 	#hasExpose = new UmbBooleanState(undefined);
 	readonly hasExpose = this.#hasExpose.asObservable();
+
+	/**
+	 * Whether the block is currently published/exposed. For a block backed by external (library element)
+	 * content, this reflects that content's own variant state rather than the local expose entry.
+	 */
+	readonly isExposed = mergeObservables(
+		[this.hasExpose, this.isExternalContent, this.externalContentVariantState],
+		([hasExpose, isExternalContent, variantState]) =>
+			// External content blocks use the element's variant state; local blocks use the expose entry
+			isExternalContent
+				? variantState === UmbElementVariantState.PUBLISHED ||
+					variantState === UmbElementVariantState.PUBLISHED_PENDING_CHANGES
+				: hasExpose,
+	);
 
 	#actionsVisibility = new UmbBooleanState(true);
 	readonly actionsVisibility = this.#actionsVisibility.asObservable();

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -87,6 +87,9 @@ export abstract class UmbBlockEntryContext<
 	protected readonly _variantId = this.#variantId.asObservable();
 
 	#hasExpose = new UmbBooleanState(undefined);
+	/**
+	 * Whether the local expose entry exists. Prefer {@link isExposed} to determine rendered publish state.
+	 */
 	readonly hasExpose = this.#hasExpose.asObservable();
 
 	/**


### PR DESCRIPTION
## Description

The Block Grid, Block List, Block Single and RTE block entry elements each had their own copy of the same "is this block currently published/exposed" logic: for a block backed by an Element Library reference, look at that content's own variant state; for a local block, look at the expose entry. Grid, list and single each carried their own private state and a private `#updateExposedState()` method to combine them.

Moved that derivation onto the shared `UmbBlockEntryContext` as a single `isExposed` observable, and had all four entry elements consume it instead of recomputing it themselves. No behaviour change - this is purely deduplicating logic that already existed in four places.

### How to test?

This is a refactor, so it's really a regression check across the block editors:

1. On a Block Grid, Block List and Block Single data type, add a local block and an Element Library reference block, then unpublish/publish each and confirm the entry's "unpublished" styling toggles correctly in both cases.
2. Do the same for a Rich Text (Tiptap) property with an RTE block and an Element Library reference block inside it.
