### PR TITLE
Tiptap RTE: Show a name label and reference icon on Block entries

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -100,7 +100,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	@state()
 	private _isReadOnly = false;
 
-	// TODO: consumed by <umb-entity-frame> label, landing in a follow-up PR; add `@state()` when used in render [LK]
+	@state()
 	private _name?: string;
 
 	@state()
@@ -108,6 +108,10 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 		contentKey: undefined!,
 		config: { showContentEdit: false, showSettingsEdit: false },
 	}; // Set to undefined cause it will be set before we render.
+
+	// 'is-reference' attribute is used for styling purpose.
+	@property({ type: Boolean, attribute: 'is-reference', reflect: true })
+	private _isExternalContent = false;
 
 	// 'content-invalid' attribute is used for styling purpose.
 	@property({ type: Boolean, attribute: 'content-invalid', reflect: true })
@@ -241,6 +245,13 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 			null,
 		);
 		this.observe(
+			this.#context.isExternalContent,
+			(isExternalContent) => {
+				this._isExternalContent = isExternalContent;
+			},
+			null,
+		);
+		this.observe(
 			this.#context.unsupported,
 			(unsupported) => {
 				if (unsupported === undefined) return;
@@ -324,7 +335,10 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 		return when(
 			this.contentKey && (this._contentTypeAlias || this.unsupported),
 			() => html`
-				<div>
+				<div class="umb-block-rte__block">
+					<umb-entity-frame>
+						${when(this._isExternalContent, () => html`<uui-icon name="link"></uui-icon>`)} ${this._name}
+					</umb-entity-frame>
 					<umb-extension-slot
 						type="blockEditorCustomView"
 						default-element="umb-ref-rte-block"
@@ -382,6 +396,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 			:host {
 				position: relative;
 				display: block;
+				margin-top: var(--uui-size-3);
 				user-select: all;
 				user-drag: auto;
 				white-space: nowrap;
@@ -396,6 +411,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 
 			:host(.ProseMirror-selectednode) {
 				--uui-color-default-contrast: initial;
+				border-radius: var(--uui-border-radius);
 				outline: 3px solid var(--uui-color-focus);
 			}
 


### PR DESCRIPTION
> [!IMPORTANT]
> PR #23195 needs to be reviewed first.
 
## Description

RTE block entries didn't show a name label the way Block Grid, Block List and Block Single entries do, and there was no visual indicator that a block was an Element Library reference rather than a local block.

RTE block entries now render the same `umb-entity-frame` label as the other block editors, with a link icon in front of the name for reference blocks. Along with that, a block sitting right at the top of the editor no longer has its label clipped (needed some spacing above it), and the focus outline on a selected block now has a rounded corner to match the block itself instead of a square one.

### How to test?

1. Add a Rich Text property editor to a document type, with an RTE block configured.
2. In the editor, insert an instance of that block right at the very top of the content, before any other text - confirm its name label isn't clipped/cut off.
3. Insert an Element Library reference of that same block type elsewhere in the content - it should show a link icon next to its name, where the local block doesn't.
4. Click a block to select it and confirm the focus outline has rounded corners.
