### PR TITLE
Menu: Generalise `UmbMenuStructureWorkspaceContext` to support variant specialisation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-list-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-list-structure-workspace-context-base.ts
@@ -1,10 +1,10 @@
-import type { UmbStructureItemModel } from './types.js';
 import { UMB_MENU_STRUCTURE_WORKSPACE_CONTEXT } from './menu-structure-workspace-context.context-token.js';
 import type { UmbMenuStructureWorkspaceContext } from './menu-structure-workspace-context.interface.js';
-import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbStructureItemModel } from './types.js';
 import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbParentEntityContext } from '@umbraco-cms/backoffice/entity';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 /**
  * Base class for a menu structure workspace context for an entity that is organized as a flat
@@ -17,10 +17,10 @@ export abstract class UmbMenuListStructureWorkspaceContextBase
 	extends UmbContextBase
 	implements UmbMenuStructureWorkspaceContext
 {
-	#structure = new UmbArrayState<UmbStructureItemModel>([], (x) => x.unique);
+	readonly #structure = new UmbArrayState<UmbStructureItemModel>([], (x) => x.unique);
 	public readonly structure = this.#structure.asObservable();
 
-	#parentContext = new UmbParentEntityContext(this);
+	readonly #parentContext = new UmbParentEntityContext(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_MENU_STRUCTURE_WORKSPACE_CONTEXT);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-structure-workspace-context.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-structure-workspace-context.interface.ts
@@ -1,7 +1,24 @@
-import type { UmbStructureItemModel } from './types.js';
+import type { UmbStructureItemModel, UmbStructureItemModelBase } from './types.js';
 import type { UmbContext } from '@umbraco-cms/backoffice/class-api';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 
-export interface UmbMenuStructureWorkspaceContext extends UmbContext {
-	structure: Observable<UmbStructureItemModel[]>;
+/**
+ * Base context for exposing an entity's ancestor/parent structure to menu UI.
+ * @template TStructureItemModel - The shape of each item in the structure.
+ */
+export interface UmbMenuStructureWorkspaceContext<
+	TStructureItemModel extends UmbStructureItemModelBase = UmbStructureItemModel,
+> extends UmbContext {
+	/**
+	 * Observable array of structure items representing the workspace's breadcrumb hierarchy.
+	 */
+	structure: Observable<Array<TStructureItemModel>>;
+
+	/**
+	 * Returns the href for a breadcrumb structure item, or `undefined` if the item should not be a link.
+	 * Used by the workspace breadcrumb element to generate clickable navigation links.
+	 * @param {TStructureItemModel} structureItem The structure item to generate an href for.
+	 * @returns {string | undefined} The href string, or `undefined` if the item should not be clickable.
+	 */
+	getItemHref?(structureItem: TStructureItemModel): string | undefined;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -1,47 +1,51 @@
-import type { ManifestWorkspaceContextMenuStructureKind, UmbStructureItemModel } from './types.js';
 import { UMB_MENU_STRUCTURE_WORKSPACE_CONTEXT } from './menu-structure-workspace-context.context-token.js';
 import { UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT } from './section-sidebar-menu/index.js';
-import type { UmbTreeRepository, UmbTreeItemModel, UmbTreeRootModel } from '@umbraco-cms/backoffice/tree';
+import type { ManifestWorkspaceContextMenuStructureKind, UmbStructureItemModel } from './types.js';
+import type { UmbMenuStructureWorkspaceContext } from './menu-structure-workspace-context.interface.js';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
-import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
-import { UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
-import { UmbArrayState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UmbAncestorsEntityContext, UmbParentEntityContext, type UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import { debounce, linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
-import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
-import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbAncestorsEntityContext, UmbParentEntityContext, type UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import { UmbArrayState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import { UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbTreeRepository, UmbTreeItemModel, UmbTreeRootModel } from '@umbraco-cms/backoffice/tree';
 
 interface UmbMenuTreeStructureWorkspaceContextBaseArgs {
 	treeRepositoryAlias: string;
 }
 
 // TODO: introduce base class for all menu structure workspaces to handle ancestors and parent
-export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContextBase {
+export abstract class UmbMenuTreeStructureWorkspaceContextBase
+	extends UmbContextBase
+	implements UmbMenuStructureWorkspaceContext
+{
 	manifest?: ManifestWorkspaceContextMenuStructureKind;
 
 	#workspaceContext?: typeof UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT.TYPE;
-	#args: UmbMenuTreeStructureWorkspaceContextBaseArgs;
+	readonly #args: UmbMenuTreeStructureWorkspaceContextBaseArgs;
 
-	#structure = new UmbArrayState<UmbStructureItemModel>([], (x) => x.unique);
+	readonly #structure = new UmbArrayState<UmbStructureItemModel>([], (x) => x.unique);
 	public readonly structure = this.#structure.asObservable();
 
-	#parent = new UmbObjectState<UmbStructureItemModel | undefined>(undefined);
+	readonly #parent = new UmbObjectState<UmbStructureItemModel | undefined>(undefined);
 	/**
 	 * @deprecated Will be removed in v.18: Use UMB_PARENT_ENTITY_CONTEXT instead.
 	 */
 	public readonly parent = this.#parent.asObservable();
 
-	#parentContext = new UmbParentEntityContext(this);
-	#ancestorContext = new UmbAncestorsEntityContext(this);
+	readonly #parentContext = new UmbParentEntityContext(this);
+	readonly #ancestorContext = new UmbAncestorsEntityContext(this);
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
 	#isModalContext: boolean = false;
 	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 	#structureRequestId = 0;
 
 	// Coalesces the unique/isNew/reload-event triggers when they fire in quick succession.
-	#requestStructure = debounce(() => this.#requestStructureImpl(), 100);
+	readonly #requestStructure = debounce(() => this.#requestStructureImpl(), 100);
 
 	constructor(host: UmbControllerHost, args: UmbMenuTreeStructureWorkspaceContextBaseArgs) {
 		super(host, UMB_MENU_STRUCTURE_WORKSPACE_CONTEXT);
@@ -105,7 +109,7 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		);
 	}
 
-	#onReloadStructureForEntityRequest = (event: UmbRequestReloadStructureForEntityEvent) => {
+	readonly #onReloadStructureForEntityRequest = (event: UmbRequestReloadStructureForEntityEvent) => {
 		if (!this.#isCurrentEntityOrAncestor(event.getEntityType(), event.getUnique())) return;
 		this.#requestStructure();
 	};

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-structure-workspace-context.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-structure-workspace-context.interface.ts
@@ -1,8 +1,6 @@
 import type { UmbVariantStructureItemModel } from './types.js';
-import type { UmbContext } from '@umbraco-cms/backoffice/class-api';
-import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
+import type { UmbMenuStructureWorkspaceContext } from './menu-structure-workspace-context.interface.js';
 
-export interface UmbMenuVariantStructureWorkspaceContext extends UmbContext {
-	structure: Observable<UmbVariantStructureItemModel[]>;
+export interface UmbMenuVariantStructureWorkspaceContext extends UmbMenuStructureWorkspaceContext<UmbVariantStructureItemModel> {
 	getItemHref(structureItem: UmbVariantStructureItemModel): string | undefined;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -1,40 +1,44 @@
-import type { ManifestWorkspaceContextMenuStructureKind, UmbVariantStructureItemModel } from './types.js';
 import { UMB_MENU_VARIANT_STRUCTURE_WORKSPACE_CONTEXT } from './menu-variant-structure-workspace-context.context-token.js';
 import { UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT } from './section-sidebar-menu/section-context/section-sidebar-menu.section-context.token.js';
+import type { ManifestWorkspaceContextMenuStructureKind, UmbVariantStructureItemModel } from './types.js';
+import type { UmbMenuVariantStructureWorkspaceContext } from './menu-variant-structure-workspace-context.interface.js';
 import type { UmbTreeItemModel, UmbTreeRepository, UmbTreeRootModel } from '@umbraco-cms/backoffice/tree';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
-import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
-import { UmbArrayState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { debounce, linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 import { UmbAncestorsEntityContext, UmbParentEntityContext, type UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import { UmbArrayState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
 import {
 	UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT,
 	UMB_VARIANT_WORKSPACE_CONTEXT,
 	UMB_WORKSPACE_EDIT_PATH_PATTERN,
 	UMB_WORKSPACE_EDIT_VARIANT_PATH_PATTERN,
 } from '@umbraco-cms/backoffice/workspace';
-import { debounce, linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
-import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
-import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
-import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
-import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
-import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 interface UmbMenuVariantTreeStructureWorkspaceContextBaseArgs {
 	treeRepositoryAlias: string;
 }
 
 // TODO: introduce base class for all menu structure workspaces to handle ancestors and parent
-export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends UmbContextBase {
+export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase
+	extends UmbContextBase
+	implements UmbMenuVariantStructureWorkspaceContext
+{
 	manifest?: ManifestWorkspaceContextMenuStructureKind;
 
 	#workspaceContext?: typeof UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT.TYPE;
-	#args: UmbMenuVariantTreeStructureWorkspaceContextBaseArgs;
+	readonly #args: UmbMenuVariantTreeStructureWorkspaceContextBaseArgs;
 
-	#structure = new UmbArrayState<UmbVariantStructureItemModel>([], (x) => x.unique);
+	readonly #structure = new UmbArrayState<UmbVariantStructureItemModel>([], (x) => x.unique);
 	public readonly structure = this.#structure.asObservable();
 
-	#parent = new UmbObjectState<UmbVariantStructureItemModel | undefined>(undefined);
+	readonly #parent = new UmbObjectState<UmbVariantStructureItemModel | undefined>(undefined);
 	/**
 	 * @deprecated Will be removed in v.18: Use UMB_PARENT_ENTITY_CONTEXT instead.
 	 */
@@ -42,8 +46,8 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 
 	protected _sectionContext?: typeof UMB_SECTION_CONTEXT.TYPE;
 
-	#parentContext = new UmbParentEntityContext(this);
-	#ancestorContext = new UmbAncestorsEntityContext(this);
+	readonly #parentContext = new UmbParentEntityContext(this);
+	readonly #ancestorContext = new UmbAncestorsEntityContext(this);
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
 	#isModalContext: boolean = false;
 	#variantWorkspaceContext?: typeof UMB_VARIANT_WORKSPACE_CONTEXT.TYPE;
@@ -52,7 +56,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	#structureRequestId = 0;
 
 	// Coalesces the unique/isNew/reload-event triggers when they fire in quick succession.
-	#requestStructure = debounce(() => this.#requestStructureImpl(), 100);
+	readonly #requestStructure = debounce(() => this.#requestStructureImpl(), 100);
 
 	public readonly IS_MENU_VARIANT_STRUCTURE_WORKSPACE_CONTEXT = true;
 
@@ -160,7 +164,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 		);
 	}
 
-	#onReloadStructureForEntityRequest = (event: UmbRequestReloadStructureForEntityEvent) => {
+	readonly #onReloadStructureForEntityRequest = (event: UmbRequestReloadStructureForEntityEvent) => {
 		if (!this.#isCurrentEntityOrAncestor(event.getEntityType(), event.getUnique())) return;
 		this.#requestStructure();
 	};

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.element.ts
@@ -163,7 +163,7 @@ export class UmbWorkspaceVariantMenuBreadcrumbElement extends UmbLitElement {
 		`;
 	}
 
-	static override styles = [
+	static override readonly styles = [
 		UmbTextStyles,
 		css`
 			:host {

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/menu/member-menu-structure.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/menu/member-menu-structure.context.ts
@@ -26,10 +26,10 @@ export class UmbMemberMenuStructureWorkspaceContext
 
 	#sectionContext?: typeof UMB_SECTION_CONTEXT.TYPE;
 
-	#structure = new UmbArrayState<UmbVariantStructureItemModel>([], (x) => x.unique);
+	readonly #structure = new UmbArrayState<UmbVariantStructureItemModel>([], (x) => x.unique);
 	public readonly structure = this.#structure.asObservable();
 
-	#parentContext = new UmbParentEntityContext(this);
+	readonly #parentContext = new UmbParentEntityContext(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_MENU_VARIANT_STRUCTURE_WORKSPACE_CONTEXT);


### PR DESCRIPTION
## Description

Refactored `UmbMenuStructureWorkspaceContext` interface to add an optional `getItemHref`, along aligning `UmbMenuVariantStructureWorkspaceContext` to extend it (and override `getItemHref` as required).

The reason for this is that in v18, `UmbMenuStructureWorkspaceContext.getItemHref` was added as a required method (in PR #21897, to support Element workspaces).

However if new classes that implement the `UmbMenuStructureWorkspaceContext` interface are added in v17, then up-merging them to v18 causes an issue (since they don't implement `getItemHref`). This was the case with PR #23832, with the new `UmbMenuListStructureWorkspaceContextBase` class.

To reduce friction with our v17 to v18 upstream merges, my aim is to introduce `getItemHref` as an optional method for v17... an whilst doing this, attempt to align the `UmbMenuVariantStructureWorkspaceContext` interface too.

Also applied some SonarQube suggestions, mostly `readonly` keywords and import sorting.

<details>
<summary>🤖 <b>Claude/AI generated summary</b></summary>

`UmbMenuStructureWorkspaceContext` and `UmbMenuVariantStructureWorkspaceContext` were two separate interfaces that happened to share a `structure` observable, with `getItemHref` only declared on the variant one. That made it impossible to express the variant contract as a proper specialisation of the base one, and the breadcrumb element consuming `getItemHref` had no compile-time guarantee it existed.

`UmbMenuStructureWorkspaceContext` is now generic over the structure item model and declares `getItemHref` as optional, so `UmbMenuVariantStructureWorkspaceContext` can extend it directly (re-declaring `getItemHref` as required, since variant breadcrumbs always need it) instead of duplicating the shape. The menu structure base classes (`UmbMenuTreeStructureWorkspaceContextBase`, `UmbMenuVariantTreeStructureWorkspaceContextBase`, `UmbMenuListStructureWorkspaceContextBase`) now explicitly `implements` their interface so a missing member fails to compile. While in there, private state fields on these classes were marked `readonly` since they're only ever assigned once, at construction.

</details>


### How to test?

1. Open a Document, Media, or Member workspace nested a few levels deep and confirm the breadcrumb still renders the full ancestor chain with working links.
2. Confirm clicking a breadcrumb item still navigates to that ancestor.
3. Run `npx tsc --noEmit` in `src/Umbraco.Web.UI.Client` and confirm it's clean.
