### PR TITLE
Refetch menu structure after creating root item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.test.ts
@@ -16,6 +16,7 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
+import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
 
 const TEST_TREE_REPOSITORY_ALIAS = 'Umb.Test.MenuTreeStructureWorkspaceContextBase.TreeRepository';
 
@@ -279,6 +280,73 @@ describe('UmbMenuTreeStructureWorkspaceContextBase (creating a new item)', () =>
 		await aTimeout(150);
 
 		expect(UmbTestSectionSidebarMenuContext.expandItemsCalls).to.have.lengthOf(1);
+	});
+});
+
+describe('UmbMenuTreeStructureWorkspaceContextBase (creating a new item directly under the root)', () => {
+	let host: UmbTestMenuStructureControllerHostElement;
+	let workspaceContext: UmbTestSubmittableTreeEntityWorkspaceContext;
+	let context: TestMenuTreeStructureWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.register(createTestTreeRepositoryManifest(TEST_TREE_REPOSITORY_ALIAS));
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregister(TEST_TREE_REPOSITORY_ALIAS);
+	});
+
+	beforeEach(async () => {
+		UmbTestTreeRepository.reset();
+		UmbTestSectionSidebarMenuContext.reset();
+
+		host = new UmbTestMenuStructureControllerHostElement();
+		document.body.appendChild(host);
+
+		workspaceContext = new UmbTestSubmittableTreeEntityWorkspaceContext(host);
+		new UmbContextProviderController(host, UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, workspaceContext as never);
+		new UmbContextProviderController(
+			host,
+			UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT,
+			new UmbTestSectionSidebarMenuContext(host) as never,
+		);
+
+		context = new TestMenuTreeStructureWorkspaceContext(host);
+		context.manifest = {
+			type: 'workspaceContext',
+			kind: 'menuStructure',
+			alias: 'Umb.Test.MenuStructureWorkspaceContext.CreateUnderRoot',
+			name: 'Test Menu Structure Workspace Context (create under root)',
+			meta: { menuItemAlias: 'test-menu-item' },
+		};
+
+		// Creating directly under the tree root (e.g. a Dictionary item created at the root): the parent IS the
+		// root, so no ancestors call happens while still new (the root is already the full structure on its own).
+		workspaceContext.setEntityType('test-entity-type');
+		workspaceContext.setIsNew(true);
+		workspaceContext.setCreateUnderParent({ unique: null, entityType: 'test-root-entity-type' });
+		workspaceContext.setUnique('new-item-unique');
+		await aTimeout(150);
+	});
+
+	afterEach(() => {
+		context.destroy();
+		document.body.removeChild(host);
+	});
+
+	it('re-fetches the structure once the item has been saved, so the root stays in the breadcrumb', async () => {
+		// The real ancestors endpoint, once the item exists, returns the item itself as the trailing entry.
+		UmbTestTreeRepository.ancestors = [createTestAncestorItem({ unique: 'new-item-unique', entityType: 'test-entity-type' })];
+
+		workspaceContext.setIsNew(false);
+		await aTimeout(150);
+
+		expect(UmbTestTreeRepository.requestTreeItemAncestorsCalls).to.deep.equal([
+			{ unique: 'new-item-unique', entityType: 'test-entity-type' },
+		]);
+
+		const structure = await firstValueFrom(context.structure);
+		expect(structure.map((item) => item.unique)).to.deep.equal([null, 'new-item-unique']);
 	});
 });
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -37,6 +37,7 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 	#ancestorContext = new UmbAncestorsEntityContext(this);
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
 	#isModalContext: boolean = false;
+	#isNew: boolean | undefined = undefined;
 	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 	#structureRequestId = 0;
 
@@ -82,9 +83,15 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 			this.observe(
 				this.#workspaceContext?.isNew,
 				(isNew) => {
-					if (isNew === false) {
+					// The item has just been created: the structure fetched while new was based on the parent (the
+					// item didn't exist yet), so it must be re-fetched using the item's own identity - otherwise the
+					// structure never ends with the item itself, which the breadcrumb relies on when trimming it.
+					if (isNew === false && this.#isNew === true) {
+						this.#requestStructure();
+					} else if (isNew === false) {
 						this.#tryExpandSectionSidebarMenu();
 					}
+					this.#isNew = isNew;
 				},
 				'observeIsNew',
 			);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -106,9 +106,10 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 			this.observe(
 				this.#workspaceContext?.isNew,
 				(isNew) => {
-					// The item has just been created: the structure fetched while new was based on the parent (the
-					// item didn't exist yet), so it must be re-fetched using the item's own identity - otherwise the
-					// structure never ends with the item itself, which the breadcrumb relies on when trimming it.
+					// The item has just been created: the structure fetched while new was based on the create-under
+					// parent's identity (the item didn't exist yet), so it must be re-fetched using the item's own
+					// identity - otherwise parent/ancestor data downstream keeps describing the parent it was
+					// created under rather than the entity that now actually exists.
 					if (isNew === false && this.#isNew === true) {
 						this.#requestStructure();
 					} else if (isNew === false) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -46,6 +46,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	#ancestorContext = new UmbAncestorsEntityContext(this);
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
 	#isModalContext: boolean = false;
+	#isNew: boolean | undefined = undefined;
 	#variantWorkspaceContext?: typeof UMB_VARIANT_WORKSPACE_CONTEXT.TYPE;
 	#workspaceActiveVariantId?: UmbVariantId;
 	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
@@ -105,9 +106,15 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 			this.observe(
 				this.#workspaceContext?.isNew,
 				(isNew) => {
-					if (isNew === false) {
+					// The item has just been created: the structure fetched while new was based on the parent (the
+					// item didn't exist yet), so it must be re-fetched using the item's own identity - otherwise the
+					// structure never ends with the item itself, which the breadcrumb relies on when trimming it.
+					if (isNew === false && this.#isNew === true) {
+						this.#requestStructure();
+					} else if (isNew === false) {
 						this.#tryExpandSectionSidebarMenu();
 					}
+					this.#isNew = isNew;
 				},
 				'observeIsNew',
 			);


### PR DESCRIPTION
PR fixing unreleased regression introduced by #23860

**Symptom:** Creating a new item directly under a tree root (e.g. a Dictionary item at the root) shows the correct breadcrumb while creating (`Dictionary / New Item`), but loses the root segment as soon as the item is saved — the breadcrumb becomes just `New Item`.

**Root cause:** `UmbMenuTreeStructureWorkspaceContextBase`/`UmbMenuVariantTreeStructureWorkspaceContextBase` fetch the menu "structure" (root + ancestors) using the *parent's* identity while the workspace is new (the entity doesn't exist yet), and using the entity's *own* identity once it's saved. The breadcrumb component (`workspace-menu-breadcrumb.element.ts`) relies on that: once `isNew` is `false`, it assumes the last item in `structure` is the entity itself and trims it off (`structure.slice(0, -1)`) before appending the live name.

#23860 removed the structure re-fetch that used to run on the `isNew: true → false` transition (replacing it with only a menu-expand call), on the assumption it wasn't needed. For an item created directly under the root, the structure fetched while still "new" is just `[root]` (the ancestor fetch is skipped entirely, since the parent *is* the root). Without a re-fetch after save, that stays as `[root]`, and the breadcrumb's "trim the last item" logic then strips the root itself instead of a self-entry — exactly matching the reported symptom.

**Fix:** restore the structure re-fetch specifically on the `isNew: true → false` transition, keeping the decoupled menu-expand behavior from #23860 for the other cases it was meant to fix.

### How to test

1. Go to Translation → Dictionary.
2. Click "Create" at the root level.
3. Confirm the breadcrumb reads `Dictionary / <name>` while creating.
4. Enter a name and save.
5. Confirm the breadcrumb still reads `Dictionary / <name>` after saving (previously it dropped to just `<name>`).



