### PR TITLE
Dictionary: Add `KeySearchMode` setting to control how the filter matches the item key (closes #23881)

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/DictionaryKeySearchMode.cs
+++ b/src/Umbraco.Core/Configuration/Models/DictionaryKeySearchMode.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Configuration.Models;
+
+/// <summary>
+///     Determines how a dictionary item filter is matched against the dictionary item key.
+/// </summary>
+public enum DictionaryKeySearchMode
+{
+    /// <summary>
+    ///     Match keys that start with the filter.
+    /// </summary>
+    StartsWith,
+
+    /// <summary>
+    ///     Match keys that contain the filter at any position. This finds more items than <see cref="StartsWith" />,
+    ///     at the cost of a less efficient lookup on installations with a large number of dictionary items.
+    /// </summary>
+    Contains,
+}

--- a/src/Umbraco.Core/Configuration/Models/DictionarySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/DictionarySettings.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Cms.Core.Configuration.Models;
 public class DictionarySettings
 {
     private const bool StaticEnableValueSearch = false;
+    private const DictionaryKeySearchMode StaticKeySearchMode = DictionaryKeySearchMode.StartsWith;
 
     /// <summary>
     ///     Gets or sets a value indicating whether to enable searching in dictionary values in addition to keys.
@@ -22,4 +23,13 @@ public class DictionarySettings
     /// </remarks>
     [DefaultValue(StaticEnableValueSearch)]
     public bool EnableValueSearch { get; set; } = StaticEnableValueSearch;
+
+    /// <summary>
+    ///     Gets or sets a value indicating how a dictionary item filter is matched against the dictionary item key.
+    /// </summary>
+    /// <remarks>
+    ///     Applies whether or not <see cref="EnableValueSearch" /> is enabled.
+    /// </remarks>
+    [DefaultValue(StaticKeySearchMode)]
+    public DictionaryKeySearchMode KeySearchMode { get; set; } = StaticKeySearchMode;
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -212,13 +212,13 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             // Then fetch ALL translations for those items
             sql.Where(
                 $"({QuotedColumn("key")} LIKE @0 OR {QuotedColumn("id")} IN (SELECT DISTINCT {QuoteColumnName("UniqueId")} FROM {QuoteTableName(LanguageTextDto.TableName)} WHERE {QuoteColumnName("value")} LIKE @1))",
-                $"{filter}%",
+                $"%{filter}%",
                 $"%{filter}%");
         }
         else
         {
             // Search only in keys
-            sql.Where<DictionaryDto>(x => x.Key.StartsWith(filter));
+            sql.Where<DictionaryDto>(x => x.Key.Contains(filter));
         }
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NPoco;
@@ -206,7 +207,15 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
         }
 
         DictionarySettings settings = _dictionarySettings.CurrentValue;
-        var matchKeyAnywhere = settings.KeySearchMode == DictionaryKeySearchMode.Contains;
+
+        // Resolve search mode forms. The key is matched as a LIKE pattern when combined with the translation
+        // values in raw SQL, and as a predicate when matched on its own.
+        (string Pattern, Expression<Func<DictionaryDto, bool>> Predicate) keyMatch = settings.KeySearchMode switch
+        {
+            DictionaryKeySearchMode.Contains => ($"%{filter}%", x => x.Key.Contains(filter)),
+            DictionaryKeySearchMode.StartsWith => ($"{filter}%", x => x.Key.StartsWith(filter)),
+            _ => throw new ArgumentOutOfRangeException(nameof(settings.KeySearchMode), settings.KeySearchMode, null),
+        };
 
         if (settings.EnableValueSearch)
         {
@@ -215,15 +224,13 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             // Then fetch ALL translations for those items
             sql.Where(
                 $"({QuotedColumn("key")} LIKE @0 OR {QuotedColumn("id")} IN (SELECT DISTINCT {QuoteColumnName("UniqueId")} FROM {QuoteTableName(LanguageTextDto.TableName)} WHERE {QuoteColumnName("value")} LIKE @1))",
-                matchKeyAnywhere ? $"%{filter}%" : $"{filter}%",
+                keyMatch.Pattern,
                 $"%{filter}%");
         }
         else
         {
             // Search only in keys
-            sql.Where<DictionaryDto>(matchKeyAnywhere
-                ? x => x.Key.Contains(filter)
-                : x => x.Key.StartsWith(filter));
+            sql.Where(keyMatch.Predicate);
         }
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -205,20 +205,25 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             return;
         }
 
-        if (_dictionarySettings.CurrentValue.EnableValueSearch)
+        DictionarySettings settings = _dictionarySettings.CurrentValue;
+        var matchKeyAnywhere = settings.KeySearchMode == DictionaryKeySearchMode.Contains;
+
+        if (settings.EnableValueSearch)
         {
             // Search in both keys and values
             // Use a subquery to find dictionary items that have matching translations
             // Then fetch ALL translations for those items
             sql.Where(
                 $"({QuotedColumn("key")} LIKE @0 OR {QuotedColumn("id")} IN (SELECT DISTINCT {QuoteColumnName("UniqueId")} FROM {QuoteTableName(LanguageTextDto.TableName)} WHERE {QuoteColumnName("value")} LIKE @1))",
-                $"%{filter}%",
+                matchKeyAnywhere ? $"%{filter}%" : $"{filter}%",
                 $"%{filter}%");
         }
         else
         {
             // Search only in keys
-            sql.Where<DictionaryDto>(x => x.Key.Contains(filter));
+            sql.Where<DictionaryDto>(matchKeyAnywhere
+                ? x => x.Key.Contains(filter)
+                : x => x.Key.StartsWith(filter));
         }
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
@@ -649,6 +649,39 @@ internal sealed class DictionaryRepositoryTest : UmbracoIntegrationTest
         }
     }
 
+    /// <summary>
+    /// Verifies that <see cref="IDictionaryRepository.GetDictionaryItemDescendants"/> matches the filter
+    /// anywhere in the dictionary item key, not only at the start of it.
+    /// </summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task GetDictionaryItemDescendants_Matches_Filter_Anywhere_In_Key(bool enableValueSearch)
+    {
+        // Arrange - a key whose middle segment does not occur in any of its translation values,
+        // so only a key match can satisfy the filter regardless of the value search setting.
+        var languageService = GetRequiredService<ILanguageService>();
+        var dictionaryItemService = GetRequiredService<IDictionaryItemService>();
+        var language = await languageService.GetAsync("en-US");
+
+        await dictionaryItemService.CreateAsync(
+            new DictionaryItem("AlphaBravoCharlie")
+            {
+                Translations = new List<IDictionaryTranslation> { new DictionaryTranslation(language, "Delta") }
+            },
+            Constants.Security.SuperUserKey);
+
+        var repository = CreateRepositoryWithCache(AppCaches.Create(Mock.Of<IRequestCache>()), enableValueSearch);
+
+        using (ScopeProvider.CreateScope())
+        {
+            // Act
+            var results = repository.GetDictionaryItemDescendants(null, "Bravo").ToArray();
+
+            // Assert
+            Assert.That(results.Select(x => x.ItemKey), Is.EqualTo(new[] { "AlphaBravoCharlie" }));
+        }
+    }
+
     public async Task CreateTestData()
     {
         var languageService = GetRequiredService<ILanguageService>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
@@ -693,6 +693,47 @@ internal sealed class DictionaryRepositoryTest : UmbracoIntegrationTest
         }
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task GetDictionaryItemDescendants_Of_Parent_With_KeySearchMode_Contains_Matches_Filter_Anywhere_In_Key(bool enableValueSearch)
+    {
+        // Arrange
+        var parentKey = await CreateChildItemWithFilterTermInsideKey();
+        var repository = CreateRepositoryWithCache(AppCaches.Create(Mock.Of<IRequestCache>()), enableValueSearch, DictionaryKeySearchMode.Contains);
+
+        using (ScopeProvider.CreateScope())
+        {
+            // Act
+            var results = repository.GetDictionaryItemDescendants(parentKey, "Bravo").ToArray();
+
+            // Assert
+            Assert.That(results.Select(x => x.ItemKey), Is.EqualTo(new[] { "AlphaBravoCharlie" }));
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task GetDictionaryItemDescendants_Of_Parent_With_KeySearchMode_StartsWith_Matches_Filter_Only_At_Start_Of_Key(bool enableValueSearch)
+    {
+        // Arrange
+        var parentKey = await CreateChildItemWithFilterTermInsideKey();
+        var repository = CreateRepositoryWithCache(AppCaches.Create(Mock.Of<IRequestCache>()), enableValueSearch, DictionaryKeySearchMode.StartsWith);
+
+        using (ScopeProvider.CreateScope())
+        {
+            // Act
+            var matchedInsideKey = repository.GetDictionaryItemDescendants(parentKey, "Bravo").ToArray();
+            var matchedAtStartOfKey = repository.GetDictionaryItemDescendants(parentKey, "Alpha").ToArray();
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(matchedInsideKey, Is.Empty);
+                Assert.That(matchedAtStartOfKey.Select(x => x.ItemKey), Is.EqualTo(new[] { "AlphaBravoCharlie" }));
+            });
+        }
+    }
+
     /// <summary>
     /// Creates a dictionary item whose key contains "Bravo" at a position other than the start, and whose
     /// translation value contains neither "Bravo" nor "Alpha" so that only a key match can satisfy those filters.
@@ -711,6 +752,40 @@ internal sealed class DictionaryRepositoryTest : UmbracoIntegrationTest
                 }
             },
             Constants.Security.SuperUserKey);
+    }
+
+    /// <summary>
+    /// Creates the same item as <see cref="CreateItemWithFilterTermInsideKey" />, but as the child of another
+    /// item, so that the filter is applied by the recursive descendant query rather than the flat one.
+    /// </summary>
+    /// <returns>The key of the parent dictionary item.</returns>
+    private async Task<Guid> CreateChildItemWithFilterTermInsideKey()
+    {
+        var languageService = GetRequiredService<ILanguageService>();
+        var dictionaryItemService = GetRequiredService<IDictionaryItemService>();
+
+        var parentKey = (await dictionaryItemService.CreateAsync(
+            new DictionaryItem("Omega")
+            {
+                Translations = new List<IDictionaryTranslation>
+                {
+                    new DictionaryTranslation(await languageService.GetAsync("en-US"), "Omega")
+                }
+            },
+            Constants.Security.SuperUserKey)).Result.Key;
+
+        await dictionaryItemService.CreateAsync(
+            new DictionaryItem("AlphaBravoCharlie")
+            {
+                ParentId = parentKey,
+                Translations = new List<IDictionaryTranslation>
+                {
+                    new DictionaryTranslation(await languageService.GetAsync("en-US"), "Delta")
+                }
+            },
+            Constants.Security.SuperUserKey);
+
+        return parentKey;
     }
 
     public async Task CreateTestData()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
@@ -672,11 +672,11 @@ internal sealed class DictionaryRepositoryTest : UmbracoIntegrationTest
 
     [TestCase(true)]
     [TestCase(false)]
-    public async Task GetDictionaryItemDescendants_With_Default_KeySearchMode_Matches_Filter_Only_At_Start_Of_Key(bool enableValueSearch)
+    public async Task GetDictionaryItemDescendants_With_KeySearchMode_StartsWith_Matches_Filter_Only_At_Start_Of_Key(bool enableValueSearch)
     {
         // Arrange
         await CreateItemWithFilterTermInsideKey();
-        var repository = CreateRepositoryWithCache(AppCaches.Create(Mock.Of<IRequestCache>()), enableValueSearch);
+        var repository = CreateRepositoryWithCache(AppCaches.Create(Mock.Of<IRequestCache>()), enableValueSearch, DictionaryKeySearchMode.StartsWith);
 
         using (ScopeProvider.CreateScope())
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
@@ -27,10 +27,13 @@ internal sealed class DictionaryRepositoryTest : UmbracoIntegrationTest
 
     private IDictionaryRepository CreateRepository() => GetRequiredService<IDictionaryRepository>();
 
-    private IDictionaryRepository CreateRepositoryWithCache(AppCaches cache, bool enableValueSearch = false)
+    private IDictionaryRepository CreateRepositoryWithCache(
+        AppCaches cache,
+        bool enableValueSearch = false,
+        DictionaryKeySearchMode keySearchMode = DictionaryKeySearchMode.StartsWith)
     {
         var dictionarySettingsMonitor = new Mock<IOptionsMonitor<DictionarySettings>>();
-        dictionarySettingsMonitor.Setup(x => x.CurrentValue).Returns(new DictionarySettings { EnableValueSearch = enableValueSearch });
+        dictionarySettingsMonitor.Setup(x => x.CurrentValue).Returns(new DictionarySettings { EnableValueSearch = enableValueSearch, KeySearchMode = keySearchMode });
 
         // Create a repository with a real runtime cache.
         return new DictionaryRepository(
@@ -649,28 +652,13 @@ internal sealed class DictionaryRepositoryTest : UmbracoIntegrationTest
         }
     }
 
-    /// <summary>
-    /// Verifies that <see cref="IDictionaryRepository.GetDictionaryItemDescendants"/> matches the filter
-    /// anywhere in the dictionary item key, not only at the start of it.
-    /// </summary>
     [TestCase(true)]
     [TestCase(false)]
-    public async Task GetDictionaryItemDescendants_Matches_Filter_Anywhere_In_Key(bool enableValueSearch)
+    public async Task GetDictionaryItemDescendants_With_KeySearchMode_Contains_Matches_Filter_Anywhere_In_Key(bool enableValueSearch)
     {
-        // Arrange - a key whose middle segment does not occur in any of its translation values,
-        // so only a key match can satisfy the filter regardless of the value search setting.
-        var languageService = GetRequiredService<ILanguageService>();
-        var dictionaryItemService = GetRequiredService<IDictionaryItemService>();
-        var language = await languageService.GetAsync("en-US");
-
-        await dictionaryItemService.CreateAsync(
-            new DictionaryItem("AlphaBravoCharlie")
-            {
-                Translations = new List<IDictionaryTranslation> { new DictionaryTranslation(language, "Delta") }
-            },
-            Constants.Security.SuperUserKey);
-
-        var repository = CreateRepositoryWithCache(AppCaches.Create(Mock.Of<IRequestCache>()), enableValueSearch);
+        // Arrange
+        await CreateItemWithFilterTermInsideKey();
+        var repository = CreateRepositoryWithCache(AppCaches.Create(Mock.Of<IRequestCache>()), enableValueSearch, DictionaryKeySearchMode.Contains);
 
         using (ScopeProvider.CreateScope())
         {
@@ -680,6 +668,49 @@ internal sealed class DictionaryRepositoryTest : UmbracoIntegrationTest
             // Assert
             Assert.That(results.Select(x => x.ItemKey), Is.EqualTo(new[] { "AlphaBravoCharlie" }));
         }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task GetDictionaryItemDescendants_With_Default_KeySearchMode_Matches_Filter_Only_At_Start_Of_Key(bool enableValueSearch)
+    {
+        // Arrange
+        await CreateItemWithFilterTermInsideKey();
+        var repository = CreateRepositoryWithCache(AppCaches.Create(Mock.Of<IRequestCache>()), enableValueSearch);
+
+        using (ScopeProvider.CreateScope())
+        {
+            // Act
+            var matchedInsideKey = repository.GetDictionaryItemDescendants(null, "Bravo").ToArray();
+            var matchedAtStartOfKey = repository.GetDictionaryItemDescendants(null, "Alpha").ToArray();
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(matchedInsideKey, Is.Empty);
+                Assert.That(matchedAtStartOfKey.Select(x => x.ItemKey), Is.EqualTo(new[] { "AlphaBravoCharlie" }));
+            });
+        }
+    }
+
+    /// <summary>
+    /// Creates a dictionary item whose key contains "Bravo" at a position other than the start, and whose
+    /// translation value contains neither "Bravo" nor "Alpha" so that only a key match can satisfy those filters.
+    /// </summary>
+    private async Task CreateItemWithFilterTermInsideKey()
+    {
+        var languageService = GetRequiredService<ILanguageService>();
+        var dictionaryItemService = GetRequiredService<IDictionaryItemService>();
+
+        await dictionaryItemService.CreateAsync(
+            new DictionaryItem("AlphaBravoCharlie")
+            {
+                Translations = new List<IDictionaryTranslation>
+                {
+                    new DictionaryTranslation(await languageService.GetAsync("en-US"), "Delta")
+                }
+            },
+            Constants.Security.SuperUserKey);
     }
 
     public async Task CreateTestData()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #23881

### Description

The dictionary filter only matched the start of the item key, so searching `Intro` never found `FanclubIntroText`.

Adds `Umbraco:CMS:Dictionary:KeySearchMode` with `StartsWith` (default, unchanged behaviour and index seek) and `Contains`. It applies whether or not `EnableValueSearch` is enabled, as discussed in the issue.

### How to test

1. Create a dictionary item `FanclubIntroText`.
2. Search for `Intro` in *Translation* → *Dictionary*, or call `GET /umbraco/management/api/v1/dictionary?skip=0&take=50&filter=Intro`.
3. Default: no result. With `KeySearchMode: Contains`: the item is returned.

Covered by `GetDictionaryItemDescendants_With_KeySearchMode_Contains_Matches_Filter_Anywhere_In_Key` and `..._With_Default_KeySearchMode_Matches_Filter_Only_At_Start_Of_Key`, both run for `EnableValueSearch` true and false.
