### PR TITLE
Localization: Regenerate the known localization keys (fixes the generation guard test)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/known-keys.const.generated.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/known-keys.const.generated.ts
@@ -456,6 +456,7 @@ export const KNOWN_LOCALIZATION_KEYS: readonly UmbKnownLocalizationKey[] = [
 	'content_isPublished',
 	'content_isSensitiveValue',
 	'content_isSensitiveValue_short',
+	'content_isSensitiveValueNotice',
 	'content_itemChanged',
 	'content_itemNotPublished',
 	'content_languagesToPublish',

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/known-keys.types.generated.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/known-keys.types.generated.ts
@@ -483,6 +483,7 @@ declare global {
 		content_isPublished: string;
 		content_isSensitiveValue: string;
 		content_isSensitiveValue_short: string;
+		content_isSensitiveValueNotice: string;
 		content_itemChanged: string;
 		content_itemNotPublished: string;
 		content_languagesToPublish: string;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

`content.isSensitiveValueNotice` exists in `src/Umbraco.Web.UI.Client/src/assets/lang/en.ts` but the committed generated key files were never regenerated for it. `known-keys.test.ts` — the guard that exists to catch exactly this drift — is therefore **failing on `main` today**:

```
❌ UmbKnownLocalizationSet generation > stays in sync with `assets/lang/en.ts`
   AssertionError: 1 key(s) in en.ts are missing from the generated file.
   Missing: content_isSensitiveValueNotice
```

This regenerates the two files. No hand edits — the two added lines are the generator's own output:

```bash
cd src/Umbraco.Web.UI.Client
node ./devops/localization/generate-known-keys.js   # what `npm run generate:localization-keys` runs
```

Why it drifted in the first place: the generator runs as part of `prebuild`, which `build:for:cms` and `test:prepare` both invoke, so every local build and CI build regenerates these files — but nothing fails on *uncommitted* generated output, so the regenerated result was simply never committed. The guard test is what catches it, and it has been red rather than blocking.

Splitting this out on its own because it keeps turning up as unrelated noise in feature PRs (it was picked up incidentally by https://github.com/umbraco/Umbraco-CMS/pull/23793), and because these files do not exist on the v17 line at all, so carrying them in a feature branch breaks cherry-picks back to `v17/dev`.

### How to test

```bash
cd src/Umbraco.Web.UI.Client
npm ci
npm test -- --files "src/libs/localization-api/known-keys.test.ts"
```

Fails on `main` with the assertion above; passes on this branch. Verified locally both ways.

Re-running the generator on this branch produces no further diff, confirming the committed output is current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQbHMCm1MTgJjFQd6RrnvN


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQbHMCm1MTgJjFQd6RrnvN)_