### PR TITLE
Cookies: Write the exposed backoffice cookie only once per token response (closes #23885)

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Security/ExposeBackOfficeAuthenticationOpenIddictServerEventsHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/Security/ExposeBackOfficeAuthenticationOpenIddictServerEventsHandler.cs
@@ -48,8 +48,9 @@ public class ExposeBackOfficeAuthenticationOpenIddictServerEventsHandler : IOpen
     /// </remarks>
     public async ValueTask HandleAsync(OpenIddictServerEvents.GenerateTokenContext context)
     {
-        // A single token response generates several tokens (access, refresh and potentially identity tokens), each
-        // raising this event. We only sign in once per response, otherwise the cookie is written multiple times.
+        // This event is raised once per generated token, not once per token response, so signing in on every
+        // occurrence would write the cookie more than once. The access token is the one token generated both by
+        // the initial code exchange and by every refresh grant, making it the point to refresh the cookie from.
         if (context.TokenType != OpenIddictConstants.TokenTypeIdentifiers.AccessToken)
         {
             return;

--- a/src/Umbraco.Cms.Api.Common/Security/ExposeBackOfficeAuthenticationOpenIddictServerEventsHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/Security/ExposeBackOfficeAuthenticationOpenIddictServerEventsHandler.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using OpenIddict.Abstractions;
 using OpenIddict.Server;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Security;
@@ -47,6 +48,13 @@ public class ExposeBackOfficeAuthenticationOpenIddictServerEventsHandler : IOpen
     /// </remarks>
     public async ValueTask HandleAsync(OpenIddictServerEvents.GenerateTokenContext context)
     {
+        // A single token response generates several tokens (access, refresh and potentially identity tokens), each
+        // raising this event. We only sign in once per response, otherwise the cookie is written multiple times.
+        if (context.TokenType != OpenIddictConstants.TokenTypeIdentifiers.AccessToken)
+        {
+            return;
+        }
+
         // Only proceed if this is a back-office sign-in.
         if (context.Principal.Identity?.AuthenticationType != Core.Constants.Security.BackOfficeAuthenticationType)
         {


### PR DESCRIPTION
## Description

Signing in to the backoffice returned two `Set-Cookie` headers for `UMB_UCONTEXT_EXPOSED` in the same response, each with different ciphertext but identical attributes:

```http
Set-Cookie: UMB_UCONTEXT_EXPOSED=<value-1>; path=/; secure; samesite=lax; httponly
Set-Cookie: UMB_UCONTEXT_EXPOSED=<value-2>; path=/; secure; samesite=lax; httponly
```

### Why did it happen?

`ExposeBackOfficeAuthenticationOpenIddictServerEventsHandler` is registered against OpenIddict's `GenerateTokenContext`, and that event is raised **once per token generated**, not once per token response. Because the backoffice uses both reference access tokens and reference refresh tokens, a single token exchange runs `GenerateAccessToken` *and* `GenerateRefreshToken`, so the handler called `HttpContext.SignInAsync` twice.

The cookie authentication handler appends a `Set-Cookie` header rather than replacing an existing one, and `GetAuthenticationProperties()` re-stamps `IssuedUtc`/`ExpiresUtc` on each call — hence two headers carrying the same principal under different ciphertext.

The browser keeps the last value and both tickets are valid, so the practical impact was small, but the response carried a redundant copy of a large encrypted cookie.

### How is it fixed?

The handler now returns early unless the token being generated is the access token:

```csharp
if (context.TokenType != OpenIddictConstants.TokenTypeIdentifiers.AccessToken)
{
    return;
}
```

Access token is the right anchor rather than refresh token, because it is generated both on the initial authorization-code exchange and on every refresh grant — so the cookie is still written, and still slid forward, at exactly the points it was before.

Fixes #23885

## Testing

### Manual

Verified in the debugger: access-token generation proceeds and writes the cookie, refresh-token generation returns early, leaving a single `Set-Cookie: UMB_UCONTEXT_EXPOSED` header on the token response.

The response can also be viewed via dev tools, looking at the response headers on the `/umbraco/management/api/v1/security/back-office/token` response.  Previously two `Set-Cookie` headers for `UMB_UCONTEXT_EXPOSED` are seen, now only one.