### PR TITLE
Publishing: Align the languages offered by the publish-with-descendants dialog with the other publish dialogs (closes #23886)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/index.ts
@@ -2,5 +2,6 @@ export * from './bulk-content-publishing.controller.js';
 export * from './content-published-pending-changes-manager-base.js';
 export * from './publish/index.js';
 export * from './unpublish/index.js';
+export * from './utils.js';
 
 export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/publish/modal/content-publish-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/publish/modal/content-publish-modal.element.ts
@@ -1,4 +1,4 @@
-import { isNotPublishedMandatory } from '../../utils.js';
+import { isNotPublishedMandatory, isSelectableForPublishing } from '../../utils.js';
 import type { UmbContentPublishModalData, UmbContentPublishModalValue } from './types.js';
 import { css, customElement, html, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
@@ -47,7 +47,7 @@ export class UmbContentPublishModalElement extends UmbModalBaseElement<
 		this.#selectionManager.setMultiple(true);
 		this.#selectionManager.setSelectable(true);
 
-		this._options = this.#filterSelectableOptions(this.data?.options ?? []);
+		this._options = this.data?.options.filter(isSelectableForPublishing) ?? [];
 
 		const validOptions = this._options.filter((o) => this.#pickableFilter(o));
 
@@ -57,17 +57,6 @@ export class UmbContentPublishModalElement extends UmbModalBaseElement<
 		this.#selectionManager.setSelection(selected);
 
 		this.observe(this.#selectionManager.selection, this.#handleSelectionChange, 'observeSelection');
-	}
-
-	#filterSelectableOptions(options: Array<UmbEntityVariantOptionModel>): Array<UmbEntityVariantOptionModel> {
-		// Only display variants that are relevant to pick from, i.e. variants that are draft, not-published-mandatory or published with pending changes.
-		// If we don't know the state (e.g. from a bulk publishing selection) we need to consider it available for selection.
-		return options.filter(
-			(option) =>
-				option.variant?.state === null ||
-				isNotPublishedMandatory(option) ||
-				(option.variant && option.variant.state !== UmbPublishableVariantState.NOT_CREATED),
-		);
 	}
 
 	readonly #handleSelectionChange = (selection: Array<string>) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/utils.ts
@@ -13,3 +13,18 @@ export function isNotPublishedMandatory(option: UmbEntityVariantOptionModel): bo
 		option.variant?.state !== UmbPublishableVariantState.PUBLISHED_PENDING_CHANGES
 	);
 }
+
+/**
+ * @function isSelectableForPublishing
+ * @param {UmbEntityVariantOptionModel} option - the option to check.
+ * @returns {boolean} boolean
+ * @description A variant can only be published if it holds data, so a variant that has not been created is not
+ * selectable — unless its language is mandatory and not yet published, in which case it is listed as a requirement.
+ * A variant whose state is unknown (e.g. from a bulk selection) has to be considered selectable.
+ */
+export function isSelectableForPublishing(option: UmbEntityVariantOptionModel): boolean {
+	return (
+		isNotPublishedMandatory(option) ||
+		(!!option.variant && option.variant.state !== UmbPublishableVariantState.NOT_CREATED)
+	);
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
@@ -1,6 +1,5 @@
-import { UmbDocumentVariantState } from '../../../variant-state.js';
 import type { UmbDocumentVariantOptionModel } from '../../../types.js';
-import { isNotPublishedMandatory } from '../../utils.js';
+import { isNotPublishedMandatory, isSelectableForPublishing } from '../../utils.js';
 import type {
 	UmbDocumentPublishWithDescendantsModalData,
 	UmbDocumentPublishWithDescendantsModalValue,
@@ -42,11 +41,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 		this.#selectionManager.setMultiple(true);
 		this.#selectionManager.setSelectable(true);
 
-		// Only display variants that are relevant to pick from, i.e. variants that are draft, not-published-mandatory or published with pending changes:
-		this._options =
-			this.data?.options.filter(
-				(option) => isNotPublishedMandatory(option) || option.variant?.state !== UmbDocumentVariantState.NOT_CREATED,
-			) ?? [];
+		this._options = this.data?.options.filter(isSelectableForPublishing) ?? [];
 
 		let selected = this.value?.selection ?? [];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.test.ts
@@ -2,7 +2,6 @@ import { UmbDocumentVariantState } from '../../../variant-state.js';
 import type { UmbDocumentPublishWithDescendantsModalElement } from './document-publish-with-descendants-modal.element.js';
 import type { UmbDocumentVariantOptionModel } from '../../../types.js';
 import { expect, fixture, html } from '@open-wc/testing';
-import type { UmbDocumentVariantLanguagePickerElement } from '../../../modals/shared/document-variant-language-picker.element.js';
 
 import './document-publish-with-descendants-modal.element.js';
 
@@ -49,11 +48,10 @@ async function listedOptions(options: Array<UmbDocumentVariantOptionModel>): Pro
 	);
 	await element.updateComplete;
 
-	const picker = element.shadowRoot!.querySelector(
-		'umb-document-variant-language-picker',
-	) as UmbDocumentVariantLanguagePickerElement;
+	const picker = element.shadowRoot!.querySelector('umb-document-variant-language-picker');
+	expect(picker, 'the variant picker is rendered').to.exist;
 
-	return picker.variantLanguageOptions.map((o) => o.unique);
+	return picker!.variantLanguageOptions.map((o) => o.unique);
 }
 
 describe('UmbDocumentPublishWithDescendantsModalElement', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.test.ts
@@ -1,0 +1,89 @@
+import { UmbDocumentVariantState } from '../../../variant-state.js';
+import type { UmbDocumentPublishWithDescendantsModalElement } from './document-publish-with-descendants-modal.element.js';
+import type { UmbDocumentVariantOptionModel } from '../../../types.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import type { UmbDocumentVariantLanguagePickerElement } from '../../../modals/shared/document-variant-language-picker.element.js';
+
+import './document-publish-with-descendants-modal.element.js';
+
+function option(
+	unique: string,
+	variant: Partial<UmbDocumentVariantOptionModel['variant']> | undefined,
+	language: Partial<UmbDocumentVariantOptionModel['language']> = {},
+): UmbDocumentVariantOptionModel {
+	return {
+		unique,
+		culture: unique,
+		segment: null,
+		variant: variant
+			? ({
+					name: unique,
+					culture: unique,
+					segment: null,
+					state: UmbDocumentVariantState.DRAFT,
+					createDate: null,
+					publishDate: null,
+					updateDate: null,
+					scheduledPublishDate: null,
+					scheduledUnpublishDate: null,
+					flags: [],
+					...variant,
+				} as UmbDocumentVariantOptionModel['variant'])
+			: undefined,
+		language: {
+			entityType: 'language',
+			name: unique,
+			unique,
+			isDefault: false,
+			isMandatory: false,
+			fallbackIsoCode: null,
+			...language,
+		},
+	} as UmbDocumentVariantOptionModel;
+}
+
+async function listedOptions(options: Array<UmbDocumentVariantOptionModel>): Promise<Array<string>> {
+	const element = await fixture<UmbDocumentPublishWithDescendantsModalElement>(
+		html`<umb-document-publish-with-descendants-modal
+			.data=${{ options }}></umb-document-publish-with-descendants-modal>`,
+	);
+	await element.updateComplete;
+
+	const picker = element.shadowRoot!.querySelector(
+		'umb-document-variant-language-picker',
+	) as UmbDocumentVariantLanguagePickerElement;
+
+	return picker.variantLanguageOptions.map((o) => o.unique);
+}
+
+describe('UmbDocumentPublishWithDescendantsModalElement', () => {
+	// A variant the document does not hold any data for cannot be published, so listing it offers the user
+	// a choice that can never be acted on. (#23886)
+	it('does not list variants that have not been created', async () => {
+		const listed = await listedOptions([
+			option('en-us', { state: UmbDocumentVariantState.PUBLISHED }),
+			option('da-dk', { state: UmbDocumentVariantState.NOT_CREATED }),
+			option('de-de', undefined),
+		]);
+
+		expect(listed).to.eql(['en-us']);
+	});
+
+	// A mandatory language has to be publishable from here even before it holds data, as publishing cannot
+	// complete without it.
+	it('lists a mandatory variant that has not been created', async () => {
+		const listed = await listedOptions([
+			option('en-us', { state: UmbDocumentVariantState.PUBLISHED }),
+			option('da-dk', undefined, { isMandatory: true }),
+		]);
+
+		expect(listed).to.have.members(['en-us', 'da-dk']);
+	});
+
+	// A variant whose state is unknown may well hold data, so it stays available for selection.
+	it('lists variants of unknown state', async () => {
+		const listed = await listedOptions([option('en-us', { state: null })]);
+
+		expect(listed).to.eql(['en-us']);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/modal/document-publish-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/modal/document-publish-modal.element.ts
@@ -1,6 +1,6 @@
 import { UmbDocumentVariantState } from '../../../variant-state.js';
 import type { UmbDocumentVariantOptionModel } from '../../../types.js';
-import { isNotPublishedMandatory } from '../../utils.js';
+import { isNotPublishedMandatory, isSelectableForPublishing } from '../../utils.js';
 import type { UmbDocumentPublishModalData, UmbDocumentPublishModalValue } from './document-publish-modal.token.js';
 import { css, customElement, html, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
@@ -62,15 +62,7 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 		this.#selectionManager.setMultiple(true);
 		this.#selectionManager.setSelectable(true);
 
-		// Only display variants that are relevant to pick from, i.e. variants that are draft, not-published-mandatory or published with pending changes.
-		// If we don't know the state (e.g. from a bulk publishing selection) we need to consider it available for selection.
-		this._options =
-			this.data?.options.filter(
-				(option) =>
-					(option.variant && option.variant.state === null) ||
-					isNotPublishedMandatory(option) ||
-					option.variant?.state !== UmbDocumentVariantState.NOT_CREATED,
-			) ?? [];
+		this._options = this.data?.options.filter(isSelectableForPublishing) ?? [];
 
 		let selected = this.value?.selection ?? [];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -98,8 +98,6 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 
 		let selected = this.data?.activeVariants ?? [];
 
-		// Only display variants that are relevant to pick from, i.e. variants that are draft, not-published-mandatory or published with pending changes.
-		// If we don't know the state (e.g. from a bulk publishing selection) we need to consider it available for selection.
 		const validOptions = this._options.filter((option) => this.#pickableFilter(option));
 
 		// Filter selection based on options:

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -1,6 +1,6 @@
 import { UmbDocumentVariantState } from '../../../variant-state.js';
 import type { UmbDocumentVariantOptionModel } from '../../../types.js';
-import { isNotPublishedMandatory } from '../../utils.js';
+import { isNotPublishedMandatory, isSelectableForPublishing } from '../../utils.js';
 import { UmbDocumentVariantLanguagePickerElement } from '../../../modals/index.js';
 import type {
 	UmbDocumentScheduleModalData,
@@ -94,15 +94,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 			return option ? this.#pickableFilter(option) : true;
 		});
 
-		// Only display variants that are relevant to pick from, i.e. variants that are draft, not-published-mandatory or published with pending changes.
-		// If we don't know the state (e.g. from a bulk publishing selection) we need to consider it available for selection.
-		this._options =
-			this.data?.options.filter(
-				(option) =>
-					(option.variant && option.variant.state === null) ||
-					isNotPublishedMandatory(option) ||
-					option.variant?.state !== UmbDocumentVariantState.NOT_CREATED,
-			) ?? [];
+		this._options = this.data?.options.filter(isSelectableForPublishing) ?? [];
 
 		let selected = this.data?.activeVariants ?? [];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/utils.ts
@@ -1,15 +1,1 @@
-import { UmbDocumentVariantState } from '../variant-state.js';
-import type { UmbDocumentVariantOptionModel } from '../types.js';
-
-/**
- * @function isNotPublishedMandatory
- * @param {UmbDocumentVariantOptionModel} option - the option to check.
- * @returns {boolean} boolean
- */
-export function isNotPublishedMandatory(option: UmbDocumentVariantOptionModel): boolean {
-	return (
-		option.language.isMandatory &&
-		option.variant?.state !== UmbDocumentVariantState.PUBLISHED &&
-		option.variant?.state !== UmbDocumentVariantState.PUBLISHED_PENDING_CHANGES
-	);
-}
+export { isNotPublishedMandatory, isSelectableForPublishing } from '@umbraco-cms/backoffice/content';


### PR DESCRIPTION
## Description

The "save and publish with descendants" dialog listed languages that the "save and publish" and "unpublish" dialogs did not, for the same document.

All three dialogs are handed the same option list and the same `pickableFilter` by `UmbDocumentPublishingWorkspaceContext`, so the only thing that could differ was each modal's own "which options are worth listing" filter — and those had drifted apart. The shared content publish modal required the variant to exist:

```ts
option.variant?.state === null || isNotPublishedMandatory(option) ||
	(option.variant && option.variant.state !== NOT_CREATED)
```

Whereas publish-with-descendants (and schedule publish, and the deprecated document publish modal) did not:

```ts
isNotPublishedMandatory(option) || option.variant?.state !== NOT_CREATED
```

For a culture the document holds no data for, `option.variant` is `undefined`, so `undefined !== 'NotCreated'` is `true` and the culture got listed as a disabled "Not created" row.

The rule is now expressed once, as `isSelectableForPublishing` in the content layer, re-exported for documents, and used by every publishing modal.

Note the original report also mentions the **save** dialog listing a language the user has no access to. That variant does exist, so it is shown disabled rather than hidden, and this PR does not change it — whether read-only variants should be hidden altogether is a separate design question (see [comment](https://github.com/umbraco/Umbraco-CMS/issues/23886#issuecomment-5602680203) I added to the issue).

Fixes #23886

## Testing

Add two languages beyond the default, create a document that varies by culture and give it content in only some of those languages, then open "save and publish" and "save and publish with descendants" — both dialogs now offer the same languages.
