### PR TITLE
Tiptap RTE: Detect class-only style menu items outside paragraphs and match whole class names

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.test.ts
@@ -1,0 +1,128 @@
+import { BulletList, Document, Editor, Heading, ListItem, Paragraph, Text } from '../../externals.js';
+import { HtmlClassAttribute } from '../html-attr-class/html-attr-class.tiptap-extension.js';
+import { HtmlIdAttribute } from '../html-attr-id/html-attr-id.tiptap-extension.js';
+import type { MetaTiptapToolbarStyleMenuItem } from '../types.js';
+import UmbTiptapToolbarStyleMenuApi from './style-menu.tiptap-toolbar-api.js';
+import { expect } from '@open-wc/testing';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+
+@customElement('umb-test-style-menu-host')
+class UmbTestStyleMenuHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+describe('UmbTiptapToolbarStyleMenuApi', () => {
+	let hostElement: UmbTestStyleMenuHostElement;
+	let editorHost: HTMLDivElement;
+	let editor: Editor;
+	let api: UmbTiptapToolbarStyleMenuApi;
+
+	const attributeTypes = ['bulletList', 'heading', 'listItem', 'paragraph'];
+
+	const item = (data: MetaTiptapToolbarStyleMenuItem['data']): MetaTiptapToolbarStyleMenuItem => ({
+		label: 'Test style',
+		data,
+	});
+
+	/** Loads the HTML and places the caret at `position` (by default at the start of the first text block). */
+	const setContent = (html: string, position = 1) => {
+		editor.commands.setContent(html);
+		editor.commands.setTextSelection(position);
+	};
+
+	beforeEach(() => {
+		hostElement = new UmbTestStyleMenuHostElement();
+		document.body.appendChild(hostElement);
+
+		editorHost = document.createElement('div');
+		document.body.appendChild(editorHost);
+
+		editor = new Editor({
+			element: editorHost,
+			extensions: [
+				Document,
+				Paragraph,
+				Text,
+				Heading,
+				BulletList,
+				ListItem,
+				HtmlClassAttribute.configure({ types: attributeTypes }),
+				HtmlIdAttribute.configure({ types: attributeTypes }),
+			],
+		});
+
+		api = new UmbTiptapToolbarStyleMenuApi(hostElement);
+	});
+
+	afterEach(() => {
+		api.destroy();
+		editor.destroy();
+		editorHost.remove();
+		hostElement.remove();
+	});
+
+	describe('isActive', () => {
+		it('detects a class-only style on a paragraph', () => {
+			setContent('<p class="lead">text</p>');
+
+			expect(api.isActive(editor, item({ class: 'lead' }))).to.equal(true);
+		});
+
+		it('detects a class-only style on a heading', () => {
+			setContent('<h2 class="title--size-5">text</h2>');
+
+			expect(api.isActive(editor, item({ class: 'title--size-5' }))).to.equal(true);
+		});
+
+		it('detects a class-only style on an ancestor of the selection', () => {
+			// Caret inside the paragraph of the list item; the class sits on the list itself.
+			setContent('<ul class="list--checkmarks"><li><p>item</p></li></ul>', 3);
+
+			expect(api.isActive(editor, item({ class: 'list--checkmarks' }))).to.equal(true);
+		});
+
+		it('detects an id-only style on a heading', () => {
+			setContent('<h2 id="intro">text</h2>');
+
+			expect(api.isActive(editor, item({ id: 'intro' }))).to.equal(true);
+			expect(api.isActive(editor, item({ id: 'outro' }))).to.equal(false);
+		});
+
+		it('is not active when the class is absent', () => {
+			setContent('<h2>text</h2>');
+
+			expect(api.isActive(editor, item({ class: 'title--size-5' }))).to.equal(false);
+		});
+
+		it('compares whole class names', () => {
+			setContent('<p class="title--size-10">text</p>');
+
+			expect(api.isActive(editor, item({ class: 'title--size-10' }))).to.equal(true);
+			expect(api.isActive(editor, item({ class: 'title--size-1' }))).to.equal(false);
+		});
+
+		it('requires every class name of a multi-class style', () => {
+			setContent('<p class="list list--ordered">text</p>');
+
+			expect(api.isActive(editor, item({ class: 'list list--ordered' }))).to.equal(true);
+			expect(api.isActive(editor, item({ class: 'list--ordered list' }))).to.equal(true);
+			expect(api.isActive(editor, item({ class: 'list list--unordered' }))).to.equal(false);
+		});
+
+		it('checks the tag together with the class', () => {
+			setContent('<h2 class="title">text</h2>');
+
+			expect(api.isActive(editor, item({ tag: 'h2', class: 'title' }))).to.equal(true);
+			expect(api.isActive(editor, item({ tag: 'h3', class: 'title' }))).to.equal(false);
+			expect(api.isActive(editor, item({ tag: 'h2', class: 'other' }))).to.equal(false);
+		});
+
+		it('reflects a class-only style after it has been applied to a heading', () => {
+			setContent('<h2>text</h2>');
+
+			api.execute(editor, item({ class: 'title--size-5' }));
+
+			expect(editor.getHTML()).to.include('<h2 class="title--size-5">');
+			expect(api.isActive(editor, item({ class: 'title--size-5' }))).to.equal(true);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
@@ -43,14 +43,39 @@ export default class UmbTiptapToolbarStyleMenuApi extends UmbTiptapToolbarElemen
 		if (!editor || !item?.data) return false;
 
 		const { tag, id, class: className } = item.data;
-		const ext = tag ? this.#commands[tag] : null;
-		const attrs = editor?.getAttributes(ext?.type ?? 'paragraph');
 
-		const tagMatch = !tag ? true : ext ? (ext.isActive?.(editor) ?? editor?.isActive(ext.type) ?? false) : false;
+		if (tag) {
+			const ext = this.#commands[tag];
+			if (!ext) return false;
+			const tagMatch = ext.isActive?.(editor) ?? editor.isActive(ext.type) ?? false;
+			return tagMatch && this.#hasAttributes(editor.getAttributes(ext.type), id, className);
+		}
+
+		// Without a tag, `execute` toggles the id/class on every node type around the selection, not only on paragraphs,
+		// so the item is active when any ancestor node of the selection carries them.
+		const { $from } = editor.state.selection;
+		for (let depth = $from.depth; depth > 0; depth--) {
+			if (this.#hasAttributes($from.node(depth).attrs, id, className)) return true;
+		}
+
+		return false;
+	}
+
+	#hasAttributes(attrs: Record<string, unknown>, id?: string, className?: string): boolean {
 		const idMatch = !id ? true : attrs.id === id;
-		const classMatch = !className ? true : attrs.class?.includes(className) === true;
+		const classMatch = !className ? true : this.#hasClassNames(attrs.class, className);
+		return idMatch && classMatch;
+	}
 
-		return tagMatch && idMatch && classMatch;
+	#hasClassNames(value: unknown, className: string): boolean {
+		// Compare whole class names (as `toggleClassName` does), so that e.g. `size-1` does not match `size-10`.
+		const classes = String(value ?? '')
+			.split(/\s+/)
+			.filter((c) => c);
+		return className
+			.split(/\s+/)
+			.filter((c) => c)
+			.every((c) => classes.includes(c));
 	}
 
 	override execute(editor?: Editor, item?: MetaTiptapToolbarStyleMenuItem) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
@@ -43,21 +43,24 @@ export default class UmbTiptapToolbarStyleMenuApi extends UmbTiptapToolbarElemen
 		if (!editor || !item?.data) return false;
 
 		const { tag, id, class: className } = item.data;
+		if (tag) return this.#isTagActive(editor, tag, id, className);
+		return this.#hasAncestorWithAttributes(editor, id, className);
+	}
 
-		if (tag) {
-			const ext = this.#commands[tag];
-			if (!ext) return false;
-			const tagMatch = ext.isActive?.(editor) ?? editor.isActive(ext.type) ?? false;
-			return tagMatch && this.#hasAttributes(editor.getAttributes(ext.type), id, className);
-		}
+	#isTagActive(editor: Editor, tag: string, id?: string, className?: string): boolean {
+		const ext = this.#commands[tag];
+		if (!ext) return false;
+		const tagMatch = ext.isActive?.(editor) ?? editor.isActive(ext.type) ?? false;
+		return tagMatch && this.#hasAttributes(editor.getAttributes(ext.type), id, className);
+	}
 
+	#hasAncestorWithAttributes(editor: Editor, id?: string, className?: string): boolean {
 		// Without a tag, `execute` toggles the id/class on every node type around the selection, not only on paragraphs,
 		// so the item is active when any ancestor node of the selection carries them.
 		const { $from } = editor.state.selection;
 		for (let depth = $from.depth; depth > 0; depth--) {
 			if (this.#hasAttributes($from.node(depth).attrs, id, className)) return true;
 		}
-
 		return false;
 	}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

`UmbTiptapToolbarStyleMenuApi.isActive` (the `styleMenu` toolbar kind) misses styles that have been applied, for two reasons:

1. **Items without a `tag` are only detected inside a paragraph.** `isActive` reads the attributes of `ext?.type ?? 'paragraph'`, so a class-only item such as `{ "class": "title--size-5" }` is never highlighted while the caret is in a heading, a list or any other block. `execute` does apply the class there (`toggleClassName` without a type toggles it on every configured node type around the selection), so the menu and the content disagree. The fix walks the ancestor nodes of the selection and reports the item as active when one of them carries the id/class, which mirrors what `execute` toggles.
2. **Class names are compared as substrings.** `attrs.class?.includes(className)` makes `title--size-1` light up on an element that has `title--size-10`. The fix compares whole class names, the same way `toggleClassName` decides whether the classes are already present, so multi-class items also work in any order.

Items with a `tag` keep their behaviour (the node/mark check plus the id/class check on that node); only the class comparison changed for them.

The code is identical on `release/17.*`, so the fix applies to the LTS as well. A backport would be appreciated.

### How to test

1. Register a custom style menu (`kind: 'styleMenu'`, see [Style menu](https://docs.umbraco.com/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu)) with three class-only items: `{ "class": "title--size-1" }`, `{ "class": "title--size-5" }` and `{ "class": "title--size-10" }`. Add it to a Rich Text data type and enable the `Umb.Tiptap.HtmlAttributeClass` extension on that data type.
2. Type a heading (H2), keep the caret in it and apply the `title--size-5` item. The class is added to the `<h2>` (check the source view).
   - Before: reopening the menu shows no highlighted item.
   - After: the `title--size-5` item is highlighted while the caret is in the heading.
3. Put the caret in a paragraph and apply the `title--size-10` item.
   - Before: both `title--size-10` and `title--size-1` are highlighted.
   - After: only `title--size-10` is highlighted.
4. Unit tests: `npx web-test-runner --files "src/packages/tiptap/extensions/style-menu/*.test.ts"` in `src/Umbraco.Web.UI.Client`. The heading, ancestor, id and whole-class-name tests fail on the previous implementation and pass with this change.
