### PR TITLE
WIP: Add relation type picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/collection/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/collection/constants.ts
@@ -1,2 +1,3 @@
 export const UMB_RELATION_TYPE_COLLECTION_ALIAS = 'Umb.Collection.RelationType';
+export const UMB_RELATION_TYPE_COLLECTION_MENU_ALIAS = 'Umb.CollectionMenu.RelationType';
 export * from './repository/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/collection/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/collection/manifests.ts
@@ -1,4 +1,8 @@
-import { UMB_RELATION_TYPE_COLLECTION_ALIAS, UMB_RELATION_TYPE_COLLECTION_REPOSITORY_ALIAS } from './constants.js';
+import {
+	UMB_RELATION_TYPE_COLLECTION_ALIAS,
+	UMB_RELATION_TYPE_COLLECTION_MENU_ALIAS,
+	UMB_RELATION_TYPE_COLLECTION_REPOSITORY_ALIAS,
+} from './constants.js';
 import { manifests as collectionRepositoryManifests } from './repository/manifests.js';
 import { manifests as collectionViewManifests } from './views/manifests.js';
 
@@ -12,6 +16,15 @@ export const manifests: Array<UmbExtensionManifest> = [
 		api: () => import('./relation-type-collection.context.js'),
 		meta: {
 			repositoryAlias: UMB_RELATION_TYPE_COLLECTION_REPOSITORY_ALIAS,
+		},
+	},
+	{
+		type: 'collectionMenu',
+		kind: 'default',
+		alias: UMB_RELATION_TYPE_COLLECTION_MENU_ALIAS,
+		name: 'Relation Type Collection Menu',
+		meta: {
+			collectionRepositoryAlias: UMB_RELATION_TYPE_COLLECTION_REPOSITORY_ALIAS,
 		},
 	},
 	...collectionRepositoryManifests,

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/components/input-relation-type/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/components/input-relation-type/index.ts
@@ -1,0 +1,2 @@
+export * from './input-relation-type.context.js';
+export * from './input-relation-type.element.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/components/input-relation-type/input-relation-type.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/components/input-relation-type/input-relation-type.context.ts
@@ -1,0 +1,15 @@
+import type { UmbRelationTypeCollectionItemModel } from '../../collection/types.js';
+import type { UmbRelationTypeItemModel } from '../../repository/item/types.js';
+import { UMB_RELATION_TYPE_ITEM_REPOSITORY_ALIAS } from '../../repository/item/constants.js';
+import { UMB_RELATION_TYPE_PICKER_MODAL } from '../../modals/relation-type-picker-modal.token.js';
+import { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+export class UmbRelationTypePickerInputContext extends UmbPickerInputContext<
+	UmbRelationTypeItemModel,
+	UmbRelationTypeCollectionItemModel
+> {
+	constructor(host: UmbControllerHost) {
+		super(host, UMB_RELATION_TYPE_ITEM_REPOSITORY_ALIAS, UMB_RELATION_TYPE_PICKER_MODAL);
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/components/input-relation-type/input-relation-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/components/input-relation-type/input-relation-type.element.ts
@@ -1,0 +1,231 @@
+import type { UmbRelationTypeItemModel } from '../../repository/item/types.js';
+import { UMB_EDIT_RELATION_TYPE_WORKSPACE_PATH_PATTERN } from '../../paths.js';
+import { UmbRelationTypePickerInputContext } from './input-relation-type.context.js';
+import { css, customElement, html, nothing, property, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
+import type { UmbRepositoryItemsStatus } from '@umbraco-cms/backoffice/repository';
+
+import '@umbraco-cms/backoffice/entity-item';
+
+@customElement('umb-input-relation-type')
+export class UmbInputRelationTypeElement extends UmbFormControlMixin<string | undefined, typeof UmbLitElement>(
+	UmbLitElement,
+	undefined,
+) {
+	#sorter = new UmbSorterController<string>(this, {
+		getUniqueOfElement: (element) => {
+			return element.id;
+		},
+		getUniqueOfModel: (modelEntry) => {
+			return modelEntry;
+		},
+		identifier: 'Umb.SorterIdentifier.InputRelationType',
+		itemSelector: 'uui-ref-node',
+		containerSelector: 'uui-ref-list',
+		onChange: ({ model }) => {
+			this.selection = model;
+			this.dispatchEvent(new UmbChangeEvent());
+		},
+	});
+
+	/**
+	 * This is a minimum amount of selected items in this input.
+	 * @type {number}
+	 * @attr
+	 * @default
+	 */
+	@property({ type: Number })
+	public set min(value: number) {
+		this.#pickerContext.min = value;
+	}
+	public get min(): number {
+		return this.#pickerContext.min;
+	}
+
+	/**
+	 * Min validation message.
+	 * @type {string}
+	 * @attr
+	 * @default
+	 */
+	@property({ type: String, attribute: 'min-message' })
+	minMessage = 'This field needs more items';
+
+	/**
+	 * This is a maximum amount of selected items in this input.
+	 * @type {number}
+	 * @attr
+	 * @default
+	 */
+	@property({ type: Number })
+	public set max(value: number) {
+		this.#pickerContext.max = value;
+	}
+	public get max(): number {
+		return this.#pickerContext.max;
+	}
+
+	/**
+	 * Max validation message.
+	 * @type {string}
+	 * @attr
+	 * @default
+	 */
+	@property({ type: String, attribute: 'max-message' })
+	maxMessage = 'This field exceeds the allowed amount of items';
+
+	@property({ type: Array })
+	public set selection(uniques: Array<string>) {
+		this.#pickerContext.setSelection(uniques);
+		this.#sorter.setModel(uniques);
+	}
+	public get selection(): Array<string> {
+		return this.#pickerContext.getSelection();
+	}
+
+	@property({ type: String })
+	public override set value(uniques: string | undefined) {
+		this.selection = splitStringToArray(uniques);
+	}
+	public override get value(): string | undefined {
+		return this.selection.length > 0 ? this.selection.join(',') : undefined;
+	}
+
+	@property({ type: Boolean, attribute: 'readonly' })
+	readonly = false;
+
+	@state()
+	private _items?: Array<UmbRelationTypeItemModel>;
+
+	@state()
+	private _statuses?: Array<UmbRepositoryItemsStatus>;
+
+	#pickerContext = new UmbRelationTypePickerInputContext(this);
+
+	constructor() {
+		super();
+
+		this.addValidator(
+			'rangeUnderflow',
+			() => this.minMessage,
+			() => !!this.min && this.#pickerContext.getSelection().length < this.min,
+		);
+
+		this.addValidator(
+			'rangeOverflow',
+			() => this.maxMessage,
+			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
+		);
+
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')), null);
+		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems), null);
+		this.observe(this.#pickerContext.statuses, (statuses) => (this._statuses = statuses), null);
+	}
+
+	protected override getFormElement() {
+		return undefined;
+	}
+
+	#openPicker() {
+		this.#pickerContext.openPicker();
+	}
+
+	#removeItem(unique: string) {
+		this.#pickerContext.requestRemoveItem(unique);
+	}
+
+	override render() {
+		return html`${this.#renderItems()} ${this.#renderAddButton()}`;
+	}
+
+	#renderAddButton() {
+		if (this.readonly || (this.max > 0 && this.selection.length >= this.max)) return nothing;
+		return html`
+			<uui-button
+				id="btn-add"
+				look="placeholder"
+				@click=${this.#openPicker}
+				label="${this.localize.term('general_choose')}"></uui-button>
+		`;
+	}
+
+	#renderItems() {
+		if (!this._statuses) return nothing;
+		return html`
+			<uui-ref-list>
+				${repeat(
+					this._statuses,
+					(status) => status.unique,
+					(status) => {
+						const unique = status.unique;
+						const item = this._items?.find((x) => x.unique === unique);
+						const isError = status.state.type === 'error';
+
+						// For error state, use umb-entity-item-ref
+						if (isError) {
+							return html`
+								<umb-entity-item-ref
+									id=${unique}
+									.item=${item}
+									?error=${true}
+									.errorMessage=${status.state.error}
+									.errorDetail=${unique}
+									?readonly=${this.readonly}
+									?standalone=${this.max === 1}>
+									${when(
+										!this.readonly,
+										() => html`
+											<uui-action-bar slot="actions">
+												<uui-button
+													label=${this.localize.term('general_remove')}
+													@click=${() => this.#removeItem(unique)}></uui-button>
+											</uui-action-bar>
+										`,
+									)}
+								</umb-entity-item-ref>
+							`;
+						}
+
+						if (!item) return nothing;
+						const href = UMB_EDIT_RELATION_TYPE_WORKSPACE_PATH_PATTERN.generateAbsolute({ unique });
+						return html`
+							<uui-ref-node name=${item.name} id=${unique} href=${href} ?readonly=${this.readonly}>
+								<umb-icon slot="icon" name="icon-trafic"></umb-icon>
+								<uui-action-bar slot="actions">
+									${when(
+										!this.readonly,
+										() => html`
+											<uui-button
+												label=${this.localize.term('general_remove')}
+												@click=${() => this.#removeItem(unique)}></uui-button>
+										`,
+									)}
+								</uui-action-bar>
+							</uui-ref-node>
+						`;
+					},
+				)}
+			</uui-ref-list>
+		`;
+	}
+
+	static override styles = [
+		css`
+			#btn-add {
+				width: 100%;
+			}
+		`,
+	];
+}
+
+export default UmbInputRelationTypeElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-input-relation-type': UmbInputRelationTypeElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/entry-point.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/entry-point.ts
@@ -1,0 +1,12 @@
+import { UmbManagementApiRelationTypeItemDataCacheInvalidationManager } from './repository/item/relation-type-item.server.cache-invalidation.manager.js';
+import type { UmbEntryPointOnInit, UmbEntryPointOnUnload } from '@umbraco-cms/backoffice/extension-api';
+
+let itemDataCacheInvalidationManager: UmbManagementApiRelationTypeItemDataCacheInvalidationManager | undefined;
+
+export const onInit: UmbEntryPointOnInit = (host) => {
+	itemDataCacheInvalidationManager = new UmbManagementApiRelationTypeItemDataCacheInvalidationManager(host);
+};
+
+export const onUnload: UmbEntryPointOnUnload = () => {
+	itemDataCacheInvalidationManager?.destroy();
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/index.ts
@@ -1,5 +1,9 @@
+import './components/input-relation-type/input-relation-type.element.js';
+
 export * from './collection/index.js';
+export * from './components/input-relation-type/index.js';
 export * from './constants.js';
 export * from './entity.js';
+export * from './modals/index.js';
 export * from './paths.js';
 export * from './repository/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/manifests.ts
@@ -2,10 +2,20 @@ import { manifests as repositoryManifests } from './repository/manifests.js';
 import { manifests as workspaceManifests } from './workspace/manifests.js';
 import { manifests as collectionManifests } from './collection/manifests.js';
 import { manifests as menuManifests } from './menu/manifests.js';
+import { manifests as propertyEditorManifests } from './property-editors/manifests.js';
+import * as entryPointModule from './entry-point.js';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<UmbExtensionManifest> = [
+export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [
 	...repositoryManifests,
 	...workspaceManifests,
 	...collectionManifests,
 	...menuManifests,
+	...propertyEditorManifests,
+	{
+		name: 'Relation Type Backoffice Entry Point',
+		alias: 'Umb.EntryPoint.RelationType',
+		type: 'backofficeEntryPoint',
+		js: entryPointModule,
+	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/modals/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/modals/index.ts
@@ -1,0 +1,1 @@
+export * from './relation-type-picker-modal.token.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/modals/relation-type-picker-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/modals/relation-type-picker-modal.token.ts
@@ -1,0 +1,28 @@
+import type { UmbRelationTypeCollectionItemModel } from '../collection/types.js';
+import { UMB_RELATION_TYPE_COLLECTION_MENU_ALIAS } from '../collection/constants.js';
+import {
+	UMB_COLLECTION_ITEM_PICKER_MODAL_ALIAS,
+	type UmbCollectionItemPickerModalData,
+	type UmbCollectionItemPickerModalValue,
+} from '@umbraco-cms/backoffice/collection';
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+
+export type UmbRelationTypePickerModalData = UmbCollectionItemPickerModalData<UmbRelationTypeCollectionItemModel>;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbRelationTypePickerModalValue extends UmbCollectionItemPickerModalValue {}
+
+export const UMB_RELATION_TYPE_PICKER_MODAL = new UmbModalToken<
+	UmbRelationTypePickerModalData,
+	UmbRelationTypePickerModalValue
+>(UMB_COLLECTION_ITEM_PICKER_MODAL_ALIAS, {
+	modal: {
+		type: 'sidebar',
+		size: 'medium',
+	},
+	data: {
+		collection: {
+			menuAlias: UMB_RELATION_TYPE_COLLECTION_MENU_ALIAS,
+		},
+	},
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/manifests.ts
@@ -1,0 +1,4 @@
+import { manifest as relationTypePickerUI } from './relation-type-picker/manifests.js';
+import type { ManifestPropertyEditorUi } from '@umbraco-cms/backoffice/property-editor';
+
+export const manifests: Array<ManifestPropertyEditorUi> = [relationTypePickerUI];

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/manifests.ts
@@ -1,0 +1,15 @@
+import type { ManifestPropertyEditorUi } from '@umbraco-cms/backoffice/property-editor';
+
+export const manifest: ManifestPropertyEditorUi = {
+	type: 'propertyEditorUi',
+	alias: 'Umb.PropertyEditorUi.RelationTypePicker',
+	name: 'Relation Type Picker Property Editor UI',
+	element: () => import('./property-editor-ui-relation-type-picker.element.js'),
+	meta: {
+		label: 'Relation Type Picker',
+		icon: 'icon-trafic',
+		group: '#propertyEditorUIGroups_advanced',
+		keywords: ['relation', 'relations', 'pick'],
+		supportsReadOnly: true,
+	},
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/property-editor-ui-relation-type-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/property-editor-ui-relation-type-picker.element.ts
@@ -1,0 +1,57 @@
+import type { UmbInputRelationTypeElement } from '../../components/input-relation-type/input-relation-type.element.js';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
+import type {
+	UmbPropertyEditorConfigCollection,
+	UmbPropertyEditorUiElement,
+} from '@umbraco-cms/backoffice/property-editor';
+
+@customElement('umb-property-editor-ui-relation-type-picker')
+export class UmbPropertyEditorUIRelationTypePickerElement extends UmbLitElement implements UmbPropertyEditorUiElement {
+	@property()
+	public value?: string;
+
+	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
+		if (!config) return;
+
+		const minMax = config?.getValueByAlias<UmbNumberRangeValueType>('validationLimit');
+		this._min = minMax?.min ?? 0;
+		this._max = minMax?.max ?? Infinity;
+	}
+
+	@property({ type: Boolean, attribute: 'readonly' })
+	readonly = false;
+
+	@state()
+	private _min = 0;
+
+	@state()
+	private _max = Infinity;
+
+	#onChange(event: CustomEvent & { target: UmbInputRelationTypeElement }) {
+		this.value = event.target.value;
+		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	override render() {
+		return html`
+			<umb-input-relation-type
+				.min=${this._min}
+				.max=${this._max}
+				.value=${this.value}
+				.readonly=${this.readonly}
+				@change=${this.#onChange}>
+			</umb-input-relation-type>
+		`;
+	}
+}
+
+export default UmbPropertyEditorUIRelationTypePickerElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-property-editor-ui-relation-type-picker': UmbPropertyEditorUIRelationTypePickerElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/property-editor-ui-relation-type-picker.stories.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/property-editor-ui-relation-type-picker.stories.ts
@@ -1,0 +1,14 @@
+import type { UmbPropertyEditorUIRelationTypePickerElement } from './property-editor-ui-relation-type-picker.element.js';
+import type { Meta, StoryFn } from '@storybook/web-components-vite';
+import { html } from '@umbraco-cms/backoffice/external/lit';
+
+import './property-editor-ui-relation-type-picker.element.js';
+
+export default {
+	title: 'Extension Type/Property Editor UI/Relation Type Picker',
+	component: 'umb-property-editor-ui-relation-type-picker',
+	id: 'umb-property-editor-ui-relation-type-picker',
+} as Meta;
+
+export const Docs: StoryFn<UmbPropertyEditorUIRelationTypePickerElement> = () =>
+	html` <umb-property-editor-ui-relation-type-picker></umb-property-editor-ui-relation-type-picker>`;

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/property-editor-ui-relation-type-picker.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/property-editor-ui-relation-type-picker.test.ts
@@ -1,0 +1,26 @@
+import { UmbPropertyEditorUIRelationTypePickerElement } from './property-editor-ui-relation-type-picker.element.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
+
+// TODO: figure out why this is not imported by the tests as it should be globally available.
+import '../../components/input-relation-type/input-relation-type.element.js';
+
+describe('UmbPropertyEditorUIRelationTypePickerElement', () => {
+	let element: UmbPropertyEditorUIRelationTypePickerElement;
+
+	beforeEach(async () => {
+		element = await fixture(html`
+			<umb-property-editor-ui-relation-type-picker></umb-property-editor-ui-relation-type-picker>
+		`);
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbPropertyEditorUIRelationTypePickerElement);
+	});
+
+	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {
+		it('passes the a11y audit', async () => {
+			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);
+		});
+	}
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/constants.ts
@@ -1,1 +1,2 @@
 export * from './detail/constants.js';
+export * from './item/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/index.ts
@@ -1,1 +1,2 @@
 export * from './detail/index.js';
+export * from './item/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/constants.ts
@@ -1,0 +1,3 @@
+export const UMB_RELATION_TYPE_ITEM_REPOSITORY_ALIAS = 'Umb.Repository.RelationType.Item';
+export const UMB_RELATION_TYPE_ITEM_STORE_ALIAS = 'Umb.Store.RelationType.Item';
+export { UMB_RELATION_TYPE_ITEM_STORE_CONTEXT } from './relation-type-item.store.context-token.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/index.ts
@@ -1,0 +1,2 @@
+export { UmbRelationTypeItemRepository } from './relation-type-item.repository.js';
+export type { UmbRelationTypeItemModel } from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/manifests.ts
@@ -1,0 +1,17 @@
+import { UMB_RELATION_TYPE_ITEM_REPOSITORY_ALIAS, UMB_RELATION_TYPE_ITEM_STORE_ALIAS } from './constants.js';
+import { UmbRelationTypeItemStore } from './relation-type-item.store.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'repository',
+		alias: UMB_RELATION_TYPE_ITEM_REPOSITORY_ALIAS,
+		name: 'Relation Type Item Repository',
+		api: () => import('./relation-type-item.repository.js'),
+	},
+	{
+		type: 'itemStore',
+		alias: UMB_RELATION_TYPE_ITEM_STORE_ALIAS,
+		name: 'Relation Type Item Store',
+		api: UmbRelationTypeItemStore,
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.repository.ts
@@ -1,0 +1,12 @@
+import { UmbRelationTypeItemServerDataSource } from './relation-type-item.server.data-source.js';
+import { UMB_RELATION_TYPE_ITEM_STORE_CONTEXT } from './relation-type-item.store.context-token.js';
+import type { UmbRelationTypeItemModel } from './types.js';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbItemRepositoryBase } from '@umbraco-cms/backoffice/repository';
+
+export class UmbRelationTypeItemRepository extends UmbItemRepositoryBase<UmbRelationTypeItemModel> {
+	constructor(host: UmbControllerHost) {
+		super(host, UmbRelationTypeItemServerDataSource, UMB_RELATION_TYPE_ITEM_STORE_CONTEXT);
+	}
+}
+export default UmbRelationTypeItemRepository;

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.server.cache-invalidation.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.server.cache-invalidation.manager.ts
@@ -1,0 +1,13 @@
+import { relationTypeItemCache } from './relation-type-item.server.cache.js';
+import { UmbManagementApiItemDataCacheInvalidationManager } from '@umbraco-cms/backoffice/management-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type { RelationTypeItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+
+export class UmbManagementApiRelationTypeItemDataCacheInvalidationManager extends UmbManagementApiItemDataCacheInvalidationManager<RelationTypeItemResponseModel> {
+	constructor(host: UmbControllerHost) {
+		super(host, {
+			dataCache: relationTypeItemCache,
+			eventSources: ['Umbraco:CMS:RelationType'],
+		});
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.server.cache.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.server.cache.ts
@@ -1,0 +1,6 @@
+import type { RelationTypeItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import { UmbManagementApiItemDataCache } from '@umbraco-cms/backoffice/management-api';
+
+const relationTypeItemCache = new UmbManagementApiItemDataCache<RelationTypeItemResponseModel>();
+
+export { relationTypeItemCache };

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.server.data-source.ts
@@ -1,0 +1,45 @@
+import { UMB_RELATION_TYPE_ENTITY_TYPE } from '../../entity.js';
+import type { UmbRelationTypeItemModel } from './types.js';
+import { UmbManagementApiRelationTypeItemDataRequestManager } from './relation-type-item.server.request-manager.js';
+import { UmbItemServerDataSourceBase } from '@umbraco-cms/backoffice/repository';
+import type { RelationTypeItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+/**
+ * A server data source for Relation Type items
+ * @class UmbRelationTypeItemServerDataSource
+ * @augments {UmbItemServerDataSourceBase}
+ */
+export class UmbRelationTypeItemServerDataSource extends UmbItemServerDataSourceBase<
+	RelationTypeItemResponseModel,
+	UmbRelationTypeItemModel
+> {
+	#itemRequestManager = new UmbManagementApiRelationTypeItemDataRequestManager(this);
+
+	/**
+	 * Creates an instance of UmbRelationTypeItemServerDataSource.
+	 * @param {UmbControllerHost} host - The controller host for this controller to be appended to
+	 * @memberof UmbRelationTypeItemServerDataSource
+	 */
+	constructor(host: UmbControllerHost) {
+		super(host, {
+			mapper,
+		});
+	}
+
+	override async getItems(uniques: Array<string>) {
+		if (!uniques) throw new Error('Uniques are missing');
+
+		const { data, error } = await this.#itemRequestManager.getItems(uniques);
+
+		return { data: this._getMappedItems(data), error };
+	}
+}
+
+const mapper = (item: RelationTypeItemResponseModel): UmbRelationTypeItemModel => {
+	return {
+		unique: item.id,
+		name: item.name,
+		entityType: UMB_RELATION_TYPE_ENTITY_TYPE,
+	};
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.server.request-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.server.request-manager.ts
@@ -1,0 +1,21 @@
+/* eslint-disable local-rules/no-direct-api-import */
+import { relationTypeItemCache } from './relation-type-item.server.cache.js';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { RelationTypeService, type RelationTypeItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import {
+	UmbManagementApiItemDataRequestManager,
+	UmbManagementApiInFlightRequestCache,
+} from '@umbraco-cms/backoffice/management-api';
+
+export class UmbManagementApiRelationTypeItemDataRequestManager extends UmbManagementApiItemDataRequestManager<RelationTypeItemResponseModel> {
+	static #inflightRequestCache = new UmbManagementApiInFlightRequestCache<RelationTypeItemResponseModel>();
+
+	constructor(host: UmbControllerHost) {
+		super(host, {
+			getItems: (ids: Array<string>) => RelationTypeService.getItemRelationType({ query: { id: ids } }),
+			dataCache: relationTypeItemCache,
+			inflightRequestCache: UmbManagementApiRelationTypeItemDataRequestManager.#inflightRequestCache,
+			getUniqueMethod: (item) => item.id,
+		});
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.store.context-token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.store.context-token.ts
@@ -1,0 +1,6 @@
+import type { UmbRelationTypeItemStore } from './relation-type-item.store.js';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+
+export const UMB_RELATION_TYPE_ITEM_STORE_CONTEXT = new UmbContextToken<UmbRelationTypeItemStore>(
+	'UmbRelationTypeItemStore',
+);

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/relation-type-item.store.ts
@@ -1,0 +1,23 @@
+import type { UmbRelationTypeItemModel } from './types.js';
+import { UMB_RELATION_TYPE_ITEM_STORE_CONTEXT } from './relation-type-item.store.context-token.js';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbItemStoreBase } from '@umbraco-cms/backoffice/store';
+
+/**
+ * @class UmbRelationTypeItemStore
+ * @augments {UmbItemStoreBase}
+ * @description - Data Store for Relation Type items
+ */
+
+export class UmbRelationTypeItemStore extends UmbItemStoreBase<UmbRelationTypeItemModel> {
+	/**
+	 * Creates an instance of UmbRelationTypeItemStore.
+	 * @param {UmbControllerHost} host - The controller host for this controller to be appended to
+	 * @memberof UmbRelationTypeItemStore
+	 */
+	constructor(host: UmbControllerHost) {
+		super(host, UMB_RELATION_TYPE_ITEM_STORE_CONTEXT);
+	}
+}
+
+export default UmbRelationTypeItemStore;

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/item/types.ts
@@ -1,0 +1,7 @@
+import type { UmbRelationTypeEntityType } from '../../entity.js';
+
+export interface UmbRelationTypeItemModel {
+	entityType: UmbRelationTypeEntityType;
+	unique: string;
+	name: string;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/manifests.ts
@@ -1,3 +1,4 @@
 import { manifests as detailManifests } from './detail/manifests.js';
+import { manifests as itemManifests } from './item/manifests.js';
 
-export const manifests: Array<UmbExtensionManifest> = [...detailManifests];
+export const manifests: Array<UmbExtensionManifest> = [...detailManifests, ...itemManifests];


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
How to test this feature (for reviewers/future reference)

Since `Umb.PropertyEditorUi.RelationTypePicker` is intentionally schema-less (same as `Umb.PropertyEditorUi.DocumentTypePicker`), it won't appear in the normal "Create a new Data Type" list — that picker only lists property editor UIs that declare a propertyEditorSchemaAlias. To exercise it manually:

1. Run the CMS (dotnet run --project src/Umbraco.Web.UI) and build/deploy the client (npm run build:for:cms inside src/Umbraco.Web.UI.Client, then restart the backend and hard-refresh the browser).
2. Temporarily give the picker a fake pairing to a real schema, purely for local QA — in src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/property-editors/relation-type-picker/manifests.ts, add propertyEditorSchemaAlias: 'Umbraco.TextBox' to the manifest's meta. Umbraco.TextBox is a real, C#-registered editor with a plain string value, matching what our picker persists (a CSV of Guids) — using any unregistered alias here 404s at save time (DataTypeOperationStatus.PropertyEditorNotFound).
3. Rebuild/redeploy (npm run build:for:cms, restart, hard-refresh). "Relation Type Picker" now shows up in Settings → Data Types → Create.
4. Create the Data Type, assign it to a property on a Document Type, and test picking relation types on a content item.
5. Revert step 2 before committing — delete the propertyEditorSchemaAlias line so the shipped editor stays schema-less, consistent with Document Type Picker.


<!-- Thanks for contributing to Umbraco CMS! -->
