### PR TITLE
Added Readonly badge on dropdown item of the languge

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/language/app-language-select/app-language-select.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/app-language-select/app-language-select.element.ts
@@ -210,7 +210,7 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 
 	#renderReadOnlyTag(culture?: string) {
 		if (!culture) return nothing;
-		return html`<uui-tag slot="badge" look="secondary">${this.localize.term('general_readOnly')}</uui-tag>`;
+		return html`<uui-tag look="secondary">${this.localize.term('general_readOnly')}</uui-tag>`;
 	}
 
 	static override styles = [


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
#23887 

It will look like this.
<img width="805" height="318" alt="image" src="https://github.com/user-attachments/assets/699cfda6-28ca-404b-bacf-cec6a5428a32" />


<!-- Thanks for contributing to Umbraco CMS! -->
