### PR TITLE
Element Types: Warn when renaming the alias of a stored property (closes #23864)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1897,6 +1897,7 @@ export default {
 			'A Document Type cannot be changed to an Element Type once it has been used to create one or more content items.',
 		elementDoesNotSupport: 'This is not applicable for an Element Type',
 		propertyHasChanges: 'You have made changes to this property. Are you sure you want to discard them?',
+		propertyAliasRenamedNotice: 'Content based on element types are stored by alias, and will be lost for <strong>%0%</strong> when you save.',
 		displaySettingsHeadline: 'Appearance',
 		displaySettingsLabelOnLeft: 'Label to the left',
 		displaySettingsLabelOnTop: 'Label above (full-width)',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1898,7 +1898,7 @@ export default {
 		elementDoesNotSupport: 'This is not applicable for an Element Type',
 		propertyHasChanges: 'You have made changes to this property. Are you sure you want to discard them?',
 		propertyAliasRenamedNotice:
-			'Content based on element types is stored by alias, and will be lost for <strong>%0%</strong> when you save.',
+			'Content based on element types is stored by alias and will be lost for <strong>%0%</strong> when you save.',
 		displaySettingsHeadline: 'Appearance',
 		displaySettingsLabelOnLeft: 'Label to the left',
 		displaySettingsLabelOnTop: 'Label above (full-width)',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1897,7 +1897,8 @@ export default {
 			'A Document Type cannot be changed to an Element Type once it has been used to create one or more content items.',
 		elementDoesNotSupport: 'This is not applicable for an Element Type',
 		propertyHasChanges: 'You have made changes to this property. Are you sure you want to discard them?',
-		propertyAliasRenamedNotice: 'Content based on element types are stored by alias, and will be lost for <strong>%0%</strong> when you save.',
+		propertyAliasRenamedNotice:
+			'Content based on element types is stored by alias, and will be lost for <strong>%0%</strong> when you save.',
 		displaySettingsHeadline: 'Appearance',
 		displaySettingsLabelOnLeft: 'Label to the left',
 		displaySettingsLabelOnTop: 'Label above (full-width)',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1897,8 +1897,9 @@ export default {
 			'A Document Type cannot be changed to an Element Type once it has been used to create one or more content items.',
 		elementDoesNotSupport: 'This is not applicable for an Element Type',
 		propertyHasChanges: 'You have made changes to this property. Are you sure you want to discard them?',
-		propertyAliasRenamedNotice:
-			'Content based on element types is stored by alias and will be lost for <strong>%0%</strong> when you save.',
+		confirmPropertyAliasChangeHeadline: 'Change property alias',
+		confirmPropertyAliasChangeMessage:
+			'Content based on element types is stored by alias, so any content stored for <strong>%0%</strong> under <strong>%1%</strong> will be lost when you save.',
 		displaySettingsHeadline: 'Appearance',
 		displaySettingsLabelOnLeft: 'Label to the left',
 		displaySettingsLabelOnTop: 'Label above (full-width)',

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/structure/content-type-structure-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/structure/content-type-structure-manager.class.ts
@@ -97,13 +97,6 @@ export class UmbContentTypeStructureManager<
 	readonly ownerContentTypeName = createObservablePart(this.ownerContentType, (x) => x?.name);
 	readonly ownerContentTypeCompositions = createObservablePart(this.ownerContentType, (x) => x?.compositions);
 
-	/**
-	 * The Content Types of this structure as they are currently stored on the server.
-	 * Local, unsaved edits are not reflected here, which makes this the reference point for
-	 * determining what a save will change.
-	 */
-	readonly persistedContentTypes = this.#persistedContentTypes.asObservable();
-
 	// TODO: for v.18 make it pausable for this to be undefined when no content-type are present. [NL]
 	readonly contentTypeCompositions = this.#contentTypes.asObservablePart((contentTypes) => {
 		return contentTypes.flatMap((x) => x.compositions ?? []);
@@ -847,33 +840,21 @@ export class UmbContentTypeStructureManager<
 
 	/**
 	 * The property as it is currently stored on the server, looked up across the whole structure.
-	 * Emits undefined for a property that is not (yet) stored on the server.
+	 * Local, unsaved edits are not reflected here, which makes it the reference point for determining
+	 * what a save will change. Emits undefined for a property that is not (yet) stored on the server.
 	 * @param {string} propertyUnique - The unique of the property.
 	 * @returns {Observable<UmbPropertyTypeModel | undefined>} - An observable of the persisted property.
 	 */
 	persistedPropertyById(propertyUnique: string): Observable<UmbPropertyTypeModel | undefined> {
-		return this.#persistedContentTypes.asObservablePart((contentTypes) =>
-			this.#findPropertyById(contentTypes, propertyUnique),
-		);
-	}
-
-	/**
-	 * The property as it is currently stored on the server, looked up across the whole structure.
-	 * @param {string} propertyUnique - The unique of the property.
-	 * @returns {UmbPropertyTypeModel | undefined} - The persisted property, or undefined if it is not stored on the server.
-	 */
-	getPersistedPropertyById(propertyUnique: string): UmbPropertyTypeModel | undefined {
-		return this.#findPropertyById(this.#persistedContentTypes.getValue(), propertyUnique);
-	}
-
-	#findPropertyById(contentTypes: Array<T>, propertyUnique: string): UmbPropertyTypeModel | undefined {
-		for (const contentType of contentTypes) {
-			const property = contentType.properties?.find((x) => x.unique === propertyUnique);
-			if (property) {
-				return property;
+		return this.#persistedContentTypes.asObservablePart((contentTypes) => {
+			for (const contentType of contentTypes) {
+				const foundProp = contentType.properties?.find((property) => property.unique === propertyUnique);
+				if (foundProp) {
+					return foundProp;
+				}
 			}
-		}
-		return undefined;
+			return undefined;
+		});
 	}
 
 	async getPropertyStructureById(propertyUnique: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/structure/content-type-structure-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/structure/content-type-structure-manager.class.ts
@@ -1100,6 +1100,7 @@ export class UmbContentTypeStructureManager<
 		this.#contentTypeObservers = [];
 		this.#repoManager?.clear();
 		this.#contentTypes.setValue([]);
+		this.#persistedContentTypes.setValue([]);
 		this.#dataTypeDetails.setValue([]);
 		this.#ownerContentTypeUnique = undefined;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/structure/content-type-structure-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/structure/content-type-structure-manager.class.ts
@@ -83,8 +83,6 @@ export class UmbContentTypeStructureManager<
 
 	#contentTypes = new UmbArrayState<T>([], (x) => x.unique);
 
-	#persistedContentTypes = new UmbArrayState<T>([], (x) => x.unique);
-
 	// Data type detail loading for bulk optimization
 	#dataTypeDetailRepository = new UmbDataTypeDetailRepository(this);
 	#dataTypeDetails = new UmbArrayState<UmbDataTypeDetailModel>([], (x) => x.unique);
@@ -187,8 +185,6 @@ export class UmbContentTypeStructureManager<
 			this.observe(
 				this.#repoManager.entries,
 				(entries) => {
-					this.#persistedContentTypes.setValue(entries);
-
 					// Prevent updating once that are have edited here.
 					const entriesToBeUpdated = entries.filter(
 						(x) => !(this.#editedTypes.getHasOne(x.unique) && this.#contentTypes.getHasOne(x.unique)),
@@ -838,25 +834,6 @@ export class UmbContentTypeStructureManager<
 		});
 	}
 
-	/**
-	 * The property as it is currently stored on the server, looked up across the whole structure.
-	 * Local, unsaved edits are not reflected here, which makes it the reference point for determining
-	 * what a save will change. Emits undefined for a property that is not (yet) stored on the server.
-	 * @param {string} propertyUnique - The unique of the property.
-	 * @returns {Observable<UmbPropertyTypeModel | undefined>} - An observable of the persisted property.
-	 */
-	persistedPropertyById(propertyUnique: string): Observable<UmbPropertyTypeModel | undefined> {
-		return this.#persistedContentTypes.asObservablePart((contentTypes) => {
-			for (const contentType of contentTypes) {
-				const foundProp = contentType.properties?.find((property) => property.unique === propertyUnique);
-				if (foundProp) {
-					return foundProp;
-				}
-			}
-			return undefined;
-		});
-	}
-
 	async getPropertyStructureById(propertyUnique: string) {
 		await this.#init;
 		for (const docType of this.#contentTypes.getValue()) {
@@ -1081,14 +1058,12 @@ export class UmbContentTypeStructureManager<
 		this.#contentTypeObservers = [];
 		this.#repoManager?.clear();
 		this.#contentTypes.setValue([]);
-		this.#persistedContentTypes.setValue([]);
 		this.#dataTypeDetails.setValue([]);
 		this.#ownerContentTypeUnique = undefined;
 	}
 
 	public override destroy() {
 		this.#contentTypes.destroy();
-		this.#persistedContentTypes.destroy();
 		this.#dataTypeDetails.destroy();
 		super.destroy();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/structure/content-type-structure-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/structure/content-type-structure-manager.class.ts
@@ -83,6 +83,8 @@ export class UmbContentTypeStructureManager<
 
 	#contentTypes = new UmbArrayState<T>([], (x) => x.unique);
 
+	#persistedContentTypes = new UmbArrayState<T>([], (x) => x.unique);
+
 	// Data type detail loading for bulk optimization
 	#dataTypeDetailRepository = new UmbDataTypeDetailRepository(this);
 	#dataTypeDetails = new UmbArrayState<UmbDataTypeDetailModel>([], (x) => x.unique);
@@ -94,6 +96,13 @@ export class UmbContentTypeStructureManager<
 	readonly ownerContentTypeAlias = createObservablePart(this.ownerContentType, (x) => x?.alias);
 	readonly ownerContentTypeName = createObservablePart(this.ownerContentType, (x) => x?.name);
 	readonly ownerContentTypeCompositions = createObservablePart(this.ownerContentType, (x) => x?.compositions);
+
+	/**
+	 * The Content Types of this structure as they are currently stored on the server.
+	 * Local, unsaved edits are not reflected here, which makes this the reference point for
+	 * determining what a save will change.
+	 */
+	readonly persistedContentTypes = this.#persistedContentTypes.asObservable();
 
 	// TODO: for v.18 make it pausable for this to be undefined when no content-type are present. [NL]
 	readonly contentTypeCompositions = this.#contentTypes.asObservablePart((contentTypes) => {
@@ -185,6 +194,8 @@ export class UmbContentTypeStructureManager<
 			this.observe(
 				this.#repoManager.entries,
 				(entries) => {
+					this.#persistedContentTypes.setValue(entries);
+
 					// Prevent updating once that are have edited here.
 					const entriesToBeUpdated = entries.filter(
 						(x) => !(this.#editedTypes.getHasOne(x.unique) && this.#contentTypes.getHasOne(x.unique)),
@@ -834,6 +845,37 @@ export class UmbContentTypeStructureManager<
 		});
 	}
 
+	/**
+	 * The property as it is currently stored on the server, looked up across the whole structure.
+	 * Emits undefined for a property that is not (yet) stored on the server.
+	 * @param {string} propertyUnique - The unique of the property.
+	 * @returns {Observable<UmbPropertyTypeModel | undefined>} - An observable of the persisted property.
+	 */
+	persistedPropertyById(propertyUnique: string): Observable<UmbPropertyTypeModel | undefined> {
+		return this.#persistedContentTypes.asObservablePart((contentTypes) =>
+			this.#findPropertyById(contentTypes, propertyUnique),
+		);
+	}
+
+	/**
+	 * The property as it is currently stored on the server, looked up across the whole structure.
+	 * @param {string} propertyUnique - The unique of the property.
+	 * @returns {UmbPropertyTypeModel | undefined} - The persisted property, or undefined if it is not stored on the server.
+	 */
+	getPersistedPropertyById(propertyUnique: string): UmbPropertyTypeModel | undefined {
+		return this.#findPropertyById(this.#persistedContentTypes.getValue(), propertyUnique);
+	}
+
+	#findPropertyById(contentTypes: Array<T>, propertyUnique: string): UmbPropertyTypeModel | undefined {
+		for (const contentType of contentTypes) {
+			const property = contentType.properties?.find((x) => x.unique === propertyUnique);
+			if (property) {
+				return property;
+			}
+		}
+		return undefined;
+	}
+
 	async getPropertyStructureById(propertyUnique: string) {
 		await this.#init;
 		for (const docType of this.#contentTypes.getValue()) {
@@ -1064,6 +1106,7 @@ export class UmbContentTypeStructureManager<
 
 	public override destroy() {
 		this.#contentTypes.destroy();
+		this.#persistedContentTypes.destroy();
 		this.#dataTypeDetails.destroy();
 		super.destroy();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.test.ts
@@ -1,6 +1,7 @@
 import { UmbContentTypeDesignEditorPropertyElement } from './content-type-design-editor-property.element.js';
 import { aTimeout, expect, fixture } from '@open-wc/testing';
 import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import { UMB_ENTITY_DETAIL_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
@@ -36,7 +37,36 @@ class UmbTestWorkspaceContext {
 	}
 }
 
+class UmbTestModalManagerContext {
+	readonly opened: Array<{ headline?: string; args?: unknown[] }> = [];
+
+	#host: UmbLitElement;
+	#confirm = true;
+
+	constructor(host: UmbLitElement) {
+		this.#host = host;
+	}
+
+	getHostElement() {
+		return this.#host;
+	}
+
+	rejectNext() {
+		this.#confirm = false;
+	}
+
+	open(_host: unknown, _alias: unknown, args: any) {
+		// The message is a lit template whose single binding is the localization arguments.
+		this.opened.push({ headline: args?.data?.headline, args: args?.data?.content?.values?.[0] });
+		return {
+			onSubmit: () => (this.#confirm ? Promise.resolve(undefined) : Promise.reject(new Error('cancelled'))),
+		};
+	}
+}
+
 class UmbTestPropertyStructureHelper {
+	readonly updates: Array<Partial<UmbPropertyTypeModel>> = [];
+
 	getStructureManager() {
 		return {
 			getOwnerContentTypeUnique: () => OWNER_UNIQUE,
@@ -45,6 +75,10 @@ class UmbTestPropertyStructureHelper {
 
 	async contentTypeOfProperty() {
 		return new UmbObjectState({ unique: OWNER_UNIQUE, name: 'Hero' }).asObservable();
+	}
+
+	partialUpdateProperty(_unique: string, partial: Partial<UmbPropertyTypeModel>) {
+		this.updates.push(partial);
 	}
 }
 
@@ -74,7 +108,8 @@ const contentTypeModel = (isElement: boolean, properties: Array<UmbPropertyTypeM
 
 describe('UmbContentTypeDesignEditorPropertyElement', () => {
 	let element: UmbContentTypeDesignEditorPropertyElement;
-	let workspaceContext: UmbTestWorkspaceContext;
+	let modalManager: UmbTestModalManagerContext;
+	let structureHelper: UmbTestPropertyStructureHelper;
 
 	const setup = async (persisted: UmbContentTypeDetailModel | undefined, currentAlias: string) => {
 		const host: UmbTestPropertyHostElement = await fixture(
@@ -83,50 +118,74 @@ describe('UmbContentTypeDesignEditorPropertyElement', () => {
 			</umb-test-content-type-design-editor-property-host>`,
 		);
 
-		workspaceContext = new UmbTestWorkspaceContext(host);
+		const workspaceContext = new UmbTestWorkspaceContext(host);
 		workspaceContext.setPersisted(persisted);
 		host.provideContext(UMB_ENTITY_DETAIL_WORKSPACE_CONTEXT, workspaceContext as never);
 
+		modalManager = new UmbTestModalManagerContext(host);
+		host.provideContext(UMB_MODAL_MANAGER_CONTEXT, modalManager as never);
+
+		structureHelper = new UmbTestPropertyStructureHelper();
+
 		element = host.querySelector('umb-content-type-design-editor-property')!;
 		element.setAttribute('editpropertytypepath', '/edit/');
-		element.propertyStructureHelper = new UmbTestPropertyStructureHelper() as never;
+		element.propertyStructureHelper = structureHelper as never;
 		element.property = propertyModel(currentAlias);
 
 		await aTimeout(0);
 		await element.updateComplete;
 	};
 
-	const notice = () => element.shadowRoot!.querySelector('#alias-renamed-notice');
-
-	it('warns when the alias of a stored property is changed on an Element Type', async () => {
-		await setup(contentTypeModel(true, [propertyModel('headline')]), 'title');
-		expect(notice()).to.exist;
-	});
-
-	it('does not warn when the alias matches the stored one', async () => {
-		await setup(contentTypeModel(true, [propertyModel('headline')]), 'headline');
-		expect(notice()).to.not.exist;
-	});
-
-	it('does not warn for a property that is not stored yet', async () => {
-		await setup(contentTypeModel(true, []), 'title');
-		expect(notice()).to.not.exist;
-	});
-
-	it('does not warn when the owner is not an Element Type', async () => {
-		await setup(contentTypeModel(false, [propertyModel('headline')]), 'title');
-		expect(notice()).to.not.exist;
-	});
-
-	it('stops warning once the rename is stored', async () => {
-		await setup(contentTypeModel(true, [propertyModel('headline')]), 'title');
-		expect(notice()).to.exist;
-
-		workspaceContext.setPersisted(contentTypeModel(true, [propertyModel('title')]));
-
+	const finishEditingAlias = async () => {
+		element
+			.shadowRoot!.querySelector('umb-input-with-alias')!
+			.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
 		await aTimeout(0);
 		await element.updateComplete;
+	};
 
-		expect(notice()).to.not.exist;
+	it('asks for confirmation when the alias of a stored property is changed on an Element Type', async () => {
+		await setup(contentTypeModel(true, [propertyModel('headline')]), 'title');
+		await finishEditingAlias();
+
+		expect(modalManager.opened.length).to.equal(1);
+		expect(modalManager.opened[0].args).to.deep.equal(['Headline', 'headline']);
+	});
+
+	it('does not ask when the alias matches the stored one', async () => {
+		await setup(contentTypeModel(true, [propertyModel('headline')]), 'headline');
+		await finishEditingAlias();
+
+		expect(modalManager.opened.length).to.equal(0);
+	});
+
+	it('does not ask for a property that is not stored yet', async () => {
+		await setup(contentTypeModel(true, []), 'title');
+		await finishEditingAlias();
+
+		expect(modalManager.opened.length).to.equal(0);
+	});
+
+	it('does not ask when the owner is not an Element Type', async () => {
+		await setup(contentTypeModel(false, [propertyModel('headline')]), 'title');
+		await finishEditingAlias();
+
+		expect(modalManager.opened.length).to.equal(0);
+	});
+
+	it('does not ask again once the change is confirmed', async () => {
+		await setup(contentTypeModel(true, [propertyModel('headline')]), 'title');
+		await finishEditingAlias();
+		await finishEditingAlias();
+
+		expect(modalManager.opened.length).to.equal(1);
+	});
+
+	it('restores the stored alias when the change is not confirmed', async () => {
+		await setup(contentTypeModel(true, [propertyModel('headline')]), 'title');
+		modalManager.rejectNext();
+		await finishEditingAlias();
+
+		expect(structureHelper.updates).to.deep.equal([{ alias: 'headline' }]);
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.test.ts
@@ -1,52 +1,56 @@
 import { UmbContentTypeDesignEditorPropertyElement } from './content-type-design-editor-property.element.js';
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { aTimeout, expect, fixture } from '@open-wc/testing';
+import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
-import type { UmbPropertyTypeModel } from '../../../types.js';
+import { UMB_ENTITY_DETAIL_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
+import type { UmbContentTypeDetailModel, UmbPropertyTypeModel } from '../../../types.js';
 
 const OWNER_UNIQUE = 'owner-content-type';
+const PROPERTY_UNIQUE = 'property-unique';
 
-class UmbTestStructureManager {
-	#ownerContentType = new UmbObjectState<any>({ unique: OWNER_UNIQUE, name: 'Hero', isElement: true });
-	#persistedProperty = new UmbObjectState<UmbPropertyTypeModel | undefined>(undefined);
+@customElement('umb-test-content-type-design-editor-property-host')
+class UmbTestPropertyHostElement extends UmbLitElement {
+	override render() {
+		return html`<slot></slot>`;
+	}
+}
 
-	readonly ownerContentType = this.#ownerContentType.asObservable();
+class UmbTestWorkspaceContext {
+	readonly IS_ENTITY_DETAIL_WORKSPACE_CONTEXT = true;
 
-	ownerContentTypeObservablePart<R>(mappingFunction: (value: any) => R) {
-		return this.#ownerContentType.asObservablePart(mappingFunction);
+	#host: UmbLitElement;
+	#persisted = new UmbObjectState<UmbContentTypeDetailModel | undefined>(undefined);
+	readonly persistedData = this.#persisted.asObservable();
+
+	constructor(host: UmbLitElement) {
+		this.#host = host;
 	}
 
-	persistedPropertyById() {
-		return this.#persistedProperty.asObservable();
+	getHostElement() {
+		return this.#host;
 	}
 
-	getOwnerContentTypeUnique() {
-		return OWNER_UNIQUE;
-	}
-
-	setIsElement(isElement: boolean) {
-		this.#ownerContentType.update({ isElement });
-	}
-
-	setPersistedProperty(property: UmbPropertyTypeModel | undefined) {
-		this.#persistedProperty.setValue(property);
+	setPersisted(data: UmbContentTypeDetailModel | undefined) {
+		this.#persisted.setValue(data);
 	}
 }
 
 class UmbTestPropertyStructureHelper {
-	readonly manager = new UmbTestStructureManager();
-
 	getStructureManager() {
-		return this.manager;
+		return {
+			getOwnerContentTypeUnique: () => OWNER_UNIQUE,
+		};
 	}
 
 	async contentTypeOfProperty() {
-		return this.manager.ownerContentType;
+		return new UmbObjectState({ unique: OWNER_UNIQUE, name: 'Hero' }).asObservable();
 	}
 }
 
 const propertyModel = (alias: string) =>
 	({
-		unique: 'property-unique',
+		unique: PROPERTY_UNIQUE,
 		container: null,
 		alias,
 		name: 'Headline',
@@ -59,17 +63,33 @@ const propertyModel = (alias: string) =>
 		appearance: { labelOnTop: false },
 	}) as unknown as UmbPropertyTypeModel;
 
+const contentTypeModel = (isElement: boolean, properties: Array<UmbPropertyTypeModel>) =>
+	({
+		unique: OWNER_UNIQUE,
+		name: 'Hero',
+		alias: 'hero',
+		isElement,
+		properties,
+	}) as unknown as UmbContentTypeDetailModel;
+
 describe('UmbContentTypeDesignEditorPropertyElement', () => {
 	let element: UmbContentTypeDesignEditorPropertyElement;
-	let helper: UmbTestPropertyStructureHelper;
+	let workspaceContext: UmbTestWorkspaceContext;
 
-	const setup = async (persistedAlias: string | undefined, currentAlias: string) => {
-		helper = new UmbTestPropertyStructureHelper();
-		helper.manager.setPersistedProperty(persistedAlias ? propertyModel(persistedAlias) : undefined);
+	const setup = async (persisted: UmbContentTypeDetailModel | undefined, currentAlias: string) => {
+		const host: UmbTestPropertyHostElement = await fixture(
+			html`<umb-test-content-type-design-editor-property-host>
+				<umb-content-type-design-editor-property></umb-content-type-design-editor-property>
+			</umb-test-content-type-design-editor-property-host>`,
+		);
 
-		element = await fixture(html`<umb-content-type-design-editor-property></umb-content-type-design-editor-property>`);
+		workspaceContext = new UmbTestWorkspaceContext(host);
+		workspaceContext.setPersisted(persisted);
+		host.provideContext(UMB_ENTITY_DETAIL_WORKSPACE_CONTEXT, workspaceContext as never);
+
+		element = host.querySelector('umb-content-type-design-editor-property')!;
 		element.setAttribute('editpropertytypepath', '/edit/');
-		element.propertyStructureHelper = helper as any;
+		element.propertyStructureHelper = new UmbTestPropertyStructureHelper() as never;
 		element.property = propertyModel(currentAlias);
 
 		await aTimeout(0);
@@ -79,35 +99,30 @@ describe('UmbContentTypeDesignEditorPropertyElement', () => {
 	const notice = () => element.shadowRoot!.querySelector('#alias-renamed-notice');
 
 	it('warns when the alias of a stored property is changed on an Element Type', async () => {
-		await setup('headline', 'title');
+		await setup(contentTypeModel(true, [propertyModel('headline')]), 'title');
 		expect(notice()).to.exist;
 	});
 
 	it('does not warn when the alias matches the stored one', async () => {
-		await setup('headline', 'headline');
+		await setup(contentTypeModel(true, [propertyModel('headline')]), 'headline');
 		expect(notice()).to.not.exist;
 	});
 
 	it('does not warn for a property that is not stored yet', async () => {
-		await setup(undefined, 'title');
-		expect(notice()).to.not.exist;
-	});
-
-	it('stops warning when the structure helper is taken away', async () => {
-		await setup('headline', 'title');
-		expect(notice()).to.exist;
-
-		element.propertyStructureHelper = undefined;
-
-		await aTimeout(0);
-		await element.updateComplete;
-
+		await setup(contentTypeModel(true, []), 'title');
 		expect(notice()).to.not.exist;
 	});
 
 	it('does not warn when the owner is not an Element Type', async () => {
-		await setup('headline', 'title');
-		helper.manager.setIsElement(false);
+		await setup(contentTypeModel(false, [propertyModel('headline')]), 'title');
+		expect(notice()).to.not.exist;
+	});
+
+	it('stops warning once the rename is stored', async () => {
+		await setup(contentTypeModel(true, [propertyModel('headline')]), 'title');
+		expect(notice()).to.exist;
+
+		workspaceContext.setPersisted(contentTypeModel(true, [propertyModel('title')]));
 
 		await aTimeout(0);
 		await element.updateComplete;

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.test.ts
@@ -93,6 +93,18 @@ describe('UmbContentTypeDesignEditorPropertyElement', () => {
 		expect(notice()).to.not.exist;
 	});
 
+	it('stops warning when the structure helper is taken away', async () => {
+		await setup('headline', 'title');
+		expect(notice()).to.exist;
+
+		element.propertyStructureHelper = undefined;
+
+		await aTimeout(0);
+		await element.updateComplete;
+
+		expect(notice()).to.not.exist;
+	});
+
 	it('does not warn when the owner is not an Element Type', async () => {
 		await setup('headline', 'title');
 		helper.manager.setIsElement(false);

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.test.ts
@@ -1,0 +1,105 @@
+import { UmbContentTypeDesignEditorPropertyElement } from './content-type-design-editor-property.element.js';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
+import type { UmbPropertyTypeModel } from '../../../types.js';
+
+const OWNER_UNIQUE = 'owner-content-type';
+
+class UmbTestStructureManager {
+	#ownerContentType = new UmbObjectState<any>({ unique: OWNER_UNIQUE, name: 'Hero', isElement: true });
+	#persistedProperty = new UmbObjectState<UmbPropertyTypeModel | undefined>(undefined);
+
+	readonly ownerContentType = this.#ownerContentType.asObservable();
+
+	ownerContentTypeObservablePart<R>(mappingFunction: (value: any) => R) {
+		return this.#ownerContentType.asObservablePart(mappingFunction);
+	}
+
+	persistedPropertyById() {
+		return this.#persistedProperty.asObservable();
+	}
+
+	getOwnerContentTypeUnique() {
+		return OWNER_UNIQUE;
+	}
+
+	setIsElement(isElement: boolean) {
+		this.#ownerContentType.update({ isElement });
+	}
+
+	setPersistedProperty(property: UmbPropertyTypeModel | undefined) {
+		this.#persistedProperty.setValue(property);
+	}
+}
+
+class UmbTestPropertyStructureHelper {
+	readonly manager = new UmbTestStructureManager();
+
+	getStructureManager() {
+		return this.manager;
+	}
+
+	async contentTypeOfProperty() {
+		return this.manager.ownerContentType;
+	}
+}
+
+const propertyModel = (alias: string) =>
+	({
+		unique: 'property-unique',
+		container: null,
+		alias,
+		name: 'Headline',
+		description: '',
+		dataType: {},
+		variesByCulture: false,
+		variesBySegment: false,
+		sortOrder: 0,
+		validation: { mandatory: false, mandatoryMessage: null, regEx: null, regExMessage: null },
+		appearance: { labelOnTop: false },
+	}) as unknown as UmbPropertyTypeModel;
+
+describe('UmbContentTypeDesignEditorPropertyElement', () => {
+	let element: UmbContentTypeDesignEditorPropertyElement;
+	let helper: UmbTestPropertyStructureHelper;
+
+	const setup = async (persistedAlias: string | undefined, currentAlias: string) => {
+		helper = new UmbTestPropertyStructureHelper();
+		helper.manager.setPersistedProperty(persistedAlias ? propertyModel(persistedAlias) : undefined);
+
+		element = await fixture(html`<umb-content-type-design-editor-property></umb-content-type-design-editor-property>`);
+		element.setAttribute('editpropertytypepath', '/edit/');
+		element.propertyStructureHelper = helper as any;
+		element.property = propertyModel(currentAlias);
+
+		await aTimeout(0);
+		await element.updateComplete;
+	};
+
+	const notice = () => element.shadowRoot!.querySelector('#alias-renamed-notice');
+
+	it('warns when the alias of a stored property is changed on an Element Type', async () => {
+		await setup('headline', 'title');
+		expect(notice()).to.exist;
+	});
+
+	it('does not warn when the alias matches the stored one', async () => {
+		await setup('headline', 'headline');
+		expect(notice()).to.not.exist;
+	});
+
+	it('does not warn for a property that is not stored yet', async () => {
+		await setup(undefined, 'title');
+		expect(notice()).to.not.exist;
+	});
+
+	it('does not warn when the owner is not an Element Type', async () => {
+		await setup('headline', 'title');
+		helper.manager.setIsElement(false);
+
+		await aTimeout(0);
+		await element.updateComplete;
+
+		expect(notice()).to.not.exist;
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -99,19 +99,14 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 	#ownerIsElement = false;
 	#persistedAlias?: string;
 
-	/**
-	 * An Element Type stores its property values keyed by alias rather than by property type, so renaming
-	 * the alias of an already stored property orphans the values held under the previous alias.
-	 */
 	#observePersistedProperty() {
 		const structure = this._propertyStructureHelper?.getStructureManager();
 		const unique = this._property?.unique;
-		// The helper outlives its structure manager, which is set - and can be replaced - after construction.
+		// The helper is stable, but its structure manager is set - and can be replaced - after construction.
 		if (unique === this.#observedPropertyUnique && structure === this.#observedStructureManager) return;
 		this.#observedPropertyUnique = unique;
 		this.#observedStructureManager = structure;
 
-		// Passing no source removes the observer and calls back with undefined, which resets the state.
 		this.observe(
 			structure && unique
 				? structure.ownerContentTypeObservablePart((contentType) => contentType?.isElement === true)
@@ -133,6 +128,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		);
 	}
 
+	// Only an Element Type keys its property values by alias, so only there does a rename orphan them.
 	#updateAliasRenamed() {
 		this._aliasRenamed =
 			this.#ownerIsElement && this.#persistedAlias !== undefined && this.#persistedAlias !== this._property?.alias;

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -1,8 +1,10 @@
+import type { UmbContentTypePropertyStructureHelper } from '../../../structure/index.js';
 import type {
-	UmbContentTypePropertyStructureHelper,
-	UmbContentTypeStructureManager,
-} from '../../../structure/index.js';
-import type { UmbContentTypeModel, UmbPropertyTypeModel, UmbPropertyTypeScaffoldModel } from '../../../types.js';
+	UmbContentTypeDetailModel,
+	UmbContentTypeModel,
+	UmbPropertyTypeModel,
+	UmbPropertyTypeScaffoldModel,
+} from '../../../types.js';
 import { UmbPropertyTypeContext } from './content-type-design-editor-property.context.js';
 import { css, html, customElement, property, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
@@ -13,6 +15,7 @@ import { UMB_EDIT_PROPERTY_TYPE_WORKSPACE_PATH_PATTERN } from '@umbraco-cms/back
 import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
 import { umbBindToValidation } from '@umbraco-cms/backoffice/validation';
+import { UMB_ENTITY_DETAIL_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
 
 /**
  *  @element umb-content-type-design-editor-property
@@ -30,7 +33,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		if (value === this._propertyStructureHelper) return;
 		this._propertyStructureHelper = value;
 		this.#checkInherited();
-		this.#observePersistedProperty();
 	}
 	public get propertyStructureHelper(): UmbContentTypePropertyStructureHelper<UmbContentTypeModel> | undefined {
 		return this._propertyStructureHelper;
@@ -54,7 +56,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		this.#context.setAlias(value?.alias);
 		this.#context.setLabel(value?.name);
 		this.#checkInherited();
-		this.#observePersistedProperty();
 		this.#updateAliasRenamed();
 		this.#setDataType(this._property?.dataType?.unique);
 		this.requestUpdate('property', oldValue);
@@ -94,44 +95,34 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 	@state()
 	private _aliasRenamed = false;
 
-	#observedPropertyUnique?: string;
-	#observedStructureManager?: UmbContentTypeStructureManager<UmbContentTypeModel>;
-	#ownerIsElement = false;
-	#persistedAlias?: string;
+	#persistedContentType?: UmbContentTypeDetailModel;
 
-	#observePersistedProperty() {
-		const structure = this._propertyStructureHelper?.getStructureManager();
-		const unique = this._property?.unique;
-		// The helper is stable, but its structure manager is set - and can be replaced - after construction.
-		if (unique === this.#observedPropertyUnique && structure === this.#observedStructureManager) return;
-		this.#observedPropertyUnique = unique;
-		this.#observedStructureManager = structure;
+	constructor() {
+		super();
 
-		this.observe(
-			structure && unique
-				? structure.ownerContentTypeObservablePart((contentType) => contentType?.isElement === true)
-				: undefined,
-			(isElement) => {
-				this.#ownerIsElement = isElement === true;
-				this.#updateAliasRenamed();
-			},
-			'observeOwnerIsElement',
-		);
-
-		this.observe(
-			structure && unique ? structure.persistedPropertyById(unique) : undefined,
-			(property) => {
-				this.#persistedAlias = property?.alias;
-				this.#updateAliasRenamed();
-			},
-			'observePersistedProperty',
-		);
+		this.consumeContext(UMB_ENTITY_DETAIL_WORKSPACE_CONTEXT, (context) => {
+			this.observe(
+				context?.persistedData,
+				(data) => {
+					this.#persistedContentType = data as UmbContentTypeDetailModel | undefined;
+					this.#updateAliasRenamed();
+				},
+				'observePersistedContentType',
+			);
+		});
 	}
 
 	// Only an Element Type keys its property values by alias, so only there does a rename orphan them.
 	#updateAliasRenamed() {
+		const persistedAlias = this.#persistedAlias();
 		this._aliasRenamed =
-			this.#ownerIsElement && this.#persistedAlias !== undefined && this.#persistedAlias !== this._property?.alias;
+			this.#persistedContentType?.isElement === true &&
+			persistedAlias !== undefined &&
+			persistedAlias !== this._property?.alias;
+	}
+
+	#persistedAlias() {
+		return this.#persistedContentType?.properties?.find((x) => x.unique === this._property?.unique)?.alias;
 	}
 
 	async #checkInherited() {
@@ -318,7 +309,9 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		return html`<small id="alias-renamed-notice">
 			<uui-icon name="icon-alert"></uui-icon>
 			<span>
-				<umb-localize key="contentTypeEditor_propertyAliasRenamedNotice" .args=${[this.#persistedAlias]}></umb-localize>
+				<umb-localize
+					key="contentTypeEditor_propertyAliasRenamedNotice"
+					.args=${[this.#persistedAlias()]}></umb-localize>
 			</span>
 		</small>`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -27,6 +27,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		if (value === this._propertyStructureHelper) return;
 		this._propertyStructureHelper = value;
 		this.#checkInherited();
+		this.#observePersistedProperty();
 	}
 	public get propertyStructureHelper(): UmbContentTypePropertyStructureHelper<UmbContentTypeModel> | undefined {
 		return this._propertyStructureHelper;
@@ -50,6 +51,8 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		this.#context.setAlias(value?.alias);
 		this.#context.setLabel(value?.name);
 		this.#checkInherited();
+		this.#observePersistedProperty();
+		this.#updateAliasRenamed();
 		this.#setDataType(this._property?.dataType?.unique);
 		this.requestUpdate('property', oldValue);
 	}
@@ -84,6 +87,47 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 
 	@state()
 	private _dataTypeName?: string;
+
+	@state()
+	private _aliasRenamed = false;
+
+	#observedPropertyUnique?: string;
+	#ownerIsElement = false;
+	#persistedAlias?: string;
+
+	/**
+	 * An Element Type stores its property values keyed by alias rather than by property type, so renaming
+	 * the alias of an already stored property orphans the values held under the previous alias.
+	 */
+	#observePersistedProperty() {
+		const structure = this._propertyStructureHelper?.getStructureManager();
+		const unique = this._property?.unique;
+		if (!structure || !unique || unique === this.#observedPropertyUnique) return;
+		this.#observedPropertyUnique = unique;
+
+		this.observe(
+			structure.ownerContentTypeObservablePart((contentType) => contentType?.isElement === true),
+			(isElement) => {
+				this.#ownerIsElement = isElement;
+				this.#updateAliasRenamed();
+			},
+			'observeOwnerIsElement',
+		);
+
+		this.observe(
+			structure.persistedPropertyById(unique),
+			(property) => {
+				this.#persistedAlias = property?.alias;
+				this.#updateAliasRenamed();
+			},
+			'observePersistedProperty',
+		);
+	}
+
+	#updateAliasRenamed() {
+		this._aliasRenamed =
+			this.#ownerIsElement && this.#persistedAlias !== undefined && this.#persistedAlias !== this._property?.alias;
+	}
 
 	async #checkInherited() {
 		if (this._propertyStructureHelper && this._property) {
@@ -206,6 +250,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 						@change=${this.#onNameAliasChange}
 						${umbBindToValidation(this)}></umb-input-with-alias>
 					<umb-form-validation-message for="name-alias-input"></umb-form-validation-message>
+					${this.#renderAliasRenamedNotice()}
 
 					<slot name="action-menu"></slot>
 					<p>
@@ -261,6 +306,16 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				@change=${this.#onPropertyOrderChanged}
 				.value=${(this.property.sortOrder ?? 0).toString()}></uui-input>
 		`;
+	}
+
+	#renderAliasRenamedNotice() {
+		if (!this._aliasRenamed) return nothing;
+		return html`<small id="alias-renamed-notice">
+			<uui-icon name="icon-alert"></uui-icon>
+			<span>
+				<umb-localize key="contentTypeEditor_propertyAliasRenamedNotice" .args=${[this.#persistedAlias]}></umb-localize>
+			</span>
+		</small>`;
 	}
 
 	#renderPropertyName() {
@@ -439,6 +494,21 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 			#header umb-input-with-alias,
 			#header uui-textarea {
 				width: 100%;
+			}
+
+			#alias-renamed-notice {
+				display: flex;
+				align-items: flex-start;
+				gap: var(--uui-size-space-1);
+				margin-top: var(--uui-size-space-2);
+				/* Indent to the text inset of the inputs above, which includes their border. */
+				padding-left: calc(var(--uui-size-space-3) + 1px);
+			}
+
+			#alias-renamed-notice uui-icon {
+				flex-shrink: 0;
+				/* Centre the icon on the first line rather than the whole, possibly wrapped, block. */
+				margin-top: calc((1lh - 1em) / 2);
 			}
 
 			#description-input:not(:hover):not(:focus) {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -106,23 +106,25 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 	#observePersistedProperty() {
 		const structure = this._propertyStructureHelper?.getStructureManager();
 		const unique = this._property?.unique;
-		if (!structure || !unique) return;
 		// The helper outlives its structure manager, which is set - and can be replaced - after construction.
 		if (unique === this.#observedPropertyUnique && structure === this.#observedStructureManager) return;
 		this.#observedPropertyUnique = unique;
 		this.#observedStructureManager = structure;
 
+		// Passing no source removes the observer and calls back with undefined, which resets the state.
 		this.observe(
-			structure.ownerContentTypeObservablePart((contentType) => contentType?.isElement === true),
+			structure && unique
+				? structure.ownerContentTypeObservablePart((contentType) => contentType?.isElement === true)
+				: undefined,
 			(isElement) => {
-				this.#ownerIsElement = isElement;
+				this.#ownerIsElement = isElement === true;
 				this.#updateAliasRenamed();
 			},
 			'observeOwnerIsElement',
 		);
 
 		this.observe(
-			structure.persistedPropertyById(unique),
+			structure && unique ? structure.persistedPropertyById(unique) : undefined,
 			(property) => {
 				this.#persistedAlias = property?.alias;
 				this.#updateAliasRenamed();

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -56,7 +56,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		this.#context.setAlias(value?.alias);
 		this.#context.setLabel(value?.name);
 		this.#checkInherited();
-		this.#updateAliasRenamed();
 		this.#setDataType(this._property?.dataType?.unique);
 		this.requestUpdate('property', oldValue);
 	}
@@ -92,10 +91,8 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 	@state()
 	private _dataTypeName?: string;
 
-	@state()
-	private _aliasRenamed = false;
-
 	#persistedContentType?: UmbContentTypeDetailModel;
+	#aliasChangeConfirmed = false;
 
 	constructor() {
 		super();
@@ -105,24 +102,44 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				context?.persistedData,
 				(data) => {
 					this.#persistedContentType = data as UmbContentTypeDetailModel | undefined;
-					this.#updateAliasRenamed();
 				},
 				'observePersistedContentType',
 			);
 		});
 	}
 
-	// Only an Element Type keys its property values by alias, so only there does a rename orphan them.
-	#updateAliasRenamed() {
-		const persistedAlias = this.#persistedAlias();
-		this._aliasRenamed =
-			this.#persistedContentType?.isElement === true &&
-			persistedAlias !== undefined &&
-			persistedAlias !== this._property?.alias;
-	}
-
 	#persistedAlias() {
 		return this.#persistedContentType?.properties?.find((x) => x.unique === this._property?.unique)?.alias;
+	}
+
+	/**
+	 * Only an Element Type keys its property values by alias, so only there does a rename orphan them.
+	 * Confirmed once the alias is left alone, rather than on every keystroke.
+	 */
+	async #confirmAliasChange() {
+		const persistedAlias = this.#persistedAlias();
+		if (this.#persistedContentType?.isElement !== true || persistedAlias === undefined) return;
+
+		if (persistedAlias === this._property?.alias) {
+			this.#aliasChangeConfirmed = false;
+			return;
+		}
+
+		if (this.#aliasChangeConfirmed) return;
+
+		try {
+			await umbConfirmModal(this, {
+				headline: this.localize.term('contentTypeEditor_confirmPropertyAliasChangeHeadline'),
+				content: html`<umb-localize
+					key="contentTypeEditor_confirmPropertyAliasChangeMessage"
+					.args=${[this._property?.name, persistedAlias]}></umb-localize>`,
+				confirmLabel: '#general_change',
+				color: 'danger',
+			});
+			this.#aliasChangeConfirmed = true;
+		} catch {
+			this.#singleValueUpdate('alias', persistedAlias);
+		}
 	}
 
 	async #checkInherited() {
@@ -244,9 +261,9 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 						.value=${this.property.name}
 						.alias=${this.property.alias}
 						@change=${this.#onNameAliasChange}
+						@focusout=${this.#confirmAliasChange}
 						${umbBindToValidation(this)}></umb-input-with-alias>
 					<umb-form-validation-message for="name-alias-input"></umb-form-validation-message>
-					${this.#renderAliasRenamedNotice()}
 
 					<slot name="action-menu"></slot>
 					<p>
@@ -302,18 +319,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				@change=${this.#onPropertyOrderChanged}
 				.value=${(this.property.sortOrder ?? 0).toString()}></uui-input>
 		`;
-	}
-
-	#renderAliasRenamedNotice() {
-		if (!this._aliasRenamed) return nothing;
-		return html`<small id="alias-renamed-notice">
-			<uui-icon name="icon-alert"></uui-icon>
-			<span>
-				<umb-localize
-					key="contentTypeEditor_propertyAliasRenamedNotice"
-					.args=${[this.#persistedAlias()]}></umb-localize>
-			</span>
-		</small>`;
 	}
 
 	#renderPropertyName() {
@@ -492,21 +497,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 			#header umb-input-with-alias,
 			#header uui-textarea {
 				width: 100%;
-			}
-
-			#alias-renamed-notice {
-				display: flex;
-				align-items: flex-start;
-				gap: var(--uui-size-space-1);
-				margin-top: var(--uui-size-space-2);
-				/* Indent to the text inset of the inputs above, which includes their border. */
-				padding-left: calc(var(--uui-size-space-3) + 1px);
-			}
-
-			#alias-renamed-notice uui-icon {
-				flex-shrink: 0;
-				/* Centre the icon on the first line rather than the whole, possibly wrapped, block. */
-				margin-top: calc((1lh - 1em) / 2);
 			}
 
 			#description-input:not(:hover):not(:focus) {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -1,4 +1,7 @@
-import type { UmbContentTypePropertyStructureHelper } from '../../../structure/index.js';
+import type {
+	UmbContentTypePropertyStructureHelper,
+	UmbContentTypeStructureManager,
+} from '../../../structure/index.js';
 import type { UmbContentTypeModel, UmbPropertyTypeModel, UmbPropertyTypeScaffoldModel } from '../../../types.js';
 import { UmbPropertyTypeContext } from './content-type-design-editor-property.context.js';
 import { css, html, customElement, property, state, nothing } from '@umbraco-cms/backoffice/external/lit';
@@ -92,6 +95,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 	private _aliasRenamed = false;
 
 	#observedPropertyUnique?: string;
+	#observedStructureManager?: UmbContentTypeStructureManager<UmbContentTypeModel>;
 	#ownerIsElement = false;
 	#persistedAlias?: string;
 
@@ -102,8 +106,11 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 	#observePersistedProperty() {
 		const structure = this._propertyStructureHelper?.getStructureManager();
 		const unique = this._property?.unique;
-		if (!structure || !unique || unique === this.#observedPropertyUnique) return;
+		if (!structure || !unique) return;
+		// The helper outlives its structure manager, which is set - and can be replaced - after construction.
+		if (unique === this.#observedPropertyUnique && structure === this.#observedStructureManager) return;
 		this.#observedPropertyUnique = unique;
+		this.#observedStructureManager = structure;
 
 		this.observe(
 			structure.ownerContentTypeObservablePart((contentType) => contentType?.isElement === true),


### PR DESCRIPTION
## Description

Renaming the alias of a property on an Element Type silently discards any content already stored under the old alias. This adds a confirmation dialog when an unsaved element type alias is changed.

<img width="958" height="474" alt="image" src="https://github.com/user-attachments/assets/19a01bd5-dce0-4b8a-9dfa-834f6457d665" />

_I renamed the headline to "Change property alias" after taking the screenshot._

Fixes #23864

### Why this affects Element Types and not Document Types

Content property values live in `umbracoPropertyData`, keyed by `propertyTypeId` — an integer foreign key. Rename the alias and the row still points at the same property type, so nothing is lost.

Element data inside a block editor value is different. It is JSON, and each value is keyed **only** by alias.

### Why the rename isn't carried through to the stored values

The issue asks for the rename to be applied to persisted block values, and this PR deliberately doesn't do that.  It would mean rewriting every block value in every draft and published version of any content item that uses that property, which isn't feasible on a large site.

## Testing

1. Create an Element Type with a Textstring property aliased `headline`, add it to a Block Grid, put a block on a page, fill in the field and publish.
2. Open the Element Type and change the property alias to `title` — the confirmation dialog appears under the property, naming `headline`.
3. Cancel the dialog and the alias should revert.
4. Confirm the dialog and the change is kept.
5. Verify further changes, unless you first change back to the original, don't warn.
6. Verify no dialog is shown for an unsaved element type, 
7. Verify no dialog is shown for a content type that isn't an element type.
