### PR TITLE
Localization: Use UK conventions when formatting dates for "English (UK)" backoffice users (closes #23809)

### DIFF
--- a/src/Umbraco.Web.UI.Client/docs/package-development.md
+++ b/src/Umbraco.Web.UI.Client/docs/package-development.md
@@ -105,6 +105,7 @@ The active language is driven by the shell elements `<umb-app>` and `<umb-auth>`
 - Razor sets `lang` on the shell element from `GlobalSettings.DefaultUILanguage`. The shell reads its own `lang` on connect and calls `umbLocalizationRegistry.loadLanguage(this.lang)`.
 - After login, `current-user.context` calls `loadLanguage(user.languageIsoCode)` and the shell mirrors the new value back onto its own `lang` attribute via `umbLocalizationRegistry.currentLanguage`.
 - `<html lang>` is the static `"en"` for the noscript fallback text. Don't conflate it with the dynamic UI language.
+- Locale-sensitive formatting can use a different locale from the requested one. `Intl` resolves a language-only tag to that language's default region, which is wrong where the dictionary we ship is written for another region — `en` is UK English but resolves to US conventions — so the registry corrects those cases. `umbLocalizationManager.documentLanguage` holds the corrected locale; `this.localize.date()` and `.number()` already use it.
 
 If you're adding a new shell-like element (rare — most code lives inside `<umb-app>`), give it a `lang` attribute and the same subscribe-and-mirror pattern. For everything else, just use `this.localize` and the inherited context resolves the rest.
 

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -39,12 +39,22 @@ export class UmbLocalizationManager {
 	localizations: Map<string, UmbLocalizationSetBase> = new Map();
 
 	/**
-	 * The currently active language and direction. Read-only from a consumer perspective —
+	 * The direction of the currently active language. Read-only from a consumer perspective —
 	 * to change the active language, call `umbLocalizationRegistry.loadLanguage(locale)`.
-	 * The fields stay publicly writable for the registry's pipeline; consumers writing here
+	 * The field stays publicly writable for the registry's pipeline; consumers writing here
 	 * directly will only sync the field without loading the matching dictionaries.
 	 */
 	documentDirection: 'ltr' | 'rtl' = (document.documentElement.dir as 'ltr' | 'rtl') || 'ltr';
+
+	/**
+	 * The locale used for locale-sensitive formatting, such as dates and numbers.
+	 *
+	 * This is not necessarily the locale that was requested. Where the region `Intl` infers from
+	 * a language-only tag does not match the dictionary registered under that tag, the registry
+	 * corrects it — a bare `en`, for example, is served as `en-gb`.
+	 *
+	 * Read-only from a consumer perspective, as with {@link documentDirection}.
+	 */
 	documentLanguage = document.documentElement.lang || navigator.language;
 
 	get fallback(): UmbLocalizationSet | undefined {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.test.ts
@@ -61,9 +61,9 @@ describe('umb-localize-date', () => {
 	});
 });
 
-// `en` is corrected to en-GB for formatting, so cover the case where a region was asked for
-// explicitly and must be left alone.
 describe('umb-localize-date with an explicitly requested region', () => {
+	// `en` is corrected to en-GB for formatting, so this suite switches the active language to a
+	// specific region, which must be left alone. Hence its own hooks rather than the shared ones.
 	const englishUs = {
 		type: 'localization',
 		alias: 'test.en-us',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize-date.element.test.ts
@@ -37,14 +37,14 @@ describe('umb-localize-date', () => {
 		umbLocalizationRegistry.loadLanguage('en');
 
 		it('should localize a date', () => {
-			expect(element.shadowRoot?.textContent).to.equal('1/1/2020');
+			expect(element.shadowRoot?.textContent).to.equal('01/01/2020');
 		});
 
 		it('should localize a date with options', async () => {
 			element.options = { dateStyle: 'full' };
 			await element.updateComplete;
 
-			expect(element.shadowRoot?.textContent).to.equal('Wednesday, January 1, 2020');
+			expect(element.shadowRoot?.textContent).to.equal('Wednesday, 1 January 2020');
 		});
 
 		it('should set a title', async () => {
@@ -58,5 +58,36 @@ describe('umb-localize-date', () => {
 			await element.updateComplete;
 			expect(element.title).to.equal('Another title');
 		});
+	});
+});
+
+// `en` is corrected to en-GB for formatting, so cover the case where a region was asked for
+// explicitly and must be left alone.
+describe('umb-localize-date with an explicitly requested region', () => {
+	const englishUs = {
+		type: 'localization',
+		alias: 'test.en-us',
+		name: 'Test English (US)',
+		meta: { culture: 'en-us' },
+	};
+
+	before(async () => {
+		umbExtensionsRegistry.register(englishUs);
+		umbLocalizationRegistry.loadLanguage('en-US');
+		await aTimeout(0);
+	});
+
+	after(async () => {
+		umbExtensionsRegistry.unregister(englishUs.alias);
+		umbLocalizationRegistry.loadLanguage('en');
+		await aTimeout(0);
+	});
+
+	it('formats the date with the requested region', async () => {
+		const element: UmbLocalizeDateElement = await fixture(
+			html`<umb-localize-date .date=${new Date('2020-09-01T00:00:00')}></umb-localize-date>`,
+		);
+
+		expect(element.shadowRoot?.textContent).to.equal('9/1/2020');
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
@@ -213,7 +213,7 @@ describe('UmbLocalizeController', () => {
 		registry.loadLanguage('en');
 		await aTimeout(0);
 
-		expect(umbLocalizationManager.documentLanguage).to.equal('en');
+		expect(umbLocalizationManager.documentLanguage).to.equal('en-gb');
 		expect(document.documentElement.dir).to.equal('ltr');
 
 		const current = registry.localizations.get(englishUk.meta.culture);
@@ -294,5 +294,64 @@ describe('UmbLocalizationRegistry initialization', () => {
 		await aTimeout(0);
 
 		expect(registry.localizations.has('en'), 'expected default "en" to be loaded').to.be.true;
+	});
+});
+
+describe('UmbLocalizationRegistry formatting locale', () => {
+	let registry: UmbLocalizationRegistry;
+
+	beforeEach(() => {
+		registry = new UmbLocalizationRegistry(umbExtensionsRegistry);
+	});
+
+	afterEach(() => {
+		registry.destroy();
+		umbLocalizationManager.localizations.clear();
+	});
+
+	it('corrects a language whose default region does not match the dictionary we ship', async () => {
+		registry.loadLanguage('en');
+		await aTimeout(0);
+
+		expect(umbLocalizationManager.documentLanguage).to.equal('en-gb');
+	});
+
+	it('still resolves terms from the dictionary registered under the requested culture', async () => {
+		registry.loadLanguage('en');
+		await aTimeout(0);
+
+		expect(registry.localizations.get('en')).to.have.property('general_color', 'Colour');
+	});
+
+	it('keeps a region requested by the consumer', async () => {
+		registry.loadLanguage('en-US');
+		await aTimeout(0);
+
+		expect(umbLocalizationManager.documentLanguage).to.equal('en-us');
+	});
+
+	it('keeps a requested region that has no dictionary of its own', async () => {
+		registry.loadLanguage('en-AU');
+		await aTimeout(0);
+
+		expect(umbLocalizationManager.documentLanguage).to.equal('en-au');
+	});
+
+	it('leaves a language with no correction on the requested locale', async () => {
+		registry.loadLanguage('da');
+		await aTimeout(0);
+
+		expect(umbLocalizationManager.documentLanguage).to.equal('da');
+	});
+
+	it('re-applies the correction when the requested locale changes within the same dictionary', async () => {
+		registry.loadLanguage('en-GB');
+		await aTimeout(0);
+		expect(umbLocalizationManager.documentLanguage).to.equal('en-gb');
+
+		registry.loadLanguage('en');
+		await aTimeout(0);
+
+		expect(umbLocalizationManager.documentLanguage).to.equal('en-gb');
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
@@ -344,7 +344,7 @@ describe('UmbLocalizationRegistry formatting locale', () => {
 		expect(umbLocalizationManager.documentLanguage).to.equal('da');
 	});
 
-	it('re-applies the correction when the requested locale changes within the same dictionary', async () => {
+	it('corrects a bare en when switching from an explicitly requested region', async () => {
 		registry.loadLanguage('en-GB');
 		await aTimeout(0);
 		expect(umbLocalizationManager.documentLanguage).to.equal('en-gb');

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -64,6 +64,26 @@ function baseLocaleOf(locale: string): string {
 	return new Intl.Locale(locale).baseName.toLowerCase();
 }
 
+/**
+ * Locale-sensitive formatting is delegated to `Intl`, which resolves a language-only tag to the
+ * conventions of that language's default region. Where the dictionary we ship under that tag is
+ * written for a different region, the default is wrong for our users and is corrected here.
+ * Keyed on the full base name, so an explicitly requested region is never overridden.
+ */
+const FORMATTING_LOCALE_OVERRIDES: Record<string, string> = {
+	// The `en` dictionary is UK English, but `Intl` resolves a bare `en` to US conventions.
+	en: 'en-gb',
+};
+
+/**
+ * Returns the locale to use for locale-sensitive formatting of the given base name.
+ * @param {string} baseName - the lowercase base name of the requested locale.
+ * @returns {string} the formatting locale, which is the base name itself unless overridden.
+ */
+function toFormattingLocale(baseName: string): string {
+	return FORMATTING_LOCALE_OVERRIDES[baseName] ?? baseName;
+}
+
 export class UmbLocalizationRegistry {
 	// The active language is driven by the consuming host element (<umb-app>, <umb-auth>) via
 	// `loadLanguage()` — Razor sets `lang="@DefaultUILanguage"` on those, the element passes
@@ -97,7 +117,7 @@ export class UmbLocalizationRegistry {
 				// language on its first render. Direction and the actual consumer notification
 				// happen below, once the dictionaries are in place.
 				tap((currentLanguage) => {
-					umbLocalizationManager.documentLanguage = baseLocaleOf(currentLanguage);
+					umbLocalizationManager.documentLanguage = toFormattingLocale(baseLocaleOf(currentLanguage));
 				}),
 				// Switch to the extensions registry to get the current language and the extensions for that language
 				// Note: This also cancels the previous subscription if the language changes
@@ -207,7 +227,7 @@ export class UmbLocalizationRegistry {
 		// controller to re-render against the freshly loaded dictionaries. Inlined here because
 		// it's the only place this happens — no need for another public method on the manager
 		// that we'd just have to retire when the manager and registry get merged.
-		umbLocalizationManager.documentLanguage = newLang;
+		umbLocalizationManager.documentLanguage = toFormattingLocale(newLang);
 		umbLocalizationManager.documentDirection = direction;
 		umbLocalizationManager.connectedControllers.forEach((ctrl) => ctrl.documentUpdate());
 	}


### PR DESCRIPTION
## Description

A backoffice user whose UI language is **English (UK)** saw US-formatted dates everywhere the localization API formats one — collection date columns, audit trails, `umb-localize-date`.

The English pack registers under the bare culture `en`, and that value is what reaches `umbLocalizationManager.documentLanguage` and then `Intl`. CLDR resolves a bare `en` to en-US conventions.

The fix is a small lookup table in the localization registry, applied at the two places that set `documentLanguage`:

```ts
const FORMATTING_LOCALE_OVERRIDES: Record<string, string> = {
	// The `en` dictionary is UK English, but `Intl` resolves a bare `en` to US conventions.
	en: 'en-gb',
};
```

It is keyed on the full base name, so an explicitly requested region is never overridden — a user on `en-AU` or `en-US` keeps their own conventions.

I've implemented this as a targeted English fix rather than a general mechanism, as I found some complications when looking to do this.  And the issue seems only to be with this one language as we've used it as the default.  For every other language, including future ones, we just register the pack under the culture whose conventions we actually want.

Fixes #23809.

## Testing

1. Set your user's backoffice UI language to **English (UK)**.
2. Open a collection view with a "Last edited" column, or any audit trail — dates should read `01/09/2026`, times 24-hour.
3. Switch to **English (US)** and confirm dates read `9/1/2026`.

<img width="1024" height="559" alt="image" src="https://github.com/user-attachments/assets/6892ad55-49eb-47af-a6ae-ff58858dc2d1" />

