### PR TITLE
Backoffice: keep a long block headline within the workspace editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-editor.element.ts
@@ -56,6 +56,9 @@ export class UmbBlockWorkspaceEditorElement extends UmbLitElement {
 				gap: var(--uui-size-3);
 				min-width: 0;
 			}
+			uui-tag {
+				flex-shrink: 0;
+			}
 			#headline {
 				display: block;
 				white-space: nowrap;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-editor.element.ts
@@ -54,6 +54,7 @@ export class UmbBlockWorkspaceEditorElement extends UmbLitElement {
 				display: flex;
 				align-items: center;
 				gap: var(--uui-size-3);
+				min-width: 0;
 			}
 			#headline {
 				display: block;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-editor.element.ts
@@ -1,5 +1,5 @@
 import { UMB_BLOCK_WORKSPACE_CONTEXT } from './index.js';
-import { css, customElement, html, nothing, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-block-workspace-editor')
@@ -33,14 +33,17 @@ export class UmbBlockWorkspaceEditorElement extends UmbLitElement {
 	private _readOnly?: boolean;
 
 	override render() {
-		return html`<umb-workspace-editor
-			><div slot="header">
-				<h3 id="headline" title="${this._headline}" data-mark="layout-headline">${this._headline}</h3>
-				${this._readOnly
-					? html`<uui-tag look="secondary">${this.localize.term('general_readOnly')}</uui-tag>`
-					: nothing}
-			</div></umb-workspace-editor
-		>`;
+		return html`
+			<umb-workspace-editor>
+				<div slot="header">
+					<h3 id="headline" title=${this._headline} data-mark="layout-headline">${this._headline}</h3>
+					${when(
+						this._readOnly,
+						() => html`<uui-tag look="secondary">${this.localize.term('general_readOnly')}</uui-tag>`,
+					)}
+				</div>
+			</umb-workspace-editor>
+		`;
 	}
 
 	static override readonly styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/body-layout/body-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/body-layout/body-layout.element.ts
@@ -182,6 +182,7 @@ export class UmbBodyLayoutElement extends LitElement {
 			#header-slot {
 				padding: 0 var(--uui-size-layout-1);
 				flex-grow: 1;
+				flex-basis: 0;
 			}
 			:host([header-no-padding]) #header-slot {
 				padding: 0;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

#23835 

Added CSS to strip long block titles overlapping with Tab titles

**Before**

<img width="817" height="419" alt="image" src="https://github.com/user-attachments/assets/3c4ff503-c936-4402-8f45-3d8150e2fbb8" />

**After**

<img width="812" height="482" alt="image" src="https://github.com/user-attachments/assets/5da40f24-4795-4122-87c0-e88f3207a14c" />


<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
