### PR TITLE
Document Blueprints: Move from the Settings section to the Library section

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/ByKeyDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/ByKeyDocumentBlueprintController.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
 /// Controller for managing document blueprints identified by their unique key.
 /// </summary>
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentsOrDocumentBlueprints)]
 public class ByKeyDocumentBlueprintController : DocumentBlueprintControllerBase
 {
     private readonly IContentBlueprintEditingService _contentBlueprintEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/CreateDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/CreateDocumentBlueprintController.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
 /// API controller responsible for handling requests to create document blueprints in the Umbraco CMS.
 /// </summary>
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentBlueprints)]
 public class CreateDocumentBlueprintController : DocumentBlueprintControllerBase
 {
     private readonly IDocumentBlueprintEditingPresentationFactory _blueprintEditingPresentationFactory;
@@ -57,7 +57,6 @@ public class CreateDocumentBlueprintController : DocumentBlueprintControllerBase
     {
         ContentBlueprintCreateModel model = _blueprintEditingPresentationFactory.MapCreateModel(requestModel);
 
-        // We don't need to validate user access because we "only" require access to the Settings section to create new blueprints from scratch
         Attempt<ContentCreateResult, ContentEditingOperationStatus> result = await _contentBlueprintEditingService.CreateAsync(model, CurrentUserKey(_backOfficeSecurityAccessor));
 
         return result.Success

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/DeleteDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/DeleteDocumentBlueprintController.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
 /// API controller responsible for handling requests to delete document blueprints in the Umbraco CMS.
 /// </summary>
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentBlueprints)]
 public class DeleteDocumentBlueprintController : DocumentBlueprintControllerBase
 {
     private readonly IContentBlueprintEditingService _contentBlueprintEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Folder/DocumentBlueprintFolderControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Folder/DocumentBlueprintFolderControllerBase.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Folder;
 /// </summary>
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.DocumentBlueprint}/folder")]
 [ApiExplorerSettings(GroupName = "Document Blueprint")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentBlueprints)]
 public abstract class DocumentBlueprintFolderControllerBase : FolderManagementControllerBase<IContent>
 {
     protected DocumentBlueprintFolderControllerBase(

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/GetAuditLogDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/GetAuditLogDocumentBlueprintController.cs
@@ -13,7 +13,7 @@ using Umbraco.Cms.Web.Common.Authorization;
 namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
 
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentBlueprints)]
 public class GetAuditLogDocumentBlueprintController : DocumentBlueprintControllerBase
 {
     private readonly IAuditService _auditService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/MoveDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/MoveDocumentBlueprintController.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
 /// Controller for handling move operations on document blueprints.
 /// </summary>
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentBlueprints)]
 public class MoveDocumentBlueprintController : DocumentBlueprintControllerBase
 {
     private readonly IContentBlueprintEditingService _contentBlueprintEditingService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/DocumentBlueprintTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/DocumentBlueprintTreeControllerBase.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;
 /// </summary>
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Tree}/{Constants.UdiEntityType.DocumentBlueprint}")]
 [ApiExplorerSettings(GroupName = "Document Blueprint")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentBlueprints)]
 public class DocumentBlueprintTreeControllerBase : FolderTreeControllerBase<DocumentBlueprintTreeItemResponseModel>
 {
     private readonly IDocumentPresentationFactory _documentPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/SiblingsDocumentBlueprintTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Tree/SiblingsDocumentBlueprintTreeController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
@@ -11,6 +12,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;
 /// <summary>
 /// Controller responsible for managing the document blueprint tree for sibling nodes.
 /// </summary>
+[ApiVersion("1.0")]
 public class SiblingsDocumentBlueprintTreeController : DocumentBlueprintTreeControllerBase
 {
     /// <summary>
@@ -34,6 +36,7 @@ public class SiblingsDocumentBlueprintTreeController : DocumentBlueprintTreeCont
     /// <param name="foldersOnly">If true, only folder items are included in the results.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains an <see cref="ActionResult{T}"/> with a <see cref="SubsetViewModel{T}"/> of <see cref="DocumentBlueprintTreeItemResponseModel"/> representing the sibling items.</returns>
     [HttpGet("siblings")]
+    [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(SubsetViewModel<DocumentBlueprintTreeItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Gets a collection of document blueprint tree sibling items.")]
     [EndpointDescription("Gets a collection of document blueprint tree items that are siblings of the provided Id.")]

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/UpdateDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/UpdateDocumentBlueprintController.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
 /// Controller for updating document blueprints.
 /// </summary>
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentBlueprints)]
 public class UpdateDocumentBlueprintController : DocumentBlueprintControllerBase
 {
     private readonly IDocumentBlueprintEditingPresentationFactory _blueprintEditingPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthPolicyBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthPolicyBuilderExtensions.cs
@@ -105,8 +105,10 @@ internal static class BackOfficeAuthPolicyBuilderExtensions
         AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDictionary, Constants.Applications.Translation);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDictionaryOrTemplates, Constants.Applications.Translation, Constants.Applications.Settings);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocuments, Constants.Applications.Content);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocumentBlueprints, Constants.Applications.Library);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessElements, Constants.Applications.Library);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes, Constants.Applications.Content, Constants.Applications.Settings);
+        AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocumentsOrDocumentBlueprints, Constants.Applications.Content, Constants.Applications.Library);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocumentsOrElementsOrDocumentTypes, Constants.Applications.Content, Constants.Applications.Library, Constants.Applications.Settings);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocumentOrMediaOrContentTypes, Constants.Applications.Content, Constants.Applications.Settings, Constants.Applications.Media);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.TreeAccessDocumentsOrMediaOrMembersOrContentTypes, Constants.Applications.Content, Constants.Applications.Media, Constants.Applications.Members, Constants.Applications.Settings);

--- a/src/Umbraco.Cms.Api.Management/ServerEvents/Authorizers/DocumentBlueprintEventAuthorizer.cs
+++ b/src/Umbraco.Cms.Api.Management/ServerEvents/Authorizers/DocumentBlueprintEventAuthorizer.cs
@@ -25,5 +25,5 @@ public class DocumentBlueprintEventAuthorizer : EventSourcePolicyAuthorizer
     /// </summary>
     public override IEnumerable<string> AuthorizableEventSources => [Constants.ServerEvents.EventSource.DocumentBlueprint];
 
-    protected override string Policy => AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes;
+    protected override string Policy => AuthorizationPolicies.TreeAccessDocumentsOrDocumentBlueprints;
 }

--- a/src/Umbraco.Web.Common/Authorization/AuthorizationPolicies.cs
+++ b/src/Umbraco.Web.Common/Authorization/AuthorizationPolicies.cs
@@ -40,6 +40,10 @@ public static class AuthorizationPolicies
 
     // Single tree access
     public const string TreeAccessDocuments = nameof(TreeAccessDocuments);
+
+    /// <summary>
+    ///     Requires access to document blueprints.
+    /// </summary>
     public const string TreeAccessDocumentBlueprints = nameof(TreeAccessDocumentBlueprints);
     public const string TreeAccessElements = nameof(TreeAccessElements);
     public const string TreeAccessPartialViews = nameof(TreeAccessPartialViews);
@@ -58,6 +62,10 @@ public static class AuthorizationPolicies
 
     // Custom access based on multiple trees
     public const string TreeAccessDocumentsOrDocumentTypes = nameof(TreeAccessDocumentsOrDocumentTypes);
+
+    /// <summary>
+    ///     Requires access to either documents or document blueprints.
+    /// </summary>
     public const string TreeAccessDocumentsOrDocumentBlueprints = nameof(TreeAccessDocumentsOrDocumentBlueprints);
     public const string TreeAccessDocumentsOrElementsOrDocumentTypes = nameof(TreeAccessDocumentsOrElementsOrDocumentTypes);
     public const string TreeAccessMediaOrMediaTypes = nameof(TreeAccessMediaOrMediaTypes);

--- a/src/Umbraco.Web.Common/Authorization/AuthorizationPolicies.cs
+++ b/src/Umbraco.Web.Common/Authorization/AuthorizationPolicies.cs
@@ -40,6 +40,7 @@ public static class AuthorizationPolicies
 
     // Single tree access
     public const string TreeAccessDocuments = nameof(TreeAccessDocuments);
+    public const string TreeAccessDocumentBlueprints = nameof(TreeAccessDocumentBlueprints);
     public const string TreeAccessElements = nameof(TreeAccessElements);
     public const string TreeAccessPartialViews = nameof(TreeAccessPartialViews);
     public const string TreeAccessDataTypes = nameof(TreeAccessDataTypes);
@@ -57,6 +58,7 @@ public static class AuthorizationPolicies
 
     // Custom access based on multiple trees
     public const string TreeAccessDocumentsOrDocumentTypes = nameof(TreeAccessDocumentsOrDocumentTypes);
+    public const string TreeAccessDocumentsOrDocumentBlueprints = nameof(TreeAccessDocumentsOrDocumentBlueprints);
     public const string TreeAccessDocumentsOrElementsOrDocumentTypes = nameof(TreeAccessDocumentsOrElementsOrDocumentTypes);
     public const string TreeAccessMediaOrMediaTypes = nameof(TreeAccessMediaOrMediaTypes);
     public const string TreeAccessDictionaryOrTemplates = nameof(TreeAccessDictionaryOrTemplates);

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2982,10 +2982,10 @@ export default {
 			'Document Blueprints are pre-defined content that can be selected when creating a new content node.',
 		createHeadline: 'How do I create a Document Blueprint?',
 		createDescription:
-			'<p>There are two ways to create a Document Blueprint:</p><ul><li>Right-click a content node and select "Create Document Blueprint" to create a new Document Blueprint.</li><li>Right-click the Document Blueprints tree in the Settings section and select the Document Type you want to create a Document Blueprint for.</li></ul><p>Once given a name, editors can start using the Document Blueprint as a foundation for their new page.</p>',
+			'<p>There are two ways to create a Document Blueprint:</p><ul><li>Right-click a content node and select "Create Document Blueprint" to create a new Document Blueprint.</li><li>Right-click the Document Blueprints tree in the Library section and select the Document Type you want to create a Document Blueprint for.</li></ul><p>Once given a name, editors can start using the Document Blueprint as a foundation for their new page.</p>',
 		manageHeadline: 'How do I manage Document Blueprints?',
 		manageDescription:
-			'You can edit and delete Document Blueprints from the "Document Blueprints" tree in the Settings section. Expand the Document Type which the Document Blueprint is based on and click it to edit or delete it.',
+			'You can edit and delete Document Blueprints from the "Document Blueprints" tree in the Library section. Expand the Document Type which the Document Blueprint is based on and click it to edit or delete it.',
 	},
 	preview: {
 		endLabel: 'Exit',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
@@ -24,7 +24,7 @@ export class UmbSectionSidebarMenuWithEntityActionsElement extends UmbSectionSid
 	override renderHeader() {
 		const label = this.localize.string(this.manifest?.meta?.label ?? '');
 		return html`
-			<div id="header">
+			<div id="header" data-mark="section-sidebar-app:${this.manifest?.alias}">
 				<h3>${label}</h3>
 				<umb-entity-actions-bundle slot="actions" .label=${label}></umb-entity-actions-bundle>
 			</div>

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/menu/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/menu/constants.ts
@@ -1,1 +1,2 @@
+export const UMB_DOCUMENT_BLUEPRINT_MENU_ALIAS = 'Umb.Menu.DocumentBlueprint';
 export const UMB_DOCUMENT_BLUEPRINT_MENU_ITEM_ALIAS = 'Umb.MenuItem.DocumentBlueprints';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/menu/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/menu/manifests.ts
@@ -1,17 +1,48 @@
 import { UMB_DOCUMENT_BLUEPRINT_TREE_ALIAS } from '../tree/constants.js';
-import { UMB_DOCUMENT_BLUEPRINT_MENU_ITEM_ALIAS } from './constants.js';
+import { UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE } from '../entity.js';
+import { UMB_DOCUMENT_BLUEPRINT_MENU_ALIAS, UMB_DOCUMENT_BLUEPRINT_MENU_ITEM_ALIAS } from './constants.js';
+import { UMB_LIBRARY_SECTION_ALIAS } from '@umbraco-cms/backoffice/library';
+import { UMB_SECTION_ALIAS_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import type { ManifestMenu, ManifestSectionSidebarAppMenuWithEntityActionsKind } from '@umbraco-cms/backoffice/menu';
+import type { ManifestMenuItemTreeKind } from '@umbraco-cms/backoffice/tree';
 
-export const manifests: Array<UmbExtensionManifest> = [
-	{
-		type: 'menuItem',
-		kind: 'tree',
-		alias: UMB_DOCUMENT_BLUEPRINT_MENU_ITEM_ALIAS,
-		name: 'Document Blueprints Menu Item',
-		weight: 100,
-		meta: {
-			treeAlias: UMB_DOCUMENT_BLUEPRINT_TREE_ALIAS,
-			label: '#treeHeaders_contentBlueprints',
-			menus: ['Umb.Menu.StructureSettings'],
-		},
+const menu: ManifestMenu = {
+	type: 'menu',
+	alias: UMB_DOCUMENT_BLUEPRINT_MENU_ALIAS,
+	name: 'Document Blueprint Menu',
+};
+
+const menuItem: ManifestMenuItemTreeKind = {
+	type: 'menuItem',
+	kind: 'tree',
+	alias: UMB_DOCUMENT_BLUEPRINT_MENU_ITEM_ALIAS,
+	name: 'Document Blueprints Menu Item',
+	weight: 100,
+	meta: {
+		treeAlias: UMB_DOCUMENT_BLUEPRINT_TREE_ALIAS,
+		label: '#treeHeaders_contentBlueprints',
+		menus: [UMB_DOCUMENT_BLUEPRINT_MENU_ALIAS],
+		hideTreeRoot: true,
 	},
-];
+};
+
+const sectionSidebarApp: ManifestSectionSidebarAppMenuWithEntityActionsKind = {
+	type: 'sectionSidebarApp',
+	kind: 'menuWithEntityActions',
+	alias: 'Umb.SidebarMenu.DocumentBlueprint',
+	name: 'Document Blueprint Sidebar Menu',
+	weight: 90,
+	meta: {
+		label: '#treeHeaders_contentBlueprints',
+		menu: UMB_DOCUMENT_BLUEPRINT_MENU_ALIAS,
+		entityType: UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE,
+	},
+	conditions: [
+		{
+			alias: UMB_SECTION_ALIAS_CONDITION_ALIAS,
+			match: UMB_LIBRARY_SECTION_ALIAS,
+		},
+	],
+};
+
+export const manifests: Array<UmbExtensionManifest> = [menu, menuItem, sectionSidebarApp];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/paths.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/paths.ts
@@ -1,11 +1,11 @@
 import { UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE, type UmbDocumentBlueprintEntityTypeUnion } from './entity.js';
-import { UMB_SETTINGS_SECTION_PATHNAME } from '@umbraco-cms/backoffice/settings';
+import { UMB_LIBRARY_SECTION_PATHNAME } from '@umbraco-cms/backoffice/library';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
 import { UmbPathPattern } from '@umbraco-cms/backoffice/router';
 import { UMB_WORKSPACE_PATH_PATTERN } from '@umbraco-cms/backoffice/workspace';
 
 export const UMB_DOCUMENT_BLUEPRINT_WORKSPACE_PATH = UMB_WORKSPACE_PATH_PATTERN.generateAbsolute({
-	sectionName: UMB_SETTINGS_SECTION_PATHNAME,
+	sectionName: UMB_LIBRARY_SECTION_PATHNAME,
 	entityType: UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE,
 });
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/workspace/paths.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/workspace/paths.ts
@@ -1,10 +1,10 @@
 import { UMB_DOCUMENT_BLUEPRINT_FOLDER_ENTITY_TYPE } from '../../../entity.js';
-import { UMB_SETTINGS_SECTION_PATHNAME } from '@umbraco-cms/backoffice/settings';
+import { UMB_LIBRARY_SECTION_PATHNAME } from '@umbraco-cms/backoffice/library';
 import { UmbPathPattern } from '@umbraco-cms/backoffice/router';
 import { UMB_WORKSPACE_PATH_PATTERN } from '@umbraco-cms/backoffice/workspace';
 
 export const UMB_DOCUMENT_BLUEPRINT_FOLDER_WORKSPACE_PATH = UMB_WORKSPACE_PATH_PATTERN.generateAbsolute({
-	sectionName: UMB_SETTINGS_SECTION_PATHNAME,
+	sectionName: UMB_LIBRARY_SECTION_PATHNAME,
 	entityType: UMB_DOCUMENT_BLUEPRINT_FOLDER_ENTITY_TYPE,
 });
 

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentBlueprintUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentBlueprintUiHelper.ts
@@ -6,10 +6,12 @@ export class DocumentBlueprintUiHelper extends UiBaseLocators{
   private readonly documentBlueprintTree: Locator;
   private readonly documentBlueprintNameTxt: Locator;
   private readonly deleteMenu: Locator;
+  private readonly documentBlueprintSidebarHeader: Locator;
 
   constructor(page: Page) {
     super(page);
     this.documentBlueprintTree = page.locator('umb-tree[alias="Umb.Tree.DocumentBlueprint"]');
+    this.documentBlueprintSidebarHeader = page.locator('[data-mark="section-sidebar-app:Umb.SidebarMenu.DocumentBlueprint"]');
     this.documentBlueprintNameTxt = page.locator('#name-input #input');
     this.deleteMenu = page.locator('umb-section-sidebar #menu-item').getByLabel('Delete');
   }
@@ -19,7 +21,7 @@ export class DocumentBlueprintUiHelper extends UiBaseLocators{
   }
 
   async clickActionsMenuAtRoot() {
-    await this.clickActionsMenuForDocumentBlueprints('Document Blueprints');
+    await this.click(this.documentBlueprintSidebarHeader.getByTestId('open-dropdown'), {force: true});
   }
 
   async clickRootFolderCaretButton() {
@@ -35,11 +37,12 @@ export class DocumentBlueprintUiHelper extends UiBaseLocators{
   }
 
   async reloadDocumentBlueprintsTree() {
-    await this.reloadTree('Document Blueprints');
+    await this.clickActionsMenuAtRoot();
+    await this.clickReloadChildrenActionMenuOption();
   }
 
   async goToDocumentBlueprint(blueprintName: string) {
-    await this.goToSection(ConstantHelper.sections.settings);
+    await this.goToSection(ConstantHelper.sections.library);
     await this.reloadDocumentBlueprintsTree();
     await this.clickTreeItemWithName(blueprintName);
   }

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentBlueprintUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentBlueprintUiHelper.ts
@@ -24,10 +24,6 @@ export class DocumentBlueprintUiHelper extends UiBaseLocators{
     await this.click(this.documentBlueprintSidebarHeader.getByTestId('open-dropdown'), {force: true});
   }
 
-  async clickRootFolderCaretButton() {
-    await this.openCaretButtonForName('Document Blueprints');
-  }
-
   async clickSaveButtonAndWaitForDocumentBlueprintToBeCreated() {
     return await this.waitForResponseAfterExecutingPromise(ConstantHelper.apiEndpoints.documentBlueprint, this.clickSaveButton(), ConstantHelper.statusCodes.created);
   }

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/LibraryUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/LibraryUiHelper.ts
@@ -203,7 +203,7 @@ export class LibraryUiHelper extends UiBaseLocators {
     this.elementNameTxt = page.locator('#name-input input');
     this.publishBtn = page.getByLabel(/^Publish(…)?$/);
     this.unpublishBtn = page.getByLabel(/^Unpublish(…)?$/);
-    this.actionMenuForElementBtn = page.locator('#header').getByTestId('open-dropdown');
+    this.actionMenuForElementBtn = page.locator('[data-mark="section-sidebar-app:Umb.SidebarMenu.Element"]').getByTestId('open-dropdown');
     this.textstringTxt = page.locator('umb-property-editor-ui-text-box #input');
     this.reloadChildrenThreeDotsBtn = page.getByRole('button', {name: 'Reload children…'});
     this.elementTree = page.locator('umb-tree[alias="Umb.Tree.Element"]');
@@ -288,7 +288,7 @@ export class LibraryUiHelper extends UiBaseLocators {
     this.duplicateToBtn = page.getByRole('button', {name: 'Duplicate to'});
     this.moveToBtn = page.getByRole('button', {name: 'Move to'});
     this.duplicateBtn = page.getByLabel('Duplicate', {exact: true});
-    this.elementTreeRefreshBtn = page.locator('#header').getByLabel('#actions_refreshNode');
+    this.elementTreeRefreshBtn = page.locator('[data-mark="section-sidebar-app:Umb.SidebarMenu.Element"]').getByLabel('#actions_refreshNode');
     this.sortChildrenBtn = page.getByRole('button', {name: 'Sort children'});
     this.rollbackBtn = page.getByTestId('audit-log-action:Umb.AuditLogAction.Element.Rollback');
     this.rollbackContainerBtn = this.container.getByLabel('Rollback');

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
@@ -1095,11 +1095,6 @@ export class UiBaseLocators extends BasePage {
     await this.clickTreeItemWithName(settingsTreeItemName);
   }
 
-  async goToLibraryTreeItem(libraryTreeItemName: string) {
-    await this.goToSection(ConstantHelper.sections.library);
-    await this.clickTreeItemWithName(libraryTreeItemName);
-  }
-
   async goToWorkspacePath(path: string) {
     await this.page.goto(`${this.page.url()}${path}`);
   }

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
@@ -1095,6 +1095,11 @@ export class UiBaseLocators extends BasePage {
     await this.clickTreeItemWithName(settingsTreeItemName);
   }
 
+  async goToLibraryTreeItem(libraryTreeItemName: string) {
+    await this.goToSection(ConstantHelper.sections.library);
+    await this.clickTreeItemWithName(libraryTreeItemName);
+  }
+
   async goToWorkspacePath(path: string) {
     await this.page.goto(`${this.page.url()}${path}`);
   }

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/DocumentBlueprint/DocumentBlueprint.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/DocumentBlueprint/DocumentBlueprint.spec.ts
@@ -14,11 +14,11 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
 });
 
-test('can create a document blueprint from the settings menu', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can create a document blueprint from the library menu', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoApi.documentType.createDefaultDocumentType(documentTypeName);
   await umbracoUi.goToBackOffice();
-  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.settings);
+  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.library);
 
   // Act
   await umbracoUi.documentBlueprint.clickActionsMenuAtRoot();
@@ -42,7 +42,7 @@ test('can rename a document blueprint', async ({umbracoApi, umbracoUi}) => {
   await umbracoApi.documentBlueprint.createDefaultDocumentBlueprint(wrongDocumentBlueprintName, documentTypeId);
   expect(await umbracoApi.documentBlueprint.doesNameExist(wrongDocumentBlueprintName)).toBeTruthy();
   await umbracoUi.goToBackOffice();
-  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.settings);
+  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.library);
 
   // Act
   await umbracoUi.documentBlueprint.goToDocumentBlueprint(wrongDocumentBlueprintName);
@@ -62,7 +62,7 @@ test('can delete a document blueprint', async ({umbracoApi, umbracoUi}) => {
   await umbracoApi.documentBlueprint.createDefaultDocumentBlueprint(documentBlueprintName, documentTypeId);
   expect(await umbracoApi.documentBlueprint.doesNameExist(documentBlueprintName)).toBeTruthy();
   await umbracoUi.goToBackOffice();
-  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.settings);
+  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.library);
 
   // Act
   await umbracoUi.documentBlueprint.reloadDocumentBlueprintsTree();
@@ -89,7 +89,7 @@ test('can create a document blueprint from the content menu', {tag: '@release'},
 
   // Assert
   expect(await umbracoApi.documentBlueprint.doesNameExist(documentBlueprintName)).toBeTruthy();
-  await umbracoUi.documentBlueprint.goToSettingsTreeItem('Document Blueprints');
+  await umbracoUi.documentBlueprint.goToLibraryTreeItem('Document Blueprints');
   await umbracoUi.documentBlueprint.isDocumentBlueprintRootTreeItemVisible(documentBlueprintName, true);
 
   // Clean
@@ -101,7 +101,7 @@ test('can create a variant document blueprint', {tag: '@release'}, async ({umbra
   await umbracoApi.language.createDanishLanguage();
   await umbracoApi.documentType.createDocumentTypeWithAllowVaryByCulture(documentTypeName);
   await umbracoUi.goToBackOffice();
-  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.settings);
+  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.library);
 
   // Act
   await umbracoUi.documentBlueprint.clickActionsMenuAtRoot();

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/DocumentBlueprint/DocumentBlueprint.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/DocumentBlueprint/DocumentBlueprint.spec.ts
@@ -89,7 +89,7 @@ test('can create a document blueprint from the content menu', {tag: '@release'},
 
   // Assert
   expect(await umbracoApi.documentBlueprint.doesNameExist(documentBlueprintName)).toBeTruthy();
-  await umbracoUi.documentBlueprint.goToLibraryTreeItem('Document Blueprints');
+  await umbracoUi.documentBlueprint.goToSection(ConstantHelper.sections.library);
   await umbracoUi.documentBlueprint.isDocumentBlueprintRootTreeItemVisible(documentBlueprintName, true);
 
   // Clean

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/ByKeyDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/ByKeyDocumentBlueprintControllerTests.cs
@@ -20,7 +20,7 @@ public class ByKeyDocumentBlueprintControllerTests : ManagementApiUserGroupTestB
     private Guid _documentBlueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/ByKeyDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/ByKeyDocumentBlueprintControllerTests.cs
@@ -1,0 +1,63 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint;
+
+public class ByKeyDocumentBlueprintControllerTests : ManagementApiUserGroupTestBase<ByKeyDocumentBlueprintController>
+{
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _documentBlueprintKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var result = await ContentBlueprintEditingService.CreateAsync(
+            new ContentBlueprintCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create the blueprint: {result.Status}");
+        _documentBlueprintKey = result.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<ByKeyDocumentBlueprintController, object>> MethodSelector =>
+        x => x.ByKey(CancellationToken.None, _documentBlueprintKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/CreateDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/CreateDocumentBlueprintControllerTests.cs
@@ -20,7 +20,7 @@ public class CreateDocumentBlueprintControllerTests : ManagementApiUserGroupTest
     private Guid _contentTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/CreateDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/CreateDocumentBlueprintControllerTests.cs
@@ -1,0 +1,67 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
+using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentBlueprint;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint;
+
+public class CreateDocumentBlueprintControllerTests : ManagementApiUserGroupTestBase<CreateDocumentBlueprintController>
+{
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _contentTypeKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        _contentTypeKey = contentType.Key;
+    }
+
+    protected override Expression<Func<CreateDocumentBlueprintController, object>> MethodSelector =>
+        x => x.Create(CancellationToken.None, null!);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Created };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Created };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Created };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        var createModel = new CreateDocumentBlueprintRequestModel
+        {
+            DocumentType = new ReferenceByIdModel(_contentTypeKey),
+            Parent = null,
+            Id = Guid.NewGuid(),
+            Values = [],
+            Variants = [new DocumentVariantRequestModel { Culture = null, Segment = null, Name = $"Blueprint {Guid.NewGuid()}" }],
+        };
+
+        return await Client.PostAsync(Url, JsonContent.Create(createModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/CreateDocumentBlueprintFromDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/CreateDocumentBlueprintFromDocumentControllerTests.cs
@@ -23,7 +23,7 @@ public class CreateDocumentBlueprintFromDocumentControllerTests
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/CreateDocumentBlueprintFromDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/CreateDocumentBlueprintFromDocumentControllerTests.cs
@@ -1,0 +1,82 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
+using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentBlueprint;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint;
+
+public class CreateDocumentBlueprintFromDocumentControllerTests
+    : ManagementApiUserGroupTestBase<CreateDocumentBlueprintFromDocumentController>
+{
+    private IContentEditingService ContentEditingService => GetRequiredService<IContentEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _documentKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        contentType.AllowedAsRoot = true;
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var document = await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new VariantModel { Name = $"Document {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(document.Success, $"Failed to create the document: {document.Status}");
+        _documentKey = document.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<CreateDocumentBlueprintFromDocumentController, object>> MethodSelector =>
+        x => x.CreateFromDocument(CancellationToken.None, null!);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Created };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Created };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    // Unlike the other blueprint endpoints, this one also authorizes the source document against
+    // ActionCreateBlueprintFromContent, which writers are not granted.
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        var createModel = new CreateDocumentBlueprintFromDocumentRequestModel
+        {
+            Document = new ReferenceByIdModel(_documentKey),
+            Id = Guid.NewGuid(),
+            Name = $"Blueprint {Guid.NewGuid()}",
+            Parent = null,
+        };
+
+        return await Client.PostAsync(Url, JsonContent.Create(createModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/DeleteDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/DeleteDocumentBlueprintControllerTests.cs
@@ -20,7 +20,7 @@ public class DeleteDocumentBlueprintControllerTests : ManagementApiUserGroupTest
     private Guid _documentBlueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/DeleteDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/DeleteDocumentBlueprintControllerTests.cs
@@ -1,0 +1,65 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint;
+
+public class DeleteDocumentBlueprintControllerTests : ManagementApiUserGroupTestBase<DeleteDocumentBlueprintController>
+{
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _documentBlueprintKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        // A new blueprint for each test, since deleting removes it.
+        var createModel = new ContentBlueprintCreateModel
+        {
+            ContentTypeKey = contentType.Key,
+            ParentKey = Constants.System.RootKey,
+            Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+        };
+        var result = await ContentBlueprintEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create the blueprint: {result.Status}");
+        _documentBlueprintKey = result.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<DeleteDocumentBlueprintController, object>> MethodSelector =>
+        x => x.Delete(CancellationToken.None, _documentBlueprintKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+
+    protected override async Task<HttpResponseMessage> ClientRequest() => await Client.DeleteAsync(Url);
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/ByKeyDocumentBlueprintFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/ByKeyDocumentBlueprintFolderControllerTests.cs
@@ -16,7 +16,7 @@ public class ByKeyDocumentBlueprintFolderControllerTests
     private Guid _folderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var result = await ContentBlueprintContainerService.CreateAsync(
             null,

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/ByKeyDocumentBlueprintFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/ByKeyDocumentBlueprintFolderControllerTests.cs
@@ -1,0 +1,50 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Folder;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint.Folder;
+
+public class ByKeyDocumentBlueprintFolderControllerTests
+    : ManagementApiUserGroupTestBase<ByKeyDocumentBlueprintFolderController>
+{
+    private IContentBlueprintContainerService ContentBlueprintContainerService =>
+        GetRequiredService<IContentBlueprintContainerService>();
+
+    private Guid _folderKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var result = await ContentBlueprintContainerService.CreateAsync(
+            null,
+            $"Test Folder {Guid.NewGuid()}",
+            null,
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create the folder: {result.Status}");
+        _folderKey = result.Result!.Key;
+    }
+
+    protected override Expression<Func<ByKeyDocumentBlueprintFolderController, object>> MethodSelector =>
+        x => x.ByKey(CancellationToken.None, _folderKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/CreateDocumentBlueprintFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/CreateDocumentBlueprintFolderControllerTests.cs
@@ -1,0 +1,44 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Folder;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint.Folder;
+
+public class CreateDocumentBlueprintFolderControllerTests
+    : ManagementApiUserGroupTestBase<CreateDocumentBlueprintFolderController>
+{
+    protected override Expression<Func<CreateDocumentBlueprintFolderController, object>> MethodSelector =>
+        x => x.Create(CancellationToken.None, null!);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Created };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Created };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Created };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        var createModel = new CreateFolderRequestModel
+        {
+            Name = $"Test Folder {Guid.NewGuid()}",
+            Parent = null,
+            Id = Guid.NewGuid(),
+        };
+
+        return await Client.PostAsync(Url, JsonContent.Create(createModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/DeleteDocumentBlueprintFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/DeleteDocumentBlueprintFolderControllerTests.cs
@@ -16,7 +16,7 @@ public class DeleteDocumentBlueprintFolderControllerTests
     private Guid _folderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // A new folder for each test, since deleting removes it.
         var result = await ContentBlueprintContainerService.CreateAsync(

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/DeleteDocumentBlueprintFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/DeleteDocumentBlueprintFolderControllerTests.cs
@@ -1,0 +1,54 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Folder;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint.Folder;
+
+public class DeleteDocumentBlueprintFolderControllerTests
+    : ManagementApiUserGroupTestBase<DeleteDocumentBlueprintFolderController>
+{
+    private IContentBlueprintContainerService ContentBlueprintContainerService =>
+        GetRequiredService<IContentBlueprintContainerService>();
+
+    private Guid _folderKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        // A new folder for each test, since deleting removes it.
+        var result = await ContentBlueprintContainerService.CreateAsync(
+            null,
+            $"Test Folder {Guid.NewGuid()}",
+            null,
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create the folder: {result.Status}");
+        _folderKey = result.Result!.Key;
+    }
+
+    protected override Expression<Func<DeleteDocumentBlueprintFolderController, object>> MethodSelector =>
+        x => x.Delete(CancellationToken.None, _folderKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+        => await Client.DeleteAsync(Url);
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/UpdateDocumentBlueprintFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/UpdateDocumentBlueprintFolderControllerTests.cs
@@ -1,0 +1,59 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Folder;
+using Umbraco.Cms.Api.Management.ViewModels.Folder;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint.Folder;
+
+public class UpdateDocumentBlueprintFolderControllerTests
+    : ManagementApiUserGroupTestBase<UpdateDocumentBlueprintFolderController>
+{
+    private IContentBlueprintContainerService ContentBlueprintContainerService =>
+        GetRequiredService<IContentBlueprintContainerService>();
+
+    private Guid _folderKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var result = await ContentBlueprintContainerService.CreateAsync(
+            null,
+            $"Test Folder {Guid.NewGuid()}",
+            null,
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create the folder: {result.Status}");
+        _folderKey = result.Result!.Key;
+    }
+
+    protected override Expression<Func<UpdateDocumentBlueprintFolderController, object>> MethodSelector =>
+        x => x.Update(CancellationToken.None, _folderKey, null!);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        var updateModel = new UpdateFolderResponseModel { Name = $"Test Folder {Guid.NewGuid()}" };
+
+        return await Client.PutAsync(Url, JsonContent.Create(updateModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/UpdateDocumentBlueprintFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Folder/UpdateDocumentBlueprintFolderControllerTests.cs
@@ -18,7 +18,7 @@ public class UpdateDocumentBlueprintFolderControllerTests
     private Guid _folderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var result = await ContentBlueprintContainerService.CreateAsync(
             null,

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/GetAuditLogDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/GetAuditLogDocumentBlueprintControllerTests.cs
@@ -21,7 +21,7 @@ public class GetAuditLogDocumentBlueprintControllerTests
     private Guid _documentBlueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/GetAuditLogDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/GetAuditLogDocumentBlueprintControllerTests.cs
@@ -1,0 +1,64 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint;
+
+public class GetAuditLogDocumentBlueprintControllerTests
+    : ManagementApiUserGroupTestBase<GetAuditLogDocumentBlueprintController>
+{
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _documentBlueprintKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var result = await ContentBlueprintEditingService.CreateAsync(
+            new ContentBlueprintCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create the blueprint: {result.Status}");
+        _documentBlueprintKey = result.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<GetAuditLogDocumentBlueprintController, object>> MethodSelector =>
+        x => x.GetAuditLog(CancellationToken.None, _documentBlueprintKey, Direction.Descending, null, 0, 100);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/MoveDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/MoveDocumentBlueprintControllerTests.cs
@@ -28,7 +28,7 @@ public class MoveDocumentBlueprintControllerTests : ManagementApiUserGroupTestBa
     private Guid _targetFolderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/MoveDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/MoveDocumentBlueprintControllerTests.cs
@@ -1,0 +1,87 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
+using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentBlueprint;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint;
+
+public class MoveDocumentBlueprintControllerTests : ManagementApiUserGroupTestBase<MoveDocumentBlueprintController>
+{
+    private IContentBlueprintContainerService ContentBlueprintContainerService =>
+        GetRequiredService<IContentBlueprintContainerService>();
+
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _documentBlueprintKey;
+
+    private Guid _targetFolderKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var folder = await ContentBlueprintContainerService.CreateAsync(
+            null,
+            $"Test Folder {Guid.NewGuid()}",
+            null,
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(folder.Success, $"Failed to create the folder: {folder.Status}");
+        _targetFolderKey = folder.Result!.Key;
+
+        // A new blueprint for each test, since moving it changes where the next move starts from.
+        var blueprint = await ContentBlueprintEditingService.CreateAsync(
+            new ContentBlueprintCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(blueprint.Success, $"Failed to create the blueprint: {blueprint.Status}");
+        _documentBlueprintKey = blueprint.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<MoveDocumentBlueprintController, object>> MethodSelector =>
+        x => x.Move(CancellationToken.None, _documentBlueprintKey, null!);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        var moveModel = new MoveDocumentBlueprintRequestModel { Target = new ReferenceByIdModel(_targetFolderKey) };
+
+        return await Client.PutAsync(Url, JsonContent.Create(moveModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/ScaffoldDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/ScaffoldDocumentBlueprintControllerTests.cs
@@ -1,0 +1,63 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint;
+
+public class ScaffoldDocumentBlueprintControllerTests : ManagementApiUserGroupTestBase<ScaffoldDocumentBlueprintController>
+{
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _documentBlueprintKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var result = await ContentBlueprintEditingService.CreateAsync(
+            new ContentBlueprintCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create the blueprint: {result.Status}");
+        _documentBlueprintKey = result.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<ScaffoldDocumentBlueprintController, object>> MethodSelector =>
+        x => x.Scaffold(CancellationToken.None, _documentBlueprintKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/ScaffoldDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/ScaffoldDocumentBlueprintControllerTests.cs
@@ -20,7 +20,7 @@ public class ScaffoldDocumentBlueprintControllerTests : ManagementApiUserGroupTe
     private Guid _documentBlueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/AncestorsDocumentBlueprintTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/AncestorsDocumentBlueprintTreeControllerTests.cs
@@ -1,0 +1,76 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint.Tree;
+
+public class AncestorsDocumentBlueprintTreeControllerTests : ManagementApiUserGroupTestBase<AncestorsDocumentBlueprintTreeController>
+{
+    private IContentBlueprintContainerService ContentBlueprintContainerService =>
+        GetRequiredService<IContentBlueprintContainerService>();
+
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _folderKey;
+
+    private Guid _blueprintKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var folder = await ContentBlueprintContainerService.CreateAsync(
+            null,
+            $"Test Folder {Guid.NewGuid()}",
+            null,
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(folder.Success, $"Failed to create the folder: {folder.Status}");
+        _folderKey = folder.Result!.Key;
+
+        var blueprint = await ContentBlueprintEditingService.CreateAsync(
+            new ContentBlueprintCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = _folderKey,
+                Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(blueprint.Success, $"Failed to create the blueprint: {blueprint.Status}");
+        _blueprintKey = blueprint.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<AncestorsDocumentBlueprintTreeController, object>> MethodSelector =>
+        x => x.Ancestors(CancellationToken.None, _blueprintKey);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/AncestorsDocumentBlueprintTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/AncestorsDocumentBlueprintTreeControllerTests.cs
@@ -25,7 +25,7 @@ public class AncestorsDocumentBlueprintTreeControllerTests : ManagementApiUserGr
     private Guid _blueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/ChildrenDocumentBlueprintTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/ChildrenDocumentBlueprintTreeControllerTests.cs
@@ -25,7 +25,7 @@ public class ChildrenDocumentBlueprintTreeControllerTests : ManagementApiUserGro
     private Guid _blueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/ChildrenDocumentBlueprintTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/ChildrenDocumentBlueprintTreeControllerTests.cs
@@ -1,0 +1,76 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint.Tree;
+
+public class ChildrenDocumentBlueprintTreeControllerTests : ManagementApiUserGroupTestBase<ChildrenDocumentBlueprintTreeController>
+{
+    private IContentBlueprintContainerService ContentBlueprintContainerService =>
+        GetRequiredService<IContentBlueprintContainerService>();
+
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _folderKey;
+
+    private Guid _blueprintKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var folder = await ContentBlueprintContainerService.CreateAsync(
+            null,
+            $"Test Folder {Guid.NewGuid()}",
+            null,
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(folder.Success, $"Failed to create the folder: {folder.Status}");
+        _folderKey = folder.Result!.Key;
+
+        var blueprint = await ContentBlueprintEditingService.CreateAsync(
+            new ContentBlueprintCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = _folderKey,
+                Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(blueprint.Success, $"Failed to create the blueprint: {blueprint.Status}");
+        _blueprintKey = blueprint.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<ChildrenDocumentBlueprintTreeController, object>> MethodSelector =>
+        x => x.Children(CancellationToken.None, _folderKey, 0, 100, false);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/RootDocumentBlueprintTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/RootDocumentBlueprintTreeControllerTests.cs
@@ -17,7 +17,7 @@ public class RootDocumentBlueprintTreeControllerTests : ManagementApiUserGroupTe
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
@@ -32,7 +32,7 @@ public class RootDocumentBlueprintTreeControllerTests : ManagementApiUserGroupTe
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        ExpectedStatusCode = HttpStatusCode.Forbidden
+        ExpectedStatusCode = HttpStatusCode.OK
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/SiblingsDocumentBlueprintTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/SiblingsDocumentBlueprintTreeControllerTests.cs
@@ -25,7 +25,7 @@ public class SiblingsDocumentBlueprintTreeControllerTests : ManagementApiUserGro
     private Guid _blueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/SiblingsDocumentBlueprintTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Tree/SiblingsDocumentBlueprintTreeControllerTests.cs
@@ -1,0 +1,76 @@
+using System.Linq.Expressions;
+using System.Net;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint.Tree;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint.Tree;
+
+public class SiblingsDocumentBlueprintTreeControllerTests : ManagementApiUserGroupTestBase<SiblingsDocumentBlueprintTreeController>
+{
+    private IContentBlueprintContainerService ContentBlueprintContainerService =>
+        GetRequiredService<IContentBlueprintContainerService>();
+
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _folderKey;
+
+    private Guid _blueprintKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var folder = await ContentBlueprintContainerService.CreateAsync(
+            null,
+            $"Test Folder {Guid.NewGuid()}",
+            null,
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(folder.Success, $"Failed to create the folder: {folder.Status}");
+        _folderKey = folder.Result!.Key;
+
+        var blueprint = await ContentBlueprintEditingService.CreateAsync(
+            new ContentBlueprintCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = _folderKey,
+                Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(blueprint.Success, $"Failed to create the blueprint: {blueprint.Status}");
+        _blueprintKey = blueprint.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<SiblingsDocumentBlueprintTreeController, object>> MethodSelector =>
+        x => x.Siblings(CancellationToken.None, _blueprintKey, 10, 10, false);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/UpdateDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/UpdateDocumentBlueprintControllerTests.cs
@@ -1,0 +1,76 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DocumentBlueprint;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.DocumentBlueprint;
+
+public class UpdateDocumentBlueprintControllerTests : ManagementApiUserGroupTestBase<UpdateDocumentBlueprintController>
+{
+    private IContentBlueprintEditingService ContentBlueprintEditingService =>
+        GetRequiredService<IContentBlueprintEditingService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _documentBlueprintKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithName($"Test Document Type {Guid.NewGuid()}")
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var result = await ContentBlueprintEditingService.CreateAsync(
+            new ContentBlueprintCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new VariantModel { Name = $"Blueprint {Guid.NewGuid()}" }],
+            },
+            Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create the blueprint: {result.Status}");
+        _documentBlueprintKey = result.Result.Content!.Key;
+    }
+
+    protected override Expression<Func<UpdateDocumentBlueprintController, object>> MethodSelector =>
+        x => x.Update(CancellationToken.None, _documentBlueprintKey, null!);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Forbidden };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.OK };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel
+        => new() { ExpectedStatusCode = HttpStatusCode.Unauthorized };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        var updateModel = new UpdateDocumentBlueprintRequestModel
+        {
+            Values = [],
+            Variants = [new DocumentVariantRequestModel { Culture = null, Segment = null, Name = $"Blueprint {Guid.NewGuid()}" }],
+        };
+
+        return await Client.PutAsync(Url, JsonContent.Create(updateModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/UpdateDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/UpdateDocumentBlueprintControllerTests.cs
@@ -22,7 +22,7 @@ public class UpdateDocumentBlueprintControllerTests : ManagementApiUserGroupTest
     private Guid _documentBlueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias(Guid.NewGuid().ToString("N"))


### PR DESCRIPTION
Document Blueprints sat in Settings, which meant reaching them required access to a section
otherwise concerned with schema and configuration. They belong with the content-shaped things, so
they move to Library, alongside Elements.

The endpoints move with them: the blueprint tree and its management endpoints now authorize
against Library rather than Settings, through a `TreeAccessDocumentBlueprints` policy introduced
for the purpose.

Sidebar app headers gained a `data-mark` carrying their manifest alias, so acceptance tests can
address a section's menu without matching on its label.

**Worth knowing:** this widens access. On a clean install Library is granted to Administrators,
Writers and Editors, and neither Writers nor Editors held Settings, so relocating blueprints hands
them to two groups that could not see them before. The tree access tests are updated to say so
plainly rather than describing the old gate. #23906 narrows it again with per-group access, and the two
should land in the same release.

### Testing

Sign in as an administrator and open the Library section. Document Blueprints should appear in the
sidebar beside Elements, and the tree should list existing blueprints and folders. Create,
rename, move and delete one to confirm the management endpoints still answer.

Then sign in as a member of a group holding Settings but not Library. Blueprints should be absent,
and a direct request to a blueprint endpoint should be refused. Conversely, a member of a group
holding Library but not Settings should be able to manage blueprints without seeing the Settings
section at all — that reversal is the point of the move.
