### PR TITLE
Dependencies: Bump JS diff and underscore versions for security patches

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -28,7 +28,7 @@
         "bootstrap-social": "5.1.1",
         "chart.js": "^2.9.4",
         "clipboard": "2.0.11",
-        "diff": "5.1.0",
+        "diff": "5.2.2",
         "flatpickr": "4.6.13",
         "font-awesome": "4.7.0",
         "jquery": "3.7.1",
@@ -41,7 +41,7 @@
         "spectrum-colorpicker2": "2.0.10",
         "tinymce": "6.8.6",
         "typeahead.js": "0.11.1",
-        "underscore": "1.13.7",
+        "underscore": "1.13.8",
         "wicg-inert": "3.1.3"
       },
       "devDependencies": {
@@ -82,7 +82,7 @@
         "run-sequence": "2.2.1"
       },
       "engines": {
-        "node": ">=20.9",
+        "node": ">=20.19.4",
         "npm": ">=10.1"
       }
     },
@@ -6166,9 +6166,10 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -17029,9 +17030,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undertaker": {

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -40,7 +40,7 @@
     "bootstrap-social": "5.1.1",
     "chart.js": "^2.9.4",
     "clipboard": "2.0.11",
-    "diff": "5.1.0",
+    "diff": "5.2.2",
     "flatpickr": "4.6.13",
     "font-awesome": "4.7.0",
     "jquery": "3.7.1",
@@ -53,7 +53,7 @@
     "spectrum-colorpicker2": "2.0.10",
     "tinymce": "6.8.6",
     "typeahead.js": "0.11.1",
-    "underscore": "1.13.7",
+    "underscore": "1.13.8",
     "wicg-inert": "3.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR provides minor/patch version bumps for the jsdiff (diff) and underscore libraries to remediate security vulnerabilities. Both of these libraries have medium-level CVEs that are getting old enough that organizational remediation timeframes are coming up. 

jsdiff at version 5.1.0 is affected by CVE-2026-24001
underscore.js at version 1.13.7 is affected by CVE-2026-27601

There is no functionality change. Testing is verifying the version bumped and that standard tests do not break.
