### PR TITLE
Tiptap RTE: Fix style menu class detection on marks and stuck toggles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/html-attr-class/html-attr-class.tiptap-extension.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/html-attr-class/html-attr-class.tiptap-extension.test.ts
@@ -1,0 +1,46 @@
+import { Blockquote, Document, Editor, Paragraph, Text } from '../../externals.js';
+import { HtmlClassAttribute } from './html-attr-class.tiptap-extension.js';
+import { expect } from '@open-wc/testing';
+
+describe('HtmlClassAttribute', () => {
+	let editor: Editor;
+	let host: HTMLDivElement;
+
+	beforeEach(() => {
+		host = document.createElement('div');
+		document.body.appendChild(host);
+		editor = new Editor({
+			element: host,
+			extensions: [
+				Document,
+				Paragraph,
+				Text,
+				Blockquote,
+				HtmlClassAttribute.configure({ types: ['blockquote', 'paragraph'] }),
+			],
+		});
+	});
+
+	afterEach(() => {
+		editor.destroy();
+		host.remove();
+	});
+
+	it('toggles a class fully off when it is set on an ancestor rather than the selected node', () => {
+		editor.commands.setContent('<blockquote class="callout"><p>text</p></blockquote>');
+		editor.commands.setTextSelection(2);
+
+		editor.commands.toggleClassName('callout');
+
+		expect(editor.getHTML()).to.not.include('class="callout"');
+	});
+
+	it('applies a class to every configured type around the selection when none of them has it yet', () => {
+		editor.commands.setContent('<blockquote><p>text</p></blockquote>');
+		editor.commands.setTextSelection(2);
+
+		editor.commands.toggleClassName('callout');
+
+		expect(editor.getHTML()).to.include('<blockquote class="callout"><p class="callout">');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/html-attr-class/html-attr-class.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/html-attr-class/html-attr-class.tiptap-extension.ts
@@ -54,21 +54,18 @@ export const HtmlClassAttribute = Extension.create<UmbTiptapHtmlClassAttributeOp
 						return true;
 					}
 
+					// One decision for the whole command: deciding per type would let one type lose the classes while
+					// another gains them, so the toggle would never settle on or off across a selection spanning both.
+					const removeToggleClasses = types.some((t) =>
+						hasClassNames(editor.getAttributes(t)?.class as string | undefined, className),
+					);
+
 					return types
 						.map((t) => {
-							const existingClass = editor.getAttributes(t)?.class as string | undefined;
-							const classes = splitClassNames(existingClass);
-							const hasAllToggleClasses = hasClassNames(existingClass, className);
-
-							let newClasses: Array<string>;
-							if (hasAllToggleClasses) {
-								// All toggle classes present: remove them
-								newClasses = classes.filter((c) => !toggleClasses.includes(c));
-							} else {
-								// Not all toggle classes present: add missing ones
-								const toAdd = toggleClasses.filter((c) => !classes.includes(c));
-								newClasses = [...classes, ...toAdd];
-							}
+							const classes = splitClassNames(editor.getAttributes(t)?.class as string | undefined);
+							const newClasses = removeToggleClasses
+								? classes.filter((c) => !toggleClasses.includes(c))
+								: [...classes, ...toggleClasses.filter((c) => !classes.includes(c))];
 
 							if (newClasses.length === 0) {
 								// No classes left, remove the attribute entirely

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/html-attr-class/html-attr-class.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/html-attr-class/html-attr-class.tiptap-extension.ts
@@ -1,4 +1,5 @@
 import { Extension } from '../../externals.js';
+import { hasClassNames, splitClassNames } from '../../utils/class-names.function.js';
 import type { Attributes } from '../../externals.js';
 
 declare module '@tiptap/core' {
@@ -48,16 +49,16 @@ export const HtmlClassAttribute = Extension.create<UmbTiptapHtmlClassAttributeOp
 					if (!className) return false;
 					const types = type ? [type] : this.options.types;
 
-					const toggleClasses = className.split(/\s+/).filter((c) => c);
+					const toggleClasses = splitClassNames(className);
 					if (toggleClasses.length === 0) {
 						return true;
 					}
 
 					return types
 						.map((t) => {
-							const existingClass = (editor.getAttributes(t)?.class as string) ?? '';
-							const classes = existingClass.split(/\s+/).filter((c) => c);
-							const hasAllToggleClasses = toggleClasses.every((c) => classes.includes(c));
+							const existingClass = editor.getAttributes(t)?.class as string | undefined;
+							const classes = splitClassNames(existingClass);
+							const hasAllToggleClasses = hasClassNames(existingClass, className);
 
 							let newClasses: Array<string>;
 							if (hasAllToggleClasses) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.test.ts
@@ -1,4 +1,15 @@
-import { Bold, BulletList, Document, Editor, Heading, ListItem, Paragraph, Text } from '../../externals.js';
+import {
+	Blockquote,
+	Bold,
+	BulletList,
+	Document,
+	Editor,
+	Heading,
+	Image,
+	ListItem,
+	Paragraph,
+	Text,
+} from '../../externals.js';
 import { HtmlClassAttribute } from '../html-attr-class/html-attr-class.tiptap-extension.js';
 import { HtmlIdAttribute } from '../html-attr-id/html-attr-id.tiptap-extension.js';
 import type { MetaTiptapToolbarStyleMenuItem } from '../types.js';
@@ -16,7 +27,7 @@ describe('UmbTiptapToolbarStyleMenuApi', () => {
 	let editor: Editor;
 	let api: UmbTiptapToolbarStyleMenuApi;
 
-	const attributeTypes = ['bold', 'bulletList', 'heading', 'listItem', 'paragraph'];
+	const attributeTypes = ['blockquote', 'bold', 'bulletList', 'heading', 'image', 'listItem', 'paragraph'];
 
 	const item = (data: MetaTiptapToolbarStyleMenuItem['data']): MetaTiptapToolbarStyleMenuItem => ({
 		label: 'Test style',
@@ -46,6 +57,8 @@ describe('UmbTiptapToolbarStyleMenuApi', () => {
 				BulletList,
 				ListItem,
 				Bold,
+				Image,
+				Blockquote,
 				HtmlClassAttribute.configure({ types: attributeTypes }),
 				HtmlIdAttribute.configure({ types: attributeTypes }),
 			],
@@ -137,6 +150,32 @@ describe('UmbTiptapToolbarStyleMenuApi', () => {
 			setContent('<p class="loud">text</p>');
 
 			expect(api.isActive(editor, item({ tag: 'aside', class: 'loud' }))).to.equal(false);
+		});
+
+		it('detects a class-only style on a mark at the selection', () => {
+			setContent('<p><strong class="loud">text</strong></p>', 2);
+
+			expect(api.isActive(editor, item({ class: 'loud' }))).to.equal(true);
+			expect(api.isActive(editor, item({ class: 'quiet' }))).to.equal(false);
+		});
+
+		it('detects a class-only style on a node-selected image', () => {
+			editor.commands.setContent('<p>text</p><img class="framed" src="test.png">');
+			editor.commands.setNodeSelection(6);
+
+			expect(api.isActive(editor, item({ class: 'framed' }))).to.equal(true);
+			expect(api.isActive(editor, item({ class: 'unframed' }))).to.equal(false);
+		});
+	});
+
+	describe('execute', () => {
+		it('turns a class-only style fully off after one toggle, even split across an ancestor and its content', () => {
+			setContent('<blockquote class="callout"><p>text</p></blockquote>', 2);
+			expect(api.isActive(editor, item({ class: 'callout' }))).to.equal(true);
+
+			api.execute(editor, item({ class: 'callout' }));
+
+			expect(api.isActive(editor, item({ class: 'callout' }))).to.equal(false);
 		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.test.ts
@@ -1,4 +1,4 @@
-import { BulletList, Document, Editor, Heading, ListItem, Paragraph, Text } from '../../externals.js';
+import { Bold, BulletList, Document, Editor, Heading, ListItem, Paragraph, Text } from '../../externals.js';
 import { HtmlClassAttribute } from '../html-attr-class/html-attr-class.tiptap-extension.js';
 import { HtmlIdAttribute } from '../html-attr-id/html-attr-id.tiptap-extension.js';
 import type { MetaTiptapToolbarStyleMenuItem } from '../types.js';
@@ -16,7 +16,7 @@ describe('UmbTiptapToolbarStyleMenuApi', () => {
 	let editor: Editor;
 	let api: UmbTiptapToolbarStyleMenuApi;
 
-	const attributeTypes = ['bulletList', 'heading', 'listItem', 'paragraph'];
+	const attributeTypes = ['bold', 'bulletList', 'heading', 'listItem', 'paragraph'];
 
 	const item = (data: MetaTiptapToolbarStyleMenuItem['data']): MetaTiptapToolbarStyleMenuItem => ({
 		label: 'Test style',
@@ -45,6 +45,7 @@ describe('UmbTiptapToolbarStyleMenuApi', () => {
 				Heading,
 				BulletList,
 				ListItem,
+				Bold,
 				HtmlClassAttribute.configure({ types: attributeTypes }),
 				HtmlIdAttribute.configure({ types: attributeTypes }),
 			],
@@ -123,6 +124,19 @@ describe('UmbTiptapToolbarStyleMenuApi', () => {
 
 			expect(editor.getHTML()).to.include('<h2 class="title--size-5">');
 			expect(api.isActive(editor, item({ class: 'title--size-5' }))).to.equal(true);
+		});
+
+		it('checks the class together with a tag that maps to a mark', () => {
+			setContent('<p><strong class="loud">text</strong></p>', 2);
+
+			expect(api.isActive(editor, item({ tag: 'strong', class: 'loud' }))).to.equal(true);
+			expect(api.isActive(editor, item({ tag: 'strong', class: 'quiet' }))).to.equal(false);
+		});
+
+		it('is not active for a tag that has no matching command', () => {
+			setContent('<p class="loud">text</p>');
+
+			expect(api.isActive(editor, item({ tag: 'aside', class: 'loud' }))).to.equal(false);
 		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
@@ -1,4 +1,5 @@
 import { UmbTiptapToolbarElementApiBase } from '../tiptap-toolbar-element-api-base.js';
+import { hasClassNames } from '../../utils/class-names.function.js';
 import type { MetaTiptapToolbarStyleMenuItem } from '../../extensions/types.js';
 import type { ChainedCommands, Editor } from '../../externals.js';
 
@@ -66,19 +67,8 @@ export default class UmbTiptapToolbarStyleMenuApi extends UmbTiptapToolbarElemen
 
 	#hasAttributes(attrs: Record<string, unknown>, id?: string, className?: string): boolean {
 		const idMatch = !id ? true : attrs.id === id;
-		const classMatch = !className ? true : this.#hasClassNames(attrs.class, className);
+		const classMatch = !className ? true : hasClassNames(attrs.class, className);
 		return idMatch && classMatch;
-	}
-
-	#hasClassNames(value: unknown, className: string): boolean {
-		// Compare whole class names (as `toggleClassName` does), so that e.g. `size-1` does not match `size-10`.
-		const classes = String(value ?? '')
-			.split(/\s+/)
-			.filter((c) => c);
-		return className
-			.split(/\s+/)
-			.filter((c) => c)
-			.every((c) => classes.includes(c));
 	}
 
 	override execute(editor?: Editor, item?: MetaTiptapToolbarStyleMenuItem) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
@@ -18,7 +18,7 @@ export default class UmbTiptapToolbarStyleMenuApi extends UmbTiptapToolbarElemen
 		};
 	}
 
-	#commands: Record<string, UmbTiptapToolbarStyleMenuCommandType> = {
+	readonly #commands: Record<string, UmbTiptapToolbarStyleMenuCommandType> = {
 		h1: this.#headingCommand(1),
 		h2: this.#headingCommand(2),
 		h3: this.#headingCommand(3),

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-menu/style-menu.tiptap-toolbar-api.ts
@@ -1,3 +1,4 @@
+import { NodeSelection } from '../../externals.js';
 import { UmbTiptapToolbarElementApiBase } from '../tiptap-toolbar-element-api-base.js';
 import { hasClassNames } from '../../utils/class-names.function.js';
 import type { MetaTiptapToolbarStyleMenuItem } from '../../extensions/types.js';
@@ -45,7 +46,7 @@ export default class UmbTiptapToolbarStyleMenuApi extends UmbTiptapToolbarElemen
 
 		const { tag, id, class: className } = item.data;
 		if (tag) return this.#isTagActive(editor, tag, id, className);
-		return this.#hasAncestorWithAttributes(editor, id, className);
+		return this.#hasAttributesAroundSelection(editor, id, className);
 	}
 
 	#isTagActive(editor: Editor, tag: string, id?: string, className?: string): boolean {
@@ -55,14 +56,34 @@ export default class UmbTiptapToolbarStyleMenuApi extends UmbTiptapToolbarElemen
 		return tagMatch && this.#hasAttributes(editor.getAttributes(ext.type), id, className);
 	}
 
-	#hasAncestorWithAttributes(editor: Editor, id?: string, className?: string): boolean {
-		// Without a tag, `execute` toggles the id/class on every node type around the selection, not only on paragraphs,
-		// so the item is active when any ancestor node of the selection carries them.
+	#hasAttributesAroundSelection(editor: Editor, id?: string, className?: string): boolean {
+		// Without a tag, `execute` toggles the id/class on every node and mark type around the selection, so the item
+		// is active when any of them - the selected node, an ancestor node, or a mark on the selection - carries them.
+		return (
+			this.#hasSelectedNodeWithAttributes(editor, id, className) ||
+			this.#hasAncestorNodeWithAttributes(editor, id, className) ||
+			this.#hasMarkWithAttributes(editor, id, className)
+		);
+	}
+
+	#hasSelectedNodeWithAttributes(editor: Editor, id?: string, className?: string): boolean {
+		const { selection } = editor.state;
+		if (!(selection instanceof NodeSelection)) return false;
+		return this.#hasAttributes(selection.node.attrs, id, className);
+	}
+
+	#hasAncestorNodeWithAttributes(editor: Editor, id?: string, className?: string): boolean {
 		const { $from } = editor.state.selection;
 		for (let depth = $from.depth; depth > 0; depth--) {
 			if (this.#hasAttributes($from.node(depth).attrs, id, className)) return true;
 		}
 		return false;
+	}
+
+	#hasMarkWithAttributes(editor: Editor, id?: string, className?: string): boolean {
+		const { state } = editor;
+		const marks = state.storedMarks ?? state.selection.$from.marks();
+		return marks.some((mark) => this.#hasAttributes(mark.attrs, id, className));
 	}
 
 	#hasAttributes(attrs: Record<string, unknown>, id?: string, className?: string): boolean {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/utils/class-names.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/utils/class-names.function.test.ts
@@ -1,0 +1,41 @@
+import { expect } from '@open-wc/testing';
+import { hasClassNames, splitClassNames } from './class-names.function.js';
+
+describe('splitClassNames', () => {
+	it('splits a whitespace-separated class attribute value', () => {
+		expect(splitClassNames('title--size-5 title--bold')).to.deep.equal(['title--size-5', 'title--bold']);
+	});
+
+	it('filters out extra whitespace', () => {
+		expect(splitClassNames('  title--size-5   title--bold  ')).to.deep.equal(['title--size-5', 'title--bold']);
+	});
+
+	it('returns an empty array for undefined, null or blank input', () => {
+		expect(splitClassNames(undefined)).to.deep.equal([]);
+		expect(splitClassNames(null)).to.deep.equal([]);
+		expect(splitClassNames('   ')).to.deep.equal([]);
+	});
+});
+
+describe('hasClassNames', () => {
+	it('compares whole class names, not substrings', () => {
+		expect(hasClassNames('title--size-10', 'title--size-10')).to.equal(true);
+		expect(hasClassNames('title--size-10', 'title--size-1')).to.equal(false);
+	});
+
+	it('requires every class name of a multi-class value, in any order', () => {
+		expect(hasClassNames('list list--ordered', 'list list--ordered')).to.equal(true);
+		expect(hasClassNames('list list--ordered', 'list--ordered list')).to.equal(true);
+		expect(hasClassNames('list list--ordered', 'list list--unordered')).to.equal(false);
+	});
+
+	it('is false when the class is absent', () => {
+		expect(hasClassNames(undefined, 'title--size-5')).to.equal(false);
+		expect(hasClassNames('', 'title--size-5')).to.equal(false);
+	});
+
+	it('is true when no class names are requested', () => {
+		expect(hasClassNames(undefined, '   ')).to.equal(true);
+		expect(hasClassNames('anything', '')).to.equal(true);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/utils/class-names.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/utils/class-names.function.ts
@@ -1,0 +1,22 @@
+/**
+ * Splits a whitespace-separated class attribute value into its individual class names.
+ * @param {unknown} value The class attribute value, e.g. from a node or mark's attributes.
+ * @returns {Array<string>} The individual class names, in order, with no empty entries.
+ */
+export function splitClassNames(value: unknown): Array<string> {
+	return String(value ?? '')
+		.split(/\s+/)
+		.filter((className) => className);
+}
+
+/**
+ * Checks whether every class name in `classNames` is present in `value`, comparing whole class
+ * names rather than substrings (so e.g. `size-1` does not match `size-10`).
+ * @param {unknown} value The class attribute value to check against.
+ * @param {string} classNames One or more whitespace-separated class names that must all be present.
+ * @returns {boolean} Returns true if every class name in `classNames` is present in `value`.
+ */
+export function hasClassNames(value: unknown, classNames: string): boolean {
+	const classes = splitClassNames(value);
+	return splitClassNames(classNames).every((className) => classes.includes(className));
+}


### PR DESCRIPTION
## Description

Following on from PR #23891.

Style menu items configured with only a `class` (no tag) previously only checked ancestor node types for a match, so they never showed as active/selected when the class actually lived on a mark like bold or a link, or on a selected image. They also missed the case where the class sits on an outer element like a blockquote wrapping a plain paragraph.

That second case had a worse symptom: toggling such an item did not just fail to detect it, it applied per element type independently, so removing the class from the blockquote added it right back to the paragraph inside it. The button stayed highlighted, and clicking it again just swapped which element carried the class, forever.

Both are fixed now: detection also checks marks and node selections, and toggling makes one add/remove decision for the whole selection instead of one per element type. While in there, the whole-class-name comparison (so `size-1` doesn't match `size-10`) is shared between the toggle command and the style menu instead of living as two copies that could drift apart.

### How to test?

1. In `src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/style-select/manifests.ts`, temporarily add a class-only item, e.g. `{ label: 'Callout', data: { class: 'callout' } }`, to the `Containers` group.
2. Run the backoffice locally and open a Rich Text Editor property whose toolbar includes **Style Select**.
3. Select some text, apply **Bold**, then click **Style Select → Callout**. The item now highlights while the caret stays in the bold text (previously it never did).
4. Put the caret in a blockquote wrapping a plain paragraph, apply **Callout**, then click it again. It clears fully and the item un-highlights (previously it stayed highlighted, alternating which element held the class).
5. Revert the manifest edit from step 1.
